### PR TITLE
Fix: Disaggregation Defaults & Validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,76 @@
+# Pre-commit hooks configuration
+# Install with: cd backend && uv sync && uv run pre-commit install
+# Or globally: pip install pre-commit && pre-commit install
+
 repos:
+  # General file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
       - id: trailing-whitespace
+        exclude: ^(.*\.md|.*\.lock|.*\.json)$
       - id: end-of-file-fixer
+        exclude: ^(.*\.lock|.*\.json)$
       - id: check-yaml
+        args: [--unsafe] # Allow custom YAML tags
       - id: check-json
       - id: check-added-large-files
+        args: [--maxkb=1000]
       - id: check-merge-conflict
       - id: check-case-conflict
       - id: detect-private-key
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.4
+  # # Frontend: Biome/Ultracite (TypeScript/JavaScript)
+  # - repo: local
+  #   hooks:
+  #     - id: biome-check
+  #       name: Biome Check (Lint & Format)
+  #       entry: pre-commit-hooks/run-biome.sh
+  #       language: system
+  #       types: [file]
+  #       files: \.(ts|tsx|js|jsx|json|jsonc)$
+  #       exclude: ^(node_modules|\.next|dist|build|pnpm-lock\.yaml)/
+
+  # Backend: Ruff (Python linter and formatter) - using uv environment
+  - repo: local
     hooks:
-      # Run the linter.
       - id: ruff
-        args: [ --fix ]
-      # Run the formatter.
+        name: Ruff (Linter)
+        entry: pre-commit-hooks/run-uv-command.sh ruff check --fix --exit-non-zero-on-fix
+        language: system
+        types: [python]
+        files: ^backend/
       - id: ruff-format
+        name: Ruff (Formatter)
+        entry: pre-commit-hooks/run-uv-command.sh ruff format
+        language: system
+        types: [python]
+        files: ^backend/
+
+  # # Backend: Black (Python formatter - as backup/alternative) - using uv environment
+  # - repo: local
+  #   hooks:
+  #     - id: black
+  #       name: Black (Python Formatter)
+  #       entry: pre-commit-hooks/run-uv-command.sh black --line-length=100
+  #       language: system
+  #       types: [python]
+  #       files: ^backend/
+
+  # Custom Docker security check
+  - repo: local
+    hooks:
+      - id: check-docker-root
+        name: Check Dockerfile for root user
+        entry: pre-commit-hooks/check-docker-root.sh
+        language: system
+        types: [file]
+        files: .*Dockerfile$
+        pass_filenames: true
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        exclude: (?:.*[-\.]lock\.(json|toml|yaml|yml)|.npmrc)
+        args: ["--exclude-lines", "\\s*\"image/png\": \".+\""]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,76 +1,21 @@
-# Pre-commit hooks configuration
-# Install with: cd backend && uv sync && uv run pre-commit install
-# Or globally: pip install pre-commit && pre-commit install
-
 repos:
-  # General file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
       - id: trailing-whitespace
-        exclude: ^(.*\.md|.*\.lock|.*\.json)$
       - id: end-of-file-fixer
-        exclude: ^(.*\.lock|.*\.json)$
       - id: check-yaml
-        args: [--unsafe] # Allow custom YAML tags
       - id: check-json
       - id: check-added-large-files
-        args: [--maxkb=1000]
       - id: check-merge-conflict
       - id: check-case-conflict
       - id: detect-private-key
 
-  # # Frontend: Biome/Ultracite (TypeScript/JavaScript)
-  # - repo: local
-  #   hooks:
-  #     - id: biome-check
-  #       name: Biome Check (Lint & Format)
-  #       entry: pre-commit-hooks/run-biome.sh
-  #       language: system
-  #       types: [file]
-  #       files: \.(ts|tsx|js|jsx|json|jsonc)$
-  #       exclude: ^(node_modules|\.next|dist|build|pnpm-lock\.yaml)/
-
-  # Backend: Ruff (Python linter and formatter) - using uv environment
-  - repo: local
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.4
     hooks:
+      # Run the linter.
       - id: ruff
-        name: Ruff (Linter)
-        entry: pre-commit-hooks/run-uv-command.sh ruff check --fix --exit-non-zero-on-fix
-        language: system
-        types: [python]
-        files: ^backend/
+        args: [ --fix ]
+      # Run the formatter.
       - id: ruff-format
-        name: Ruff (Formatter)
-        entry: pre-commit-hooks/run-uv-command.sh ruff format
-        language: system
-        types: [python]
-        files: ^backend/
-
-  # # Backend: Black (Python formatter - as backup/alternative) - using uv environment
-  # - repo: local
-  #   hooks:
-  #     - id: black
-  #       name: Black (Python Formatter)
-  #       entry: pre-commit-hooks/run-uv-command.sh black --line-length=100
-  #       language: system
-  #       types: [python]
-  #       files: ^backend/
-
-  # Custom Docker security check
-  - repo: local
-    hooks:
-      - id: check-docker-root
-        name: Check Dockerfile for root user
-        entry: pre-commit-hooks/check-docker-root.sh
-        language: system
-        types: [file]
-        files: .*Dockerfile$
-        pass_filenames: true
-
-  - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.5.0
-    hooks:
-      - id: detect-secrets
-        exclude: (?:.*[-\.]lock\.(json|toml|yaml|yml)|.npmrc)
-        args: ["--exclude-lines", "\\s*\"image/png\": \".+\""]

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -2,6 +2,7 @@ import json
 import logging
 import zlib
 from typing import Any
+from urllib.parse import urlencode
 
 import dotenv
 import httpx
@@ -351,17 +352,20 @@ async def search(
     Args:
         query: Search query (e.g., "unemployment rate", "poverty")
         required_country: Country name or code (e.g., "Kenya", "KEN", or "China, USA")
-            Supports comma-separated lists to check coverage for multiple countries.
+            **STRONGLY RECOMMENDED** to use comma-separated lists to check multiple countries in a single call.
         limit: Max results (default 5)
         offset: Offset for pagination (default 0)
 
     Returns:
         EnrichedSearchResponse with:
             - indicators: List of EnrichedIndicator (idno, database_id, name,
-              truncated_definition, periodicity, latest_data, covers_country, dimensions)
+              truncated_definition, unit, periodicity, latest_data, covers_country, dimensions)
             - count, total_count, offset, has_more, next_offset: Pagination fields
             - required_country: Resolved country code
             - error: Error message if failed
+
+    Note:
+        The `covers_country` field indicates data availability for the requested country.
     """
     # NOTE: This function is for MVP only, we should be testing the relevance and performance
     # of the retrieval process in the future.
@@ -384,6 +388,7 @@ async def search(
             "time_periods",
             "ref_country",
             "dimensions",
+            "measurement_unit",
         ],
     )
 
@@ -414,10 +419,12 @@ async def search(
         covers_country = None
         ref_country = raw.get("ref_country", [])
         if country_code and ref_country and isinstance(ref_country, list):
-            country_codes = [
+            country_codes = {
                 c.get("code") if isinstance(c, dict) else c for c in ref_country
-            ]
-            covers_country = country_code in country_codes
+            }
+            # Check overlap if multiple countries requested
+            requested_codes = set([c.strip() for c in country_code.split(",")])
+            covers_country = bool(country_codes & requested_codes)
         elif country_code:
             covers_country = False
 
@@ -446,6 +453,7 @@ async def search(
                 database_id=raw.get("database_id", ""),
                 name=raw.get("name", ""),
                 truncated_definition=(raw.get("definition_long") or "")[:100],
+                unit=raw.get("measurement_unit"),
                 periodicity=raw.get("periodicity"),
                 latest_data=latest_data,
                 time_period_range=time_period_range,
@@ -711,7 +719,7 @@ async def get_data(
         indicator_id: Indicator ID (e.g., "IPC_IPC_PHASE", "WB_GS_NY_GDP_PCAP_KD")
         disaggregation_filters: Optional dictionary of disaggregation filters
             (e.g., {"REF_AREA": "UGA" or "KEN,TZA", "UNIT_MEASURE": "PT"})
-            - Supports comma-separated values for REF_AREA (e.g. "KEN,TZA").
+            - **SUPPORTS MULTIPLE VALUES**: Pass comma-separated string for REF_AREA (e.g. "KEN,TZA,USA").
             - Supports None to request all values for a dimension (e.g. {"SEX": None}).
         start_year: Optional start year to filter data (inclusive). Defaults to last 5 years.
         end_year: Optional end year to filter data (inclusive). Defaults to current year.
@@ -978,7 +986,7 @@ async def get_data_api_url(
         database_id: Database identifier (e.g., WB_HNP, WB_WDI)
         indicator_id: Indicator ID (e.g., WB_HNP_SP_POP_TOTL)
         country_code: Optional country code (e.g., "KEN" or "CHN,USA")
-            Can be a single 3-letter code or comma-separated list.
+            **SUPPORTS MULTIPLE COUNTRIES**: Can be a single 3-letter code or comma-separated list (e.g. "KEN,TZA,USA").
         start_year: Optional start year
         end_year: Optional end year
         disaggregation_filters: Optional dict of dimension filters (e.g., {"SEX": "F"})
@@ -994,16 +1002,19 @@ async def get_data_api_url(
     base = f"{base_url}/data"
 
     # Construct query params
-    params = [f"DATABASE_ID={database_id}", f"INDICATOR={indicator_id}"]
+    params = {
+        "DATABASE_ID": database_id,
+        "INDICATOR": indicator_id
+    }
 
     if country_code:
-        params.append(f"REF_AREA={country_code}")
+        params["REF_AREA"] = country_code
 
     if start_year:
-        params.append(f"timePeriodFrom={start_year}")
+        params["timePeriodFrom"] = start_year
 
     if end_year:
-        params.append(f"timePeriodTo={end_year}")
+        params["timePeriodTo"] = end_year
     # Fetch metadata and disaggregations FIRST to inform parameter building
     # This ensures we don't apply invalid defaults (like AGE=_T) which cause empty results
     metadata_res = await get_metadata(
@@ -1037,8 +1048,7 @@ async def get_data_api_url(
     )
 
     # Add dimension filters to params
-    for dim, val in effective_filters.items():
-        params.append(f"{dim}={val}")
+    params.update(effective_filters)
 
     # Default limit for viz
     limit = 1000
@@ -1048,6 +1058,7 @@ async def get_data_api_url(
         n_countries = len(country_code.split(","))
         limit = max(1000, n_countries * 1000)
 
-    params.append(f"top={limit}")
+    params["top"] = limit
 
-    return f"{base}?{'&'.join(params)}"
+    query_string = urlencode(params, safe=",")
+    return f"{base}?{query_string}"

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -966,11 +966,27 @@ async def get_data_api_url(
 
     if end_year:
         params.append(f"timePeriodTo={end_year}")
+    # Fetch metadata and disaggregations FIRST to inform parameter building
+    # This ensures we don't apply invalid defaults (like AGE=_T) which cause empty results
+    metadata_res = await get_metadata(
+        database_id,
+        indicator_id,
+        select_fields=[], # We only need disaggregation options, metadata fields not needed
+        fetch_disaggregation=True,
+    )
+    
+    # Process valid disaggregations into {dim: [values]} format
+    available_disaggregations = {}
+    for d in metadata_res.disaggregation_options or []:
+        if d.get("field_name") and d.get("field_value"):
+            available_disaggregations[d["field_name"]] = d["field_value"]
 
     # Use shared helper for disaggregation defaults (single source of truth)
     # See _build_disaggregation_params() docstring for behavior
-    effective_filters = _build_disaggregation_params(disaggregation_filters)
-
+    effective_filters = _build_disaggregation_params(
+        disaggregation_filters,
+        available_disaggregations=available_disaggregations
+    )
     # Add dimension filters to params
     for dim, val in effective_filters.items():
         params.append(f"{dim}={val}")

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -70,7 +70,17 @@ def _validate_user_filters(
         # If dimension exists in metadata, check value
         if dim in available_disaggregations:
             valid_values = available_disaggregations[dim]
-            if val not in valid_values:
+            
+            # Special handling for REF_AREA which supports comma-separated list
+            if dim == "REF_AREA" and "," in val:
+                parts = [p.strip() for p in val.split(",") if p.strip()]
+                for part in parts:
+                    if part not in valid_values:
+                        errors.append(
+                             f"Invalid value '{part}' in '{val}' for dimension '{dim}'. Available options: {valid_values}"
+                        )
+            # Standard single value check
+            elif val not in valid_values:
                 errors.append(
                     f"Invalid value '{val}' for dimension '{dim}'. Available options: {valid_values}"
                 )
@@ -795,13 +805,6 @@ async def get_data(
         available_disaggregations=available_disaggregations
     )
     params.update(effective_disagg)
-
-    # Also include any non-standard filters passed by user (e.g., REF_AREA)
-    if disaggregation_filters:
-        for k, v in disaggregation_filters.items():
-            if k not in ["SEX", "AGE", "URBANISATION", "FREQ"] and v is not None:
-                params[k] = v
-
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
             try:

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -55,25 +55,28 @@ def _get_valid_disaggregations(
 def _validate_user_filters(
     user_filters: dict[str, str | None] | None,
     available_disaggregations: dict[str, list[str]],
-) -> str | None:
+) -> tuple[dict[str, str | None], list[str]]:
     """Validate user filters against available options.
 
     Returns:
-        Error message string if invalid, None if valid.
+        Tuple of (valid_filters_dict, error_messages_list).
     """
     if not user_filters:
-        return None
+        return {}, []
 
+    valid_filters = {}
     errors = []
     for dim, val in user_filters.items():
         # Skip special 'None' filters (meaning "all") or known non-dims like REF_AREA if we don't have metadata for them
         # Note: API metadata usually returns REF_AREA as a dimension too if valid.
         if val is None:
+            valid_filters[dim] = None
             continue
 
         # If dimension exists in metadata, check value
         if dim in available_disaggregations:
             valid_values = available_disaggregations[dim]
+            is_valid = True
 
             # Special handling for REF_AREA which supports comma-separated list
             if dim == "REF_AREA" and "," in val:
@@ -83,15 +86,23 @@ def _validate_user_filters(
                         errors.append(
                             f"Invalid value '{part}' in '{val}' for dimension '{dim}'. Available options: {valid_values}"
                         )
+                        is_valid = False
             # Standard single value check
             elif val not in valid_values:
                 errors.append(
                     f"Invalid value '{val}' for dimension '{dim}'. Available options: {valid_values}"
                 )
+                is_valid = False
 
-    if errors:
-        return "\n\n".join(errors)
-    return None
+            if is_valid:
+                valid_filters[dim] = val
+        else:
+            # If dimension is unknown, we treat it as valid/passthrough for now
+            # but we could also flag it. For consistency with previous behavior,
+            # we'll keep it as valid.
+            valid_filters[dim] = val
+
+    return valid_filters, errors
 
 
 def _build_disaggregation_params(
@@ -814,17 +825,15 @@ async def get_data(
 
     # Validate user filters BEFORE applying defaults
     # This gives hints for hallucinations like SEX=ALIEN
-    val_error = _validate_user_filters(
+    valid_filters, validation_errors = _validate_user_filters(
         disaggregation_filters, available_disaggregations
     )
-    if val_error:
-        _logger.warning(f"Validation error for {indicator_id}: {val_error}")
-        return IndicatorDataResponse(error=val_error)
+    if validation_errors:
+        _logger.warning(f"Validation errors for {indicator_id}: {validation_errors}")
 
-    # Apply smart disaggregation defaults using helper (single source of truth)
-    # This adds filters to the URL, not post-fetch filtering
+    # Use only valid filters for building params
     effective_disagg = _build_disaggregation_params(
-        disaggregation_filters, available_disaggregations=available_disaggregations
+        valid_filters, available_disaggregations=available_disaggregations
     )
     params.update(effective_disagg)
     try:
@@ -875,6 +884,7 @@ async def get_data(
                 has_more=has_more,
                 next_offset=api_next_offset,
                 error=None,
+                failed_validation=validation_errors if validation_errors else None,
             )
 
     except httpx.HTTPStatusError as e:
@@ -1036,15 +1046,17 @@ async def get_data_api_url(
             available_disaggregations[d["field_name"]] = d["field_value"]
 
     # Validate user filters
-    val_error = _validate_user_filters(
+    valid_filters, validation_errors = _validate_user_filters(
         disaggregation_filters, available_disaggregations
     )
-    if val_error:
-        raise ValueError(val_error)
+    if validation_errors:
+        # For URL generation, we might still want to raise if anything is invalid
+        # or we could just skip invalid ones. Raising is safer for URL consistency.
+        raise ValueError("\n\n".join(validation_errors))
 
     # See _build_disaggregation_params() docstring for behavior
     effective_filters = _build_disaggregation_params(
-        disaggregation_filters, available_disaggregations=available_disaggregations
+        valid_filters, available_disaggregations=available_disaggregations
     )
 
     # Add dimension filters to params

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -48,6 +48,38 @@ def _get_valid_disaggregations(
     return valid
 
 
+def _validate_user_filters(
+    user_filters: dict[str, str | None] | None,
+    available_disaggregations: dict[str, list[str]],
+) -> str | None:
+    """Validate user filters against available options.
+    
+    Returns:
+        Error message string if invalid, None if valid.
+    """
+    if not user_filters:
+        return None
+        
+    errors = []
+    for dim, val in user_filters.items():
+        # Skip special 'None' filters (meaning "all") or known non-dims like REF_AREA if we don't have metadata for them
+        # Note: API metadata usually returns REF_AREA as a dimension too if valid.
+        if val is None:
+            continue
+            
+        # If dimension exists in metadata, check value
+        if dim in available_disaggregations:
+            valid_values = available_disaggregations[dim]
+            if val not in valid_values:
+                errors.append(
+                    f"Invalid value '{val}' for dimension '{dim}'. Available options: {valid_values}"
+                )
+    
+    if errors:
+        return "; ".join(errors)
+    return None
+
+
 def _build_disaggregation_params(
     disaggregation_filters: dict[str, str | None] | None,
     available_disaggregations: dict[str, list[str]] | None = None,
@@ -70,42 +102,39 @@ def _build_disaggregation_params(
         Dict of dimension -> value to add to API params.
         Dimensions with None values are omitted (API returns all).
     """
-    default_filters = {"SEX": "_T", "AGE": "_T", "URBANISATION": "_T"}
     effective = {}
     
-    # Process each dimension that has a default
-    for dim, default_val in default_filters.items():
-        # Case 1: User explicitly provided a filter for this dimension
-        if disaggregation_filters and dim in disaggregation_filters:
-            user_val = disaggregation_filters[dim]
-            if user_val is not None:
-                # Clean value: remove spaces around commas for multi-value support
-                if isinstance(user_val, str) and "," in user_val:
-                    user_val = ",".join([p.strip() for p in user_val.split(",") if p.strip()])
-                effective[dim] = user_val
-            # else: User passed None → omit dimension (get all values)
-            
-        # Case 2: User didn't specify, check if we should apply default
-        else:
-            # Only apply default if it's valid (or if we don't know validity)
-            should_apply_default = True
-            
-            if available_disaggregations:
-                valid_values = available_disaggregations.get(dim)
-                # If we have info about this dimension, and default_val is NOT in it
-                if valid_values is not None and default_val not in valid_values:
-                    should_apply_default = False
-            
-            if should_apply_default:
-                effective[dim] = default_val
-
-    # Also handle any other user-provided filters (standard dimensions that don't have defaults)
+    # 1. Start with user-provided filters
     if disaggregation_filters:
         for dim, val in disaggregation_filters.items():
-            if dim not in default_filters and val is not None:
+            if val is not None:
+                # Clean value: remove spaces around commas for multi-value support
                 if isinstance(val, str) and "," in val:
                     val = ",".join([p.strip() for p in val.split(",") if p.strip()])
                 effective[dim] = val
+    
+    # 2. Apply smart defaults for unspecified dimensions
+    if available_disaggregations:
+        for dim, values in available_disaggregations.items():
+            # Skip if user already specified/excluded this dimension
+            if disaggregation_filters and dim in disaggregation_filters:
+                continue
+                
+            # Check if this dimension has a "Total" option (_T)
+            if "_T" in values:
+                # Redundancy check: if _T is the ONLY option, don't force it
+                if len(values) == 1:
+                    continue
+                
+                # Otherwise, apply default
+                effective[dim] = "_T"
+    
+    else:
+        # Fallback for when metadata wasn't fetched or failed.
+        # We CANNOT safely apply defaults like AGE=_T because we don't know if they exist.
+        # It is better to return ALL data (no filter) than NONE (invalid filter).
+        # So we leave 'effective' as-is (containing only user provided filters).
+        pass
     
     return effective
 
@@ -752,6 +781,13 @@ async def get_data(
         if d.get("field_name") and d.get("field_value"):
             available_disaggregations[d["field_name"]] = d["field_value"]
 
+    # Validate user filters BEFORE applying defaults
+    # This gives hints for hallucinations like SEX=ALIEN
+    val_error = _validate_user_filters(disaggregation_filters, available_disaggregations)
+    if val_error:
+        _logger.warning(f"Validation error for {indicator_id}: {val_error}")
+        return IndicatorDataResponse(error=val_error)
+
     # Apply smart disaggregation defaults using helper (single source of truth)
     # This adds filters to the URL, not post-fetch filtering
     effective_disagg = _build_disaggregation_params(
@@ -981,7 +1017,13 @@ async def get_data_api_url(
         if d.get("field_name") and d.get("field_value"):
             available_disaggregations[d["field_name"]] = d["field_value"]
 
-    # Use shared helper for disaggregation defaults (single source of truth)
+        if d.get("field_name") and d.get("field_value"):
+            available_disaggregations[d["field_name"]] = d["field_value"]
+
+    # Validate user filters
+    val_error = _validate_user_filters(disaggregation_filters, available_disaggregations)
+    if val_error:
+         raise ValueError(val_error)
     # See _build_disaggregation_params() docstring for behavior
     effective_filters = _build_disaggregation_params(
         disaggregation_filters,

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import logging
 import zlib
@@ -10,7 +9,6 @@ from pydantic import ValidationError
 
 from .config import get_data360_settings
 from .models import (
-    DiscoveredIndicator,
     DiscoveryResult,
     EnrichedIndicator,
     EnrichedSearchResponse,
@@ -27,6 +25,11 @@ dotenv.load_dotenv()
 _logger = logging.getLogger(__name__)
 
 data360_config = get_data360_settings()
+
+# Constants for API logic
+COUNTRY_CODE_LENGTH = 3
+SCORE_THRESHOLD = 70
+MAX_RETURN_STATEMENTS = 6
 
 
 def _short_hash(data: dict[str, Any]) -> str:
@@ -53,38 +56,38 @@ def _validate_user_filters(
     available_disaggregations: dict[str, list[str]],
 ) -> str | None:
     """Validate user filters against available options.
-    
+
     Returns:
         Error message string if invalid, None if valid.
     """
     if not user_filters:
         return None
-        
+
     errors = []
     for dim, val in user_filters.items():
         # Skip special 'None' filters (meaning "all") or known non-dims like REF_AREA if we don't have metadata for them
         # Note: API metadata usually returns REF_AREA as a dimension too if valid.
         if val is None:
             continue
-            
+
         # If dimension exists in metadata, check value
         if dim in available_disaggregations:
             valid_values = available_disaggregations[dim]
-            
+
             # Special handling for REF_AREA which supports comma-separated list
             if dim == "REF_AREA" and "," in val:
                 parts = [p.strip() for p in val.split(",") if p.strip()]
                 for part in parts:
                     if part not in valid_values:
                         errors.append(
-                             f"Invalid value '{part}' in '{val}' for dimension '{dim}'. Available options: {valid_values}"
+                            f"Invalid value '{part}' in '{val}' for dimension '{dim}'. Available options: {valid_values}"
                         )
             # Standard single value check
             elif val not in valid_values:
                 errors.append(
                     f"Invalid value '{val}' for dimension '{dim}'. Available options: {valid_values}"
                 )
-    
+
     if errors:
         return "; ".join(errors)
     return None
@@ -104,7 +107,7 @@ def _build_disaggregation_params(
             - None or {}: Use defaults (SEX=_T, AGE=_T, URBANISATION=_T)
             - {"SEX": "F"}: Use F for SEX, defaults for others
             - {"SEX": None}: Omit SEX filter (get all values), defaults for others
-        available_disaggregations: Optional dict of {dimension: [values]} 
+        available_disaggregations: Optional dict of {dimension: [values]}
             derived from indicator metadata. If provided, defaults (like _T)
             are only applied if they exist in the available values.
 
@@ -113,39 +116,43 @@ def _build_disaggregation_params(
         Dimensions with None values are omitted (API returns all).
     """
     effective = {}
-    
+
     # 1. Start with user-provided filters
     if disaggregation_filters:
-        for dim, val in disaggregation_filters.items():
-            if val is not None:
+        for dim, raw_val in disaggregation_filters.items():
+            # Skip FREQ as it's not used for filtering in this API
+            if dim == "FREQ":
+                continue
+            if raw_val is not None:
                 # Clean value: remove spaces around commas for multi-value support
+                val = raw_val
                 if isinstance(val, str) and "," in val:
                     val = ",".join([p.strip() for p in val.split(",") if p.strip()])
                 effective[dim] = val
-    
+
     # 2. Apply smart defaults for unspecified dimensions
     if available_disaggregations:
         for dim, values in available_disaggregations.items():
             # Skip if user already specified/excluded this dimension
             if disaggregation_filters and dim in disaggregation_filters:
                 continue
-                
+
             # Check if this dimension has a "Total" option (_T)
             if "_T" in values:
                 # Redundancy check: if _T is the ONLY option, don't force it
                 if len(values) == 1:
                     continue
-                
+
                 # Otherwise, apply default
                 effective[dim] = "_T"
-    
+
     else:
         # Fallback for when metadata wasn't fetched or failed.
         # We CANNOT safely apply defaults like AGE=_T because we don't know if they exist.
         # It is better to return ALL data (no filter) than NONE (invalid filter).
         # So we leave 'effective' as-is (containing only user provided filters).
         pass
-    
+
     return effective
 
 
@@ -322,13 +329,13 @@ async def _resolve_country_code(country_query: str) -> str | None:
         return ",".join(resolved_codes) if resolved_codes else None
 
     # Already a 3-letter code
-    if len(country_query) == 3 and country_query.isupper():
+    if len(country_query) == COUNTRY_CODE_LENGTH and country_query.isupper():
         return country_query
     # Look up in codelist
     matches = await data360_providers.find_codelist_value(
         "REF_AREA", country_query, limit=1
     )
-    if matches and matches[0].get("score", 0) >= 70:
+    if matches and matches[0].get("score", 0) >= SCORE_THRESHOLD:
         return matches[0].get("id")
     return None
 
@@ -782,9 +789,9 @@ async def get_data(
         ],
         fetch_disaggregation=True,  # Crucial: fetch valid options
     )
-    
+
     api_metadata = metadata_res.indicator_metadata or {}
-    
+
     # Process valid disaggregations into {dim: [values]} format
     available_disaggregations = {}
     for d in metadata_res.disaggregation_options or []:
@@ -793,7 +800,9 @@ async def get_data(
 
     # Validate user filters BEFORE applying defaults
     # This gives hints for hallucinations like SEX=ALIEN
-    val_error = _validate_user_filters(disaggregation_filters, available_disaggregations)
+    val_error = _validate_user_filters(
+        disaggregation_filters, available_disaggregations
+    )
     if val_error:
         _logger.warning(f"Validation error for {indicator_id}: {val_error}")
         return IndicatorDataResponse(error=val_error)
@@ -801,88 +810,72 @@ async def get_data(
     # Apply smart disaggregation defaults using helper (single source of truth)
     # This adds filters to the URL, not post-fetch filtering
     effective_disagg = _build_disaggregation_params(
-        disaggregation_filters,
-        available_disaggregations=available_disaggregations
+        disaggregation_filters, available_disaggregations=available_disaggregations
     )
     params.update(effective_disagg)
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
+            print(f"Fetching data from {data_url} with params: {params}")
+            data_res = await client.get(data_url, params=params)
+            data_res.raise_for_status()
+
             try:
-                print(f"Fetching data from {data_url} with params: {params}")
-                data_res = await client.get(data_url, params=params)
-                data_res.raise_for_status()
-
-                try:
-                    data_json = data_res.json()
-                except ValueError as e:
-                    error_msg = f"Failed to parse data JSON response: {str(e)}"
-                    _logger.error(error_msg)
-                    return IndicatorDataResponse(data=None, error=error_msg)
-
-                raw_data = data_json.get("value", [])
-                total_count = data_json.get("@odata.count")  # May be None
-
-                # Compute API-level pagination BEFORE any filtering
-                # This ensures next_offset correctly tracks position in the API result set
-                api_returned_count = len(raw_data)
-                has_more = api_returned_count > limit
-
-                # Trim the extra detection row (we requested limit+1 to detect has_more)
-                if api_returned_count > limit:
-                    raw_data = raw_data[:limit]
-
-                # Compute API-based next_offset - the true cursor position for next page
-                api_next_offset = offset + len(raw_data) if has_more else None
-
-                # Sort by TIME_PERIOD descending (most recent first)
-                raw_data.sort(key=lambda x: str(x.get("TIME_PERIOD", "")), reverse=True)
-
-                # Note: Post-fetch filtering removed - filters now applied at URL level
-                # via _build_disaggregation_params() for consistency with get_data_api_url()
-
-                # Final limit enforcement (safety check)
-                if len(raw_data) > limit:
-                    raw_data = raw_data[:limit]
-
-                # Add claim_id for data verification just before returning
-                # We hash the FULL row to avoid collisions on dimensions not in the specific set
-                for row in raw_data:
-                    row["claim_id"] = _short_hash(row)
-
-                return IndicatorDataResponse(
-                    data=raw_data,
-                    metadata=api_metadata,
-                    count=len(raw_data),
-                    total_count=total_count,
-                    offset=offset,
-                    has_more=has_more,
-                    next_offset=api_next_offset,
-                    error=None,
-                )
-
-            except httpx.HTTPStatusError as e:
-                error_msg = f"HTTP error fetching data: {e.response.status_code} - {e.response.text}"
-                _logger.error(error_msg)
-                return IndicatorDataResponse(data=None, error=error_msg)
-            except httpx.TimeoutException as e:
-                error_msg = f"Timeout fetching data: {str(e)}"
-                _logger.error(error_msg)
-                return IndicatorDataResponse(data=None, error=error_msg)
-            except httpx.RequestError as e:
-                error_msg = (
-                    f"Request error fetching data for {indicator_id!r}: {str(e)}"
-                )
-                _logger.error(error_msg)
-                return IndicatorDataResponse(data=None, error=error_msg)
-            except Exception as e:
-                error_msg = f"Unexpected error fetching data: {str(e)}"
+                data_json = data_res.json()
+            except ValueError as e:
+                error_msg = f"Failed to parse data JSON response: {str(e)}"
                 _logger.error(error_msg)
                 return IndicatorDataResponse(data=None, error=error_msg)
 
+            raw_data = data_json.get("value", [])
+            total_count = data_json.get("@odata.count")  # May be None
+
+            # Compute API-level pagination BEFORE any filtering
+            # This ensures next_offset correctly tracks position in the API result set
+            api_returned_count = len(raw_data)
+            has_more = api_returned_count > limit
+
+            # Trim the extra detection row (we requested limit+1 to detect has_more)
+            if api_returned_count > limit:
+                raw_data = raw_data[:limit]
+
+            # Compute API-based next_offset - the true cursor position for next page
+            api_next_offset = offset + len(raw_data) if has_more else None
+
+            # Sort by TIME_PERIOD descending (most recent first)
+            raw_data.sort(key=lambda x: str(x.get("TIME_PERIOD", "")), reverse=True)
+
+            # Final limit enforcement (safety check)
+            if len(raw_data) > limit:
+                raw_data = raw_data[:limit]
+
+            # Add claim_id for data verification just before returning
+            for row in raw_data:
+                row["claim_id"] = _short_hash(row)
+
+            return IndicatorDataResponse(
+                data=raw_data,
+                metadata=api_metadata,
+                count=len(raw_data),
+                total_count=total_count,
+                offset=offset,
+                has_more=has_more,
+                next_offset=api_next_offset,
+                error=None,
+            )
+
+    except httpx.HTTPStatusError as e:
+        error_msg = (
+            f"HTTP error fetching data: {e.response.status_code} - {e.response.text}"
+        )
+    except httpx.TimeoutException as e:
+        error_msg = f"Timeout fetching data: {str(e)}"
+    except httpx.RequestError as e:
+        error_msg = f"Request error fetching data for {indicator_id!r}: {str(e)}"
     except Exception as e:
         error_msg = f"Unexpected error fetching data: {str(e)}"
-        _logger.exception("Unexpected error in data fetch")
-        return IndicatorDataResponse(data=None, error=error_msg)
+
+    _logger.error(error_msg)
+    return IndicatorDataResponse(data=None, error=error_msg)
 
 
 async def get_indicators(database_id: str) -> list[str]:
@@ -1010,37 +1003,31 @@ async def get_data_api_url(
     metadata_res = await get_metadata(
         database_id,
         indicator_id,
-        select_fields=[], # We only need disaggregation options, metadata fields not needed
+        select_fields=[],  # We only need disaggregation options, metadata fields not needed
         fetch_disaggregation=True,
     )
-    
+
     # Process valid disaggregations into {dim: [values]} format
     available_disaggregations = {}
     for d in metadata_res.disaggregation_options or []:
         if d.get("field_name") and d.get("field_value"):
             available_disaggregations[d["field_name"]] = d["field_value"]
 
-        if d.get("field_name") and d.get("field_value"):
-            available_disaggregations[d["field_name"]] = d["field_value"]
-
     # Validate user filters
-    val_error = _validate_user_filters(disaggregation_filters, available_disaggregations)
+    val_error = _validate_user_filters(
+        disaggregation_filters, available_disaggregations
+    )
     if val_error:
-         raise ValueError(val_error)
+        raise ValueError(val_error)
+
     # See _build_disaggregation_params() docstring for behavior
     effective_filters = _build_disaggregation_params(
-        disaggregation_filters,
-        available_disaggregations=available_disaggregations
+        disaggregation_filters, available_disaggregations=available_disaggregations
     )
+
     # Add dimension filters to params
     for dim, val in effective_filters.items():
         params.append(f"{dim}={val}")
-
-    # Also include any non-standard filters passed by user (e.g., UNIT_MEASURE)
-    if disaggregation_filters:
-        for k, v in disaggregation_filters.items():
-            if k not in effective_filters and k != "FREQ" and v is not None:
-                params.append(f"{k}={v}")
 
     # Default limit for viz
     limit = 1000

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -50,6 +50,7 @@ def _get_valid_disaggregations(
 
 def _build_disaggregation_params(
     disaggregation_filters: dict[str, str | None] | None,
+    available_disaggregations: dict[str, list[str]] | None = None,
 ) -> dict[str, str]:
     """Build effective disaggregation params with smart defaults.
 
@@ -61,28 +62,51 @@ def _build_disaggregation_params(
             - None or {}: Use defaults (SEX=_T, AGE=_T, URBANISATION=_T)
             - {"SEX": "F"}: Use F for SEX, defaults for others
             - {"SEX": None}: Omit SEX filter (get all values), defaults for others
+        available_disaggregations: Optional dict of {dimension: [values]} 
+            derived from indicator metadata. If provided, defaults (like _T)
+            are only applied if they exist in the available values.
 
     Returns:
         Dict of dimension -> value to add to API params.
         Dimensions with None values are omitted (API returns all).
     """
     default_filters = {"SEX": "_T", "AGE": "_T", "URBANISATION": "_T"}
-
-    if not disaggregation_filters:
-        return default_filters
-
     effective = {}
+    
+    # Process each dimension that has a default
     for dim, default_val in default_filters.items():
-        if dim in disaggregation_filters:
+        # Case 1: User explicitly provided a filter for this dimension
+        if disaggregation_filters and dim in disaggregation_filters:
             user_val = disaggregation_filters[dim]
             if user_val is not None:
-                # User specified a value → use it
+                # Clean value: remove spaces around commas for multi-value support
+                if isinstance(user_val, str) and "," in user_val:
+                    user_val = ",".join([p.strip() for p in user_val.split(",") if p.strip()])
                 effective[dim] = user_val
-            # else: user passed None → omit dimension (get all values)
+            # else: User passed None → omit dimension (get all values)
+            
+        # Case 2: User didn't specify, check if we should apply default
         else:
-            # User didn't specify → use default
-            effective[dim] = default_val
+            # Only apply default if it's valid (or if we don't know validity)
+            should_apply_default = True
+            
+            if available_disaggregations:
+                valid_values = available_disaggregations.get(dim)
+                # If we have info about this dimension, and default_val is NOT in it
+                if valid_values is not None and default_val not in valid_values:
+                    should_apply_default = False
+            
+            if should_apply_default:
+                effective[dim] = default_val
 
+    # Also handle any other user-provided filters (standard dimensions that don't have defaults)
+    if disaggregation_filters:
+        for dim, val in disaggregation_filters.items():
+            if dim not in default_filters and val is not None:
+                if isinstance(val, str) and "," in val:
+                    val = ",".join([p.strip() for p in val.split(",") if p.strip()])
+                effective[dim] = val
+    
     return effective
 
 
@@ -704,9 +728,36 @@ async def get_data(
         "top": limit + 1,
     }
 
+    # Fetch metadata and disaggregations FIRST to inform parameter building
+    # This ensures we don't apply invalid defaults (like AGE=_T) which cause empty results
+    metadata_res = await get_metadata(
+        database_id,
+        indicator_id,
+        select_fields=[
+            "idno",
+            "name",
+            "database_id",
+            "periodicity",
+            "measurement_unit",
+            "definition_short",
+        ],
+        fetch_disaggregation=True,  # Crucial: fetch valid options
+    )
+    
+    api_metadata = metadata_res.indicator_metadata or {}
+    
+    # Process valid disaggregations into {dim: [values]} format
+    available_disaggregations = {}
+    for d in metadata_res.disaggregation_options or []:
+        if d.get("field_name") and d.get("field_value"):
+            available_disaggregations[d["field_name"]] = d["field_value"]
+
     # Apply smart disaggregation defaults using helper (single source of truth)
     # This adds filters to the URL, not post-fetch filtering
-    effective_disagg = _build_disaggregation_params(disaggregation_filters)
+    effective_disagg = _build_disaggregation_params(
+        disaggregation_filters,
+        available_disaggregations=available_disaggregations
+    )
     params.update(effective_disagg)
 
     # Also include any non-standard filters passed by user (e.g., REF_AREA)
@@ -714,23 +765,6 @@ async def get_data(
         for k, v in disaggregation_filters.items():
             if k not in ["SEX", "AGE", "URBANISATION", "FREQ"] and v is not None:
                 params[k] = v
-
-    # Fetch basic metadata in parallel
-    metadata_task = asyncio.create_task(
-        get_metadata(
-            database_id,
-            indicator_id,
-            select_fields=[
-                "idno",
-                "name",
-                "database_id",
-                "periodicity",
-                "measurement_unit",
-                "definition_short",
-            ],
-            fetch_disaggregation=False,
-        )
-    )
 
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
@@ -775,10 +809,6 @@ async def get_data(
                 # We hash the FULL row to avoid collisions on dimensions not in the specific set
                 for row in raw_data:
                     row["claim_id"] = _short_hash(row)
-
-                # Await metadata
-                metadata_res = await metadata_task
-                api_metadata = metadata_res.indicator_metadata or {}
 
                 return IndicatorDataResponse(
                     data=raw_data,
@@ -962,137 +992,3 @@ async def get_data_api_url(
     params.append(f"top={limit}")
 
     return f"{base}?{'&'.join(params)}"
-
-    # Step 1: Resolve country code if provided as name
-    country_code: str | None = None
-    if required_country:
-        # Check if it's already a code (3 letters uppercase)
-        if len(required_country) == 3 and required_country.isupper():
-            country_code = required_country
-        else:
-            # Try to resolve the country name
-            matches = await find_reference_area(required_country, limit=1)
-            if matches and matches[0]["score"] >= 80:
-                country_code = matches[0]["id"]
-            else:
-                return DiscoveryResult(
-                    error=f"Could not resolve country: '{required_country}'"
-                )
-
-    # Step 2: Search for indicators
-    try:
-        search_result = await search(query=query, limit=limit)
-        if search_result.error:
-            return DiscoveryResult(error=search_result.error)
-        if not search_result.items:
-            return DiscoveryResult(error=f"No indicators found for query: '{query}'")
-    except Exception as e:
-        return DiscoveryResult(error=f"Search failed: {str(e)}")
-
-    # Step 3: Fetch metadata for all indicators in parallel
-    async def fetch_indicator_metadata(item: SeriesDescription) -> DiscoveredIndicator:
-        """Fetch and process metadata for a single indicator."""
-        base_info = {
-            "indicator_id": item.idno,
-            "database_id": item.database_id,
-            "name": item.name,
-            "truncated_definition": item.definition_long[:100]
-            if item.definition_long
-            else item.name,
-            "has_country": False,
-            "country_code": country_code,
-            "available_dimensions": [],
-            "available_frequencies": [],
-            "periodicity": None,
-            "has_required_dimensions": True,
-            "time_range": None,
-            "error": None,
-        }
-
-        try:
-            metadata_result = await get_metadata(
-                database_id=item.database_id, indicator_id=item.idno
-            )
-
-            if metadata_result.error:
-                base_info["error"] = metadata_result.error
-                return DiscoveredIndicator(**base_info)
-
-            # Extract time range and periodicity from metadata
-            if metadata_result.indicator_metadata:
-                time_periods = metadata_result.indicator_metadata.get(
-                    "time_periods", []
-                )
-                if time_periods:
-                    base_info["time_range"] = {
-                        "start": time_periods[0].get("start"),
-                        "end": time_periods[0].get("end"),
-                    }
-
-                # Get periodicity (more human-readable than FREQ codes)
-                base_info["periodicity"] = metadata_result.indicator_metadata.get(
-                    "periodicity"
-                )
-
-                # Check if required country is in ref_country
-                if country_code:
-                    ref_countries = metadata_result.indicator_metadata.get(
-                        "ref_country", []
-                    )
-                    country_codes = [c.get("code") for c in ref_countries]
-                    base_info["has_country"] = country_code in country_codes
-
-            # Extract available dimensions and frequencies from disaggregation options
-            available_dims: list[str] = []
-            available_freqs: list[str] = []
-            # forces the LLM to only see dimensions that offer actual choices (like "Male/Female" or "Urban/Rural")
-            for dim in metadata_result.disaggregation_options:
-                field_name = dim.get("field_name", "")
-                field_values = dim.get("field_value", [])
-
-                # Extract FREQ values
-                if field_name == "FREQ" and field_values:
-                    available_freqs = field_values
-
-                # Only include if not just "_T" or "_Z" and not FREQ
-                if (
-                    field_name != "FREQ"
-                    and field_values
-                    and not (len(field_values) == 1 and field_values[0] in ["_T", "_Z"])
-                ):
-                    available_dims.append(field_name)
-
-            base_info["available_frequencies"] = available_freqs
-            base_info["available_dimensions"] = available_dims
-
-            # Check if required dimensions are available
-            if required_dimensions:
-                missing_dims = set(required_dimensions) - set(available_dims)
-                base_info["has_required_dimensions"] = len(missing_dims) == 0
-
-        except Exception as e:
-            base_info["error"] = str(e)
-
-        return DiscoveredIndicator(**base_info)
-
-    # Fetch all metadata in parallel
-    import asyncio
-
-    tasks = [fetch_indicator_metadata(item) for item in search_result.items]
-    indicators = await asyncio.gather(*tasks)
-
-    # Step 4: Sort by relevance
-    # Priority: has_country + has_required_dimensions > has_country > everything else
-    def sort_key(ind: DiscoveredIndicator) -> tuple[int, int, int]:
-        score = 0
-        if ind.has_country:
-            score += 100
-        if ind.has_required_dimensions:
-            score += 50
-        if ind.error is None:
-            score += 10
-        return (-score, 0, 0)
-
-    indicators_sorted = sorted(indicators, key=sort_key)
-
-    return DiscoveryResult(indicators=indicators_sorted)

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -90,7 +90,7 @@ def _validate_user_filters(
                 )
 
     if errors:
-        return "; ".join(errors)
+        return "\n\n".join(errors)
     return None
 
 

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -790,6 +790,12 @@ async def get_data(
         fetch_disaggregation=True,  # Crucial: fetch valid options
     )
 
+    if metadata_res.error:
+        _logger.warning(
+            f"Metadata fetch error for {indicator_id}: {metadata_res.error}"
+        )
+        return IndicatorDataResponse(error=metadata_res.error)
+
     api_metadata = metadata_res.indicator_metadata or {}
 
     # Process valid disaggregations into {dim: [values]} format
@@ -1006,6 +1012,11 @@ async def get_data_api_url(
         select_fields=[],  # We only need disaggregation options, metadata fields not needed
         fetch_disaggregation=True,
     )
+
+    if metadata_res.error:
+        raise ValueError(
+            f"Indicator '{indicator_id}' not found or error fetching metadata: {metadata_res.error}"
+        )
 
     # Process valid disaggregations into {dim: [values]} format
     available_disaggregations = {}

--- a/src/data360/models.py
+++ b/src/data360/models.py
@@ -75,7 +75,7 @@ class SearchRequest(BaseModel):
 
 class SeriesDescription(BaseModel):
     """Model for series description in search results.
-    
+
     Fields available via select_fields in search:
     - idno, name, database_id, definition_long (core)
     - periodicity, time_periods, ref_country, dimensions (extended)
@@ -85,10 +85,18 @@ class SeriesDescription(BaseModel):
     name: str = Field(..., description="Series name")
     database_id: str = Field(..., description="Database identifier")
     definition_long: str | None = Field(None, description="Series definition")
-    periodicity: str | None = Field(None, description="Data periodicity (Annual, Monthly, etc)")
-    time_periods: list[dict[str, Any]] | None = Field(None, description="Time period coverage")
-    ref_country: list[dict[str, Any]] | None = Field(None, description="Countries with data")
-    dimensions: list[dict[str, Any]] | None = Field(None, description="Available disaggregations")
+    periodicity: str | None = Field(
+        None, description="Data periodicity (Annual, Monthly, etc)"
+    )
+    time_periods: list[dict[str, Any]] | None = Field(
+        None, description="Time period coverage"
+    )
+    ref_country: list[dict[str, Any]] | None = Field(
+        None, description="Countries with data"
+    )
+    dimensions: list[dict[str, Any]] | None = Field(
+        None, description="Available disaggregations"
+    )
 
 
 class SearchResponse(MCPPagedResponse):
@@ -104,15 +112,19 @@ class SearchResponse(MCPPagedResponse):
 
 class EnrichedIndicator(BaseModel):
     """Model for an enriched indicator in search results.
-    
+
     Optimized for LLM consumption with compact, relevant fields.
     """
 
     idno: str = Field(..., description="Indicator ID (e.g., WB_GS_NY_GDP_PCAP_KD)")
     database_id: str = Field(..., description="Database ID (e.g., WB_GS)")
     name: str = Field(..., description="Indicator name")
-    truncated_definition: str = Field(..., description="Truncated definition (max 100 chars)")
-    periodicity: str | None = Field(None, description="Data periodicity (Annual, Monthly)")
+    truncated_definition: str = Field(
+        ..., description="Truncated definition (max 100 chars)"
+    )
+    periodicity: str | None = Field(
+        None, description="Data periodicity (Annual, Monthly)"
+    )
     latest_data: str | None = Field(None, description="Most recent year with data")
     time_period_range: str | None = Field(
         None, description="Data availability range (e.g., '1990-2024')"
@@ -127,7 +139,7 @@ class EnrichedIndicator(BaseModel):
 
 class EnrichedSearchResponse(MCPPagedResponse):
     """Response model for enriched search (LLM-optimized).
-    
+
     Returns indicators sorted by country coverage and recency.
     """
 
@@ -137,15 +149,15 @@ class EnrichedSearchResponse(MCPPagedResponse):
     required_country: str | None = Field(
         None, description="Resolved country code (e.g., KEN for Kenya)"
     )
-    error: str | None = Field(
-        None, description="Error message if search failed"
-    )
+    error: str | None = Field(None, description="Error message if search failed")
 
 
 class MetadataRequest(BaseModel):
     """Request model for data 360 metadata retrieval."""
 
-    indicator_id: str = Field(..., description="Series ID (idno) to retrieve metadata for")
+    indicator_id: str = Field(
+        ..., description="Series ID (idno) to retrieve metadata for"
+    )
     database_id: str = Field(
         ..., description="Database identifier (e.g., IPC_IPC, WB_GS)"
     )
@@ -182,7 +194,9 @@ class IndicatorDataRequest(BaseModel):
     database_id: str = Field(
         ..., description="Unique identifier for the database (e.g., WB_GS)"
     )
-    indicator_id: str = Field(..., description="Indicator ID (e.g., WB_GS_NY_GDP_PCAP_KD)")
+    indicator_id: str = Field(
+        ..., description="Indicator ID (e.g., WB_GS_NY_GDP_PCAP_KD)"
+    )
     disaggregation_filters: dict[str, str | None] | None = Field(
         default=None,
         description="Dictionary of disaggregation filters (e.g., {'REF_AREA': 'UGA', 'UNIT_MEASURE': 'PT'})",
@@ -197,8 +211,6 @@ class IndicatorDataRequest(BaseModel):
                 f"Invalid database_id: '{self.database_id}'. It matches indicator_id. "
                 "Database ID should be the short dataset code (e.g., 'WB_GS', 'WB_HCP')."
             )
-        
-
 
         return self
 
@@ -210,10 +222,14 @@ class IndicatorDataResponse(MCPPagedResponse):
         default=None, description="List of indicator data points"
     )
     metadata: dict[str, Any] | None = Field(
-        default=None, description="Basic metadata for the indicator (e.g., name, definition)"
+        default=None,
+        description="Basic metadata for the indicator (e.g., name, definition)",
     )
     error: str | None = Field(
         default=None, description="Error message if data retrieval failed"
+    )
+    failed_validation: list[str] | None = Field(
+        default=None, description="List of filter validation errors"
     )
 
 
@@ -223,23 +239,33 @@ class DiscoveredIndicator(BaseModel):
     indicator_id: str = Field(..., description="Indicator ID")
     database_id: str = Field(..., description="Database identifier")
     name: str = Field(..., description="Indicator name")
-    truncated_definition: str = Field(..., description="Short definition (max 100 chars)")
-    has_country: bool = Field(..., description="Whether data exists for the requested country")
-    country_code: str | None = Field(default=None, description="Country code used for validation")
+    truncated_definition: str = Field(
+        ..., description="Short definition (max 100 chars)"
+    )
+    has_country: bool = Field(
+        ..., description="Whether data exists for the requested country"
+    )
+    country_code: str | None = Field(
+        default=None, description="Country code used for validation"
+    )
     available_dimensions: list[str] = Field(
         default_factory=list, description="List of available disaggregation dimensions"
     )
     available_frequencies: list[str] = Field(
         default_factory=list, description="List of available frequencies"
     )
-    periodicity: str | None = Field(default=None, description="Periodicity of the indicator")
+    periodicity: str | None = Field(
+        default=None, description="Periodicity of the indicator"
+    )
     has_required_dimensions: bool = Field(
         default=True, description="Whether the indicator has all required dimensions"
     )
     time_range: dict[str, str | None] | None = Field(
         default=None, description="Start and end years of data availability"
     )
-    error: str | None = Field(default=None, description="Error message if validation failed")
+    error: str | None = Field(
+        default=None, description="Error message if validation failed"
+    )
 
 
 class DiscoveryResult(BaseModel):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,12 +1,10 @@
 """Tests for data360.api module."""
 
-import json
 import re
 
 import httpx
 import pytest
 import pytest_httpx
-
 from data360.api import (
     _get_valid_disaggregations,
     get_data,
@@ -69,7 +67,7 @@ class TestSearch:
                         "name": "Population, total",
                         "database_id": "WB_WDI",
                         "definition_long": "Total population",
-                        "dimensions": []
+                        "dimensions": [],
                     }
                 },
                 {
@@ -78,7 +76,7 @@ class TestSearch:
                         "name": "Population growth",
                         "database_id": "WB_WDI",
                         "definition_long": "Population growth rate",
-                        "dimensions": []
+                        "dimensions": [],
                     }
                 },
             ],
@@ -118,7 +116,7 @@ class TestSearch:
                         "name": f"Population {i}",
                         "database_id": "WB_WDI",
                         "definition_long": f"Population indicator {i}",
-                        "dimensions": []
+                        "dimensions": [],
                     }
                 }
                 for i in range(NUM_ITEMS)
@@ -155,7 +153,7 @@ class TestSearch:
                         "name": "Population, total",
                         "database_id": "WB_WDI",
                         "definition_long": "Total population",
-                        "dimensions": []
+                        "dimensions": [],
                     }
                 },
                 {
@@ -471,21 +469,28 @@ class TestGetData:
         httpx_mock.add_response(
             method="POST",
             url="https://api.test.example.com/metadata",
-            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL", "name": "Pop"}}]}
+            json={
+                "value": [
+                    {
+                        "series_description": {
+                            "idno": "WB_WDI_SP_POP_TOTL",
+                            "name": "Pop",
+                        }
+                    }
+                ]
+            },
         )
 
         # Mock disaggregation response (called during metadata fetch)
         httpx_mock.add_response(
             method="GET",
             url=re.compile(r".*/disaggregation.*"),
-            json=[{"field_name": "REF_AREA", "field_value": ["UGA"]}]
+            json=[{"field_name": "REF_AREA", "field_value": ["UGA"]}],
         )
 
         # Mock data response
         httpx_mock.add_response(
-            method="GET",
-            url=re.compile(r".*/data\?.*"),
-            json=mock_response
+            method="GET", url=re.compile(r".*/data\?.*"), json=mock_response
         )
 
         result = await get_data("WB_WDI", "WB_WDI_SP_POP_TOTL")
@@ -513,17 +518,17 @@ class TestGetData:
         httpx_mock.add_response(
             method="POST",
             url="https://api.test.example.com/metadata",
-            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]}
+            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]},
         )
-        
-        # Mock disaggregation 
+
+        # Mock disaggregation
         httpx_mock.add_response(
             method="GET",
             url=re.compile(r".*/disaggregation.*"),
             json=[
                 {"field_name": "REF_AREA", "field_value": ["UGA"]},
                 {"field_name": "UNIT_MEASURE", "field_value": ["PT"]},
-            ]
+            ],
         )
 
         # Mock data response
@@ -558,12 +563,10 @@ class TestGetData:
         httpx_mock.add_response(
             method="POST",
             url="https://api.test.example.com/metadata",
-            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]}
+            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]},
         )
         httpx_mock.add_response(
-            method="GET",
-            url=re.compile(r".*/disaggregation.*"),
-            json=[]
+            method="GET", url=re.compile(r".*/disaggregation.*"), json=[]
         )
 
         # First page response
@@ -594,27 +597,26 @@ class TestGetData:
         httpx_mock.add_callback(first_page_callback)
 
         # Pass explicit time range to avoid smart defaults filtering
-        result = await get_data("WB_WDI", "WB_WDI_SP_POP_TOTL", start_year=2010, end_year=2019)
+        result = await get_data(
+            "WB_WDI", "WB_WDI_SP_POP_TOTL", start_year=2010, end_year=2019
+        )
 
         EXPECTED_TOTAL_COUNT = 5  # First page only
         assert result.data is not None
         assert len(result.data) == EXPECTED_TOTAL_COUNT
 
-
     @pytest.mark.asyncio
     async def test_get_data_empty_response(self, httpx_mock: pytest_httpx.HTTPXMock):
         """Test data retrieval with empty response."""
-        
+
         # Mocks
         httpx_mock.add_response(
             method="POST",
             url="https://api.test.example.com/metadata",
-            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]}
+            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]},
         )
         httpx_mock.add_response(
-            method="GET",
-            url=re.compile(r".*/disaggregation.*"),
-            json=[]
+            method="GET", url=re.compile(r".*/disaggregation.*"), json=[]
         )
 
         def empty_data_callback(request: httpx.Request) -> httpx.Response | None:
@@ -637,17 +639,15 @@ class TestGetData:
     @pytest.mark.asyncio
     async def test_get_data_http_error(self, httpx_mock: pytest_httpx.HTTPXMock):
         """Test data retrieval handles HTTP errors."""
-        
+
         # Mocks for metadata (successful, so we proceed to data)
         httpx_mock.add_response(
             method="POST",
             url="https://api.test.example.com/metadata",
-            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]}
+            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]},
         )
         httpx_mock.add_response(
-            method="GET",
-            url=re.compile(r".*/disaggregation.*"),
-            json=[]
+            method="GET", url=re.compile(r".*/disaggregation.*"), json=[]
         )
 
         # Data error
@@ -676,12 +676,10 @@ class TestGetData:
         httpx_mock.add_response(
             method="POST",
             url="https://api.test.example.com/metadata",
-            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]}
+            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]},
         )
         httpx_mock.add_response(
-            method="GET",
-            url=re.compile(r".*/disaggregation.*"),
-            json=[]
+            method="GET", url=re.compile(r".*/disaggregation.*"), json=[]
         )
 
         def invalid_json_callback(request: httpx.Request) -> httpx.Response | None:
@@ -705,5 +703,3 @@ class TestGetData:
 # NOTE: TestCodelistManager tests removed - CodelistManager was replaced with
 # ReferenceAreaManager in providers.py with a different API.
 # New tests for ReferenceAreaManager should be added in test_providers.py
-
-

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,11 @@ from data360.api import (
     get_metadata,
     search,
 )
-from data360.models import IndicatorDataResponse, MetadataResponse, SearchResponse
+from data360.models import (
+    EnrichedSearchResponse,
+    IndicatorDataResponse,
+    MetadataResponse,
+)
 
 
 class TestGetValidDisaggregations:
@@ -65,6 +69,7 @@ class TestSearch:
                         "name": "Population, total",
                         "database_id": "WB_WDI",
                         "definition_long": "Total population",
+                        "dimensions": []
                     }
                 },
                 {
@@ -73,6 +78,7 @@ class TestSearch:
                         "name": "Population growth",
                         "database_id": "WB_WDI",
                         "definition_long": "Population growth rate",
+                        "dimensions": []
                     }
                 },
             ],
@@ -86,12 +92,12 @@ class TestSearch:
 
         result = await search("population", limit=10)
 
-        assert isinstance(result, SearchResponse)
-        assert result.items is not None
-        assert len(result.items) == NUM_ITEMS
-        assert result.items[0].idno == "WB_WDI_SP_POP_TOTL"
-        assert result.items[0].name == "Population, total"
-        assert result.items[1].idno == "WB_WDI_SP_POP_GROW"
+        assert isinstance(result, EnrichedSearchResponse)
+        assert result.indicators is not None
+        assert len(result.indicators) == NUM_ITEMS
+        assert result.indicators[0].idno == "WB_WDI_SP_POP_TOTL"
+        assert result.indicators[0].name == "Population, total"
+        assert result.indicators[1].idno == "WB_WDI_SP_POP_GROW"
         assert result.total_count == NUM_ITEMS
         assert result.count == NUM_ITEMS
         assert result.has_more is False
@@ -112,6 +118,7 @@ class TestSearch:
                         "name": f"Population {i}",
                         "database_id": "WB_WDI",
                         "definition_long": f"Population indicator {i}",
+                        "dimensions": []
                     }
                 }
                 for i in range(NUM_ITEMS)
@@ -148,6 +155,7 @@ class TestSearch:
                         "name": "Population, total",
                         "database_id": "WB_WDI",
                         "definition_long": "Total population",
+                        "dimensions": []
                     }
                 },
                 {
@@ -175,59 +183,9 @@ class TestSearch:
 
         result = await search("population", limit=10)
 
-        assert result.items is not None
-        assert len(result.items) == NUM_VALID_ITEMS  # Only the valid item
-        assert result.items[0].idno == "WB_WDI_SP_POP_TOTL"
-
-    @pytest.mark.asyncio
-    async def test_search_with_custom_parameters(
-        self, httpx_mock: pytest_httpx.HTTPXMock
-    ):
-        """Test search with filter, orderby, and select parameters."""
-        TOTAL_COUNT = 1
-        LIMIT = 5
-        mock_response = {
-            "@odata.context": "https://api.test.example.com/$metadata",
-            "@odata.count": TOTAL_COUNT,
-            "value": [
-                {
-                    "series_description": {
-                        "idno": "WB_WDI_SP_POP_TOTL",
-                        "name": "Population, total",
-                        "database_id": "WB_WDI",
-                    }
-                }
-            ],
-        }
-
-        httpx_mock.add_response(
-            method="POST",
-            url="https://api.test.example.com/searchv2",
-            json=mock_response,
-        )
-
-        result = await search(
-            "population",
-            limit=LIMIT,
-            offset=0,
-            odata_options={
-                "filter": "type eq 'indicator'",
-                "orderby": "series_description/name",
-                "select": "series_description/idno, series_description/name",
-            },
-        )
-
-        # Verify the request was made with correct parameters
-        request = httpx_mock.get_request()
-        assert request is not None
-        assert request.method == "POST"
-        payload = json.loads(request.read())
-        assert payload["search"] == "population"
-        assert payload["top"] == LIMIT
-        assert payload["skip"] == 0
-
-        assert result.items is not None
-        assert len(result.items) == TOTAL_COUNT
+        assert result.indicators is not None
+        assert len(result.indicators) == NUM_VALID_ITEMS  # Only the valid item
+        assert result.indicators[0].idno == "WB_WDI_SP_POP_TOTL"
 
     @pytest.mark.asyncio
     async def test_search_http_error(self, httpx_mock: pytest_httpx.HTTPXMock):
@@ -241,7 +199,7 @@ class TestSearch:
 
         result = await search("population")
 
-        assert result.items is None
+        assert not result.indicators
         assert result.error is not None
         assert "HTTP error 500" in result.error
 
@@ -255,7 +213,7 @@ class TestSearch:
 
         result = await search("population")
 
-        assert result.items is None
+        assert not result.indicators
         assert result.error is not None
         assert "timeout" in result.error.lower()
 
@@ -271,7 +229,7 @@ class TestSearch:
 
         result = await search("population")
 
-        assert result.items is None
+        assert not result.indicators
         assert result.error is not None
         assert "Failed to parse" in result.error
 
@@ -509,17 +467,26 @@ class TestGetData:
             "count": 2,
         }
 
-        # Match URL with query parameters
-        def data_callback(request: httpx.Request) -> httpx.Response | None:
-            if (
-                request.method == "GET"
-                and request.url.host == "api.test.example.com"
-                and request.url.path == "/data"
-            ):
-                return httpx.Response(200, json=mock_response)
-            return None
+        # Mock metadata response (called first)
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.test.example.com/metadata",
+            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL", "name": "Pop"}}]}
+        )
 
-        httpx_mock.add_callback(data_callback)
+        # Mock disaggregation response (called during metadata fetch)
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(r".*/disaggregation.*"),
+            json=[{"field_name": "REF_AREA", "field_value": ["UGA"]}]
+        )
+
+        # Mock data response
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(r".*/data\?.*"),
+            json=mock_response
+        )
 
         result = await get_data("WB_WDI", "WB_WDI_SP_POP_TOTL")
 
@@ -542,13 +509,33 @@ class TestGetData:
             "count": 1,
         }
 
-        # Match URL with query parameters
+        # Mock metadata
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.test.example.com/metadata",
+            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]}
+        )
+        
+        # Mock disaggregation 
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(r".*/disaggregation.*"),
+            json=[
+                {"field_name": "REF_AREA", "field_value": ["UGA"]},
+                {"field_name": "UNIT_MEASURE", "field_value": ["PT"]},
+            ]
+        )
+
+        # Mock data response
         def data_callback(request: httpx.Request) -> httpx.Response | None:
             if (
                 request.method == "GET"
                 and request.url.host == "api.test.example.com"
                 and request.url.path == "/data"
             ):
+                # Verify params in URL
+                assert "REF_AREA=UGA" in str(request.url)
+                assert "UNIT_MEASURE=PT" in str(request.url)
                 return httpx.Response(200, json=mock_response)
             return None
 
@@ -563,15 +550,21 @@ class TestGetData:
         assert result.data is not None
         assert len(result.data) == 1
 
-        # Verify the request included the filters
-        request = httpx_mock.get_request()
-        assert request is not None
-        assert "REF_AREA=UGA" in str(request.url)
-        assert "UNIT_MEASURE=PT" in str(request.url)
-
     @pytest.mark.asyncio
     async def test_get_data_pagination(self, httpx_mock: pytest_httpx.HTTPXMock):
         """Test data retrieval with pagination."""
+
+        # Mock metadata & disaggregation (needed for get_data to proceed)
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.test.example.com/metadata",
+            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]}
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(r".*/disaggregation.*"),
+            json=[]
+        )
 
         # First page response
         def first_page_callback(request: httpx.Request) -> httpx.Response | None:
@@ -611,6 +604,18 @@ class TestGetData:
     @pytest.mark.asyncio
     async def test_get_data_empty_response(self, httpx_mock: pytest_httpx.HTTPXMock):
         """Test data retrieval with empty response."""
+        
+        # Mocks
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.test.example.com/metadata",
+            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]}
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(r".*/disaggregation.*"),
+            json=[]
+        )
 
         def empty_data_callback(request: httpx.Request) -> httpx.Response | None:
             if (
@@ -632,7 +637,20 @@ class TestGetData:
     @pytest.mark.asyncio
     async def test_get_data_http_error(self, httpx_mock: pytest_httpx.HTTPXMock):
         """Test data retrieval handles HTTP errors."""
+        
+        # Mocks for metadata (successful, so we proceed to data)
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.test.example.com/metadata",
+            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]}
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(r".*/disaggregation.*"),
+            json=[]
+        )
 
+        # Data error
         def error_data_callback(request: httpx.Request) -> httpx.Response | None:
             if (
                 request.method == "GET"
@@ -653,6 +671,18 @@ class TestGetData:
     @pytest.mark.asyncio
     async def test_get_data_invalid_json(self, httpx_mock: pytest_httpx.HTTPXMock):
         """Test data retrieval handles invalid JSON."""
+
+        # Mocks
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.test.example.com/metadata",
+            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]}
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(r".*/disaggregation.*"),
+            json=[]
+        )
 
         def invalid_json_callback(request: httpx.Request) -> httpx.Response | None:
             if (
@@ -676,138 +706,4 @@ class TestGetData:
 # ReferenceAreaManager in providers.py with a different API.
 # New tests for ReferenceAreaManager should be added in test_providers.py
 
-class TestDiscoverIndicators:
-    """Tests for discover_indicators() function."""
 
-    @pytest.mark.asyncio
-    async def test_discover_indicators_success(self, httpx_mock: pytest_httpx.HTTPXMock):
-        """Test successful indicator discovery."""
-        from data360.api import discover_indicators
-        from data360.models import DiscoveryResult
-
-        # Mock search response
-        search_response = {
-            "@odata.context": "https://api.test.example.com/$metadata",
-            "@odata.count": 1,
-            "value": [
-                {
-                    "series_description": {
-                        "idno": "WB_WDI_SP_POP_TOTL",
-                        "name": "Population, total",
-                        "database_id": "WB_WDI",
-                        "definition_long": "Total population",
-                    }
-                }
-            ],
-        }
-
-        httpx_mock.add_response(
-            method="POST",
-            url="https://api.test.example.com/searchv2",
-            json=search_response,
-        )
-
-        # Mock metadata response
-        metadata_response = {
-            "value": [
-                {
-                    "series_description": {
-                        "idno": "WB_WDI_SP_POP_TOTL",
-                        "name": "Population, total",
-                        "database_id": "WB_WDI",
-                        "definition_long": "Total population",
-                        "time_periods": [{"start": "1960", "end": "2022"}],
-                        "periodicity": "Annual",
-                    }
-                }
-            ]
-        }
-        
-        httpx_mock.add_response(
-            method="POST",
-            url="https://api.test.example.com/metadata",
-            json=metadata_response,
-        )
-
-        # Mock disaggregation response
-        disaggregation_response = [
-            {"field_value": ["AFG", "ALB"], "field_name": "REF_AREA"},
-            {"field_value": ["A"], "field_name": "FREQ"}
-        ]
-
-        def disaggregation_callback(request: httpx.Request) -> httpx.Response | None:
-            if (
-                request.method == "GET"
-                and request.url.path == "/disaggregation"
-            ):
-                return httpx.Response(200, json=disaggregation_response)
-            return None
-        
-        httpx_mock.add_callback(disaggregation_callback)
-
-        result = await discover_indicators("population")
-
-        assert isinstance(result, DiscoveryResult)
-        assert len(result.indicators) == 1
-        assert result.error is None
-        
-        ind = result.indicators[0]
-        assert ind.indicator_id == "WB_WDI_SP_POP_TOTL"
-        assert ind.available_frequencies == ["A"]
-        assert ind.periodicity == "Annual"
-        assert ind.time_range == {"start": "1960", "end": "2022"}
-
-    @pytest.mark.asyncio
-    async def test_discover_indicators_with_country_validation(self, httpx_mock: pytest_httpx.HTTPXMock):
-        """Test discovery with country validation."""
-        from data360.api import discover_indicators
-
-        # Mock Search
-        httpx_mock.add_response(
-            method="POST",
-            url="https://api.test.example.com/searchv2",
-            json={"value": [{"series_description": {"idno": "IND1", "name": "Ind 1", "database_id": "DB1"}}]}
-        )
-
-        # Mock Metadata with ref_country including KEN
-        httpx_mock.add_response(
-            method="POST",
-            url="https://api.test.example.com/metadata",
-            json={
-                "value": [{
-                    "series_description": {
-                        "idno": "IND1",
-                        "ref_country": [{"code": "KEN"}, {"code": "UGA"}]
-                    }
-                }]
-            }
-        )
-
-        # Mock Disaggregation
-        httpx_mock.add_response(
-            method="GET",
-            url=re.compile(r".*/disaggregation.*"),
-            json=[]
-        )
-
-        result = await discover_indicators("test", required_country="KEN")
-        
-        assert len(result.indicators) == 1
-        assert result.indicators[0].has_country is True
-        assert result.indicators[0].country_code == "KEN"
-
-    @pytest.mark.asyncio
-    async def test_discover_indicators_search_error(self, httpx_mock: pytest_httpx.HTTPXMock):
-        """Test handling of search errors."""
-        from data360.api import discover_indicators
-
-        httpx_mock.add_response(
-            method="POST",
-            url="https://api.test.example.com/searchv2",
-            status_code=500
-        )
-
-        result = await discover_indicators("test")
-        
-        assert result.error is not None
-        assert "HTTP error 500" in result.error


### PR DESCRIPTION
## Changes
- **Fix Smart Defaults**: Stopped applying potentially invalid default filters (e.g., `AGE=_T`) when metadata is unavailable. Now falls back to returning all data instead of risking empty result sets.
- **Add Strict Validation**: Implemented `_validate_user_filters` to reject invalid user inputs (e.g., `SEX='_Z'`) with clear error messages listing valid options.
- **Hallucination Protection**: Added strict metadata validation to `get_data` and `get_data_api_url`. If an indicator ID is invalid or hallucinated, the tools now return a clear "Not Found" error instead of an empty result set.

## Impact
- Prevents silent failures (empty results) for indicators incompatible with standard defaults.
- Provides immediate feedback to LLMs/users when invalid filters are used.
