### PR TITLE
feat: centralized error management with Data360MCPError hierarchy

### DIFF
--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -13,7 +13,7 @@ from .errors import (
     Data360MCPError,
     NotFoundError,
     ParseError,
-    from_httpx_error,
+    classify_error,
 )
 from .errors import ValidationError as Data360ValidationError
 from .models import (
@@ -316,7 +316,7 @@ async def _search_raw(
                     )
 
     except Exception as e:
-        mcp_error = from_httpx_error(e, context="search")
+        mcp_error = classify_error(e, context="search")
         _logger.error(mcp_error.detail)
 
     if mcp_error:
@@ -631,7 +631,7 @@ async def get_metadata(
                 errors.append(mcp_err.detail)
 
     except Exception as e:
-        mcp_err = from_httpx_error(e, context="metadata")
+        mcp_err = classify_error(e, context="metadata")
         _logger.exception(mcp_err.detail)
         errors.append(mcp_err.detail)
 
@@ -657,7 +657,7 @@ async def get_metadata(
                     errors.append(mcp_err.detail)
 
         except Exception as e:
-            mcp_err = from_httpx_error(e, context="disaggregation")
+            mcp_err = classify_error(e, context="disaggregation")
             _logger.error(mcp_err.detail)
             errors.append(mcp_err.detail)
 
@@ -712,7 +712,7 @@ async def get_disaggregation(
             return {"dimensions": valid_dimensions}
 
     except Exception as e:
-        mcp_err = from_httpx_error(e, context="disaggregation")
+        mcp_err = classify_error(e, context="disaggregation")
         _logger.exception(mcp_err.detail)
         return {"error": mcp_err.detail}
 
@@ -890,7 +890,7 @@ async def get_data(
             )
 
     except Exception as e:
-        mcp_err = from_httpx_error(e, context="data")
+        mcp_err = classify_error(e, context="data")
         _logger.error(mcp_err.detail)
         return IndicatorDataResponse(data=None, error=mcp_err.detail)
 

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -6,9 +6,16 @@ from urllib.parse import urlencode
 
 import dotenv
 import httpx
-from pydantic import ValidationError
+from pydantic import ValidationError as PydanticValidationError
 
 from .config import get_data360_settings
+from .errors import (
+    Data360MCPError,
+    NotFoundError,
+    ParseError,
+    from_httpx_error,
+)
+from .errors import ValidationError as Data360ValidationError
 from .models import (
     DiscoveryResult,
     EnrichedIndicator,
@@ -286,7 +293,7 @@ async def _search_raw(
     url = data360_config.search_url or f"{data360_config.api_url}/searchv2"
     payload = _build_search_payload(request)
 
-    error_msg: str | None = None
+    mcp_error: Data360MCPError | None = None
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.post(url, json=payload)
@@ -296,27 +303,24 @@ async def _search_raw(
                 response_data = response.json()
             except ValueError as e:
                 _logger.error(f"Failed to parse JSON response: {e}")
-                error_msg = f"Failed to parse API response: {str(e)}"
+                mcp_error = ParseError(context="search", original_error=e)
             else:
                 try:
                     return _process_search_response(response_data, request)
                 except Exception as e:
                     _logger.error(f"Failed to validate response data: {e}")
-                    error_msg = f"Failed to validate API response: {str(e)}"
+                    mcp_error = ParseError(
+                        context="search",
+                        detail=f"Failed to parse API response: {str(e)}",
+                        original_error=e,
+                    )
 
     except Exception as e:
-        if isinstance(e, httpx.HTTPStatusError):
-            error_msg = f"HTTP error {e.response.status_code}: {e.response.text}"
-        elif isinstance(e, httpx.TimeoutException):
-            error_msg = f"Request timeout: {str(e)}"
-        elif isinstance(e, httpx.RequestError):
-            error_msg = f"Request error: {str(e)}"
-        else:
-            error_msg = f"Unexpected error: {str(e)}"
-        _logger.error(error_msg)
+        mcp_error = from_httpx_error(e, context="search")
+        _logger.error(mcp_error.detail)
 
-    if error_msg:
-        return SearchResponse(items=None, error=error_msg)
+    if mcp_error:
+        return SearchResponse(items=None, error=mcp_error.detail)
     # This should never be reached, but pyright needs it for type checking
     return SearchResponse(
         items=None, error="Unexpected error: no response and no error message"
@@ -566,8 +570,13 @@ async def get_metadata(
     # Validate inputs
     try:
         MetadataRequest(database_id=database_id, indicator_id=indicator_id)
-    except ValidationError as e:
-        return MetadataResponse(error=f"Invalid arguments: {e}")
+    except PydanticValidationError as e:
+        mcp_err = Data360ValidationError(
+            context="metadata",
+            detail=f"Invalid arguments: {e}",
+            original_error=e,
+        )
+        return MetadataResponse(error=mcp_err.detail)
 
     # Determine URLs
     metadata_url = data360_config.metadata_url or f"{data360_config.api_url}/metadata"
@@ -610,28 +619,21 @@ async def get_metadata(
                             if k in select_fields
                         }
                 else:
-                    error_msg = f"No metadata found for indicator ID '{indicator_id}'"
-                    _logger.warning(error_msg)
-                    errors.append(error_msg)
+                    mcp_err = NotFoundError(
+                        context="metadata",
+                        detail=f"No metadata found for indicator ID '{indicator_id}'",
+                    )
+                    _logger.warning(mcp_err.detail)
+                    errors.append(mcp_err.detail)
             except ValueError as e:
-                error_msg = f"Failed to parse metadata JSON response: {str(e)}"
-                _logger.error(error_msg)
-                errors.append(error_msg)
+                mcp_err = ParseError(context="metadata", original_error=e)
+                _logger.error(mcp_err.detail)
+                errors.append(mcp_err.detail)
 
     except Exception as e:
-        error_msg: str
-        if isinstance(e, httpx.HTTPStatusError):
-            error_msg = f"HTTP error fetching metadata: {e.response.status_code} - {e.response.text}"
-        elif isinstance(e, httpx.TimeoutException):
-            error_msg = f"Timeout fetching metadata: {str(e)}"
-        elif isinstance(e, httpx.RequestError):
-            error_msg = (
-                f"Request error fetching metadata for {indicator_id!r}: {str(e)}"
-            )
-        else:
-            error_msg = f"Unexpected error fetching metadata: {str(e)}"
-        _logger.exception(error_msg)
-        errors.append(error_msg)
+        mcp_err = from_httpx_error(e, context="metadata")
+        _logger.exception(mcp_err.detail)
+        errors.append(mcp_err.detail)
 
     # 2. Fetch Disaggregation
     if fetch_disaggregation:
@@ -650,30 +652,14 @@ async def get_metadata(
                         raw_disaggregations
                     )
                 except ValueError as e:
-                    error_msg = (
-                        f"Failed to parse disaggregation JSON response: {str(e)}"
-                    )
-                    _logger.error(error_msg)
-                    errors.append(error_msg)
+                    mcp_err = ParseError(context="disaggregation", original_error=e)
+                    _logger.error(mcp_err.detail)
+                    errors.append(mcp_err.detail)
 
-        except httpx.HTTPStatusError as e:
-            error_msg = f"HTTP error fetching disaggregations: {e.response.status_code} - {e.response.text}"
-            _logger.error(error_msg)
-            errors.append(error_msg)
-        except httpx.TimeoutException as e:
-            error_msg = f"Timeout fetching disaggregations: {str(e)}"
-            _logger.error(error_msg)
-            errors.append(error_msg)
-        except httpx.RequestError as e:
-            error_msg = (
-                f"Request error fetching disaggregations for {indicator_id!r}: {str(e)}"
-            )
-            _logger.error(error_msg)
-            errors.append(error_msg)
         except Exception as e:
-            error_msg = f"Unexpected error fetching disaggregations: {str(e)}"
-            _logger.exception("Unexpected error in disaggregation fetch")
-            errors.append(error_msg)
+            mcp_err = from_httpx_error(e, context="disaggregation")
+            _logger.error(mcp_err.detail)
+            errors.append(mcp_err.detail)
 
     # 3. Combine and Return
     error_message = "; ".join(errors) if errors else None
@@ -725,15 +711,10 @@ async def get_disaggregation(
             valid_dimensions = _get_valid_disaggregations(raw_data)
             return {"dimensions": valid_dimensions}
 
-    except httpx.HTTPStatusError as e:
-        return {"error": f"HTTP error: {e.response.status_code} - {e.response.text}"}
-    except httpx.TimeoutException as e:
-        return {"error": f"Timeout: {str(e)}"}
-    except httpx.RequestError as e:
-        return {"error": f"Request error: {str(e)}"}
     except Exception as e:
-        _logger.exception("Unexpected error in get_disaggregation")
-        return {"error": f"Unexpected error: {str(e)}"}
+        mcp_err = from_httpx_error(e, context="disaggregation")
+        _logger.exception(mcp_err.detail)
+        return {"error": mcp_err.detail}
 
 
 async def get_data(
@@ -793,10 +774,14 @@ async def get_data(
             indicator_id=indicator_id,
             disaggregation_filters=disaggregation_filters,
         )
-    except ValidationError as e:
-        error_msg = f"Invalid arguments: {e}"
-        _logger.error(error_msg)
-        return IndicatorDataResponse(error=error_msg)
+    except PydanticValidationError as e:
+        mcp_err = Data360ValidationError(
+            context="data",
+            detail=f"Invalid arguments: {e}",
+            original_error=e,
+        )
+        _logger.error(mcp_err.detail)
+        return IndicatorDataResponse(error=mcp_err.detail)
 
     # Prepare API parameters
     params: dict[str, Any] = {
@@ -862,9 +847,9 @@ async def get_data(
             try:
                 data_json = data_res.json()
             except ValueError as e:
-                error_msg = f"Failed to parse data JSON response: {str(e)}"
-                _logger.error(error_msg)
-                return IndicatorDataResponse(data=None, error=error_msg)
+                mcp_err = ParseError(context="data", original_error=e)
+                _logger.error(mcp_err.detail)
+                return IndicatorDataResponse(data=None, error=mcp_err.detail)
 
             raw_data = data_json.get("value", [])
             total_count = data_json.get("@odata.count")  # May be None
@@ -904,19 +889,10 @@ async def get_data(
                 failed_validation=validation_errors if validation_errors else None,
             )
 
-    except httpx.HTTPStatusError as e:
-        error_msg = (
-            f"HTTP error fetching data: {e.response.status_code} - {e.response.text}"
-        )
-    except httpx.TimeoutException as e:
-        error_msg = f"Timeout fetching data: {str(e)}"
-    except httpx.RequestError as e:
-        error_msg = f"Request error fetching data for {indicator_id!r}: {str(e)}"
     except Exception as e:
-        error_msg = f"Unexpected error fetching data: {str(e)}"
-
-    _logger.error(error_msg)
-    return IndicatorDataResponse(data=None, error=error_msg)
+        mcp_err = from_httpx_error(e, context="data")
+        _logger.error(mcp_err.detail)
+        return IndicatorDataResponse(data=None, error=mcp_err.detail)
 
 
 async def get_indicators(database_id: str) -> list[str]:

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -302,13 +302,11 @@ async def _search_raw(
             try:
                 response_data = response.json()
             except ValueError as e:
-                _logger.error(f"Failed to parse JSON response: {e}")
                 mcp_error = ParseError(context="search", original_error=e)
             else:
                 try:
                     return _process_search_response(response_data, request)
                 except Exception as e:
-                    _logger.error(f"Failed to validate response data: {e}")
                     mcp_error = ParseError(
                         context="search",
                         detail=f"Failed to parse API response: {str(e)}",
@@ -317,7 +315,6 @@ async def _search_raw(
 
     except Exception as e:
         mcp_error = classify_error(e, context="search")
-        _logger.error(mcp_error.detail)
 
     if mcp_error:
         return SearchResponse(items=None, error=mcp_error.detail)
@@ -623,16 +620,13 @@ async def get_metadata(
                         context="metadata",
                         detail=f"No metadata found for indicator ID '{indicator_id}'",
                     )
-                    _logger.warning(mcp_err.detail)
                     errors.append(mcp_err.detail)
             except ValueError as e:
                 mcp_err = ParseError(context="metadata", original_error=e)
-                _logger.error(mcp_err.detail)
                 errors.append(mcp_err.detail)
 
     except Exception as e:
         mcp_err = classify_error(e, context="metadata")
-        _logger.exception(mcp_err.detail)
         errors.append(mcp_err.detail)
 
     # 2. Fetch Disaggregation
@@ -653,12 +647,10 @@ async def get_metadata(
                     )
                 except ValueError as e:
                     mcp_err = ParseError(context="disaggregation", original_error=e)
-                    _logger.error(mcp_err.detail)
                     errors.append(mcp_err.detail)
 
         except Exception as e:
             mcp_err = classify_error(e, context="disaggregation")
-            _logger.error(mcp_err.detail)
             errors.append(mcp_err.detail)
 
     # 3. Combine and Return
@@ -713,7 +705,6 @@ async def get_disaggregation(
 
     except Exception as e:
         mcp_err = classify_error(e, context="disaggregation")
-        _logger.exception(mcp_err.detail)
         return {"error": mcp_err.detail}
 
 
@@ -780,7 +771,6 @@ async def get_data(
             detail=f"Invalid arguments: {e}",
             original_error=e,
         )
-        _logger.error(mcp_err.detail)
         return IndicatorDataResponse(error=mcp_err.detail)
 
     # Prepare API parameters
@@ -848,7 +838,6 @@ async def get_data(
                 data_json = data_res.json()
             except ValueError as e:
                 mcp_err = ParseError(context="data", original_error=e)
-                _logger.error(mcp_err.detail)
                 return IndicatorDataResponse(data=None, error=mcp_err.detail)
 
             raw_data = data_json.get("value", [])
@@ -891,7 +880,6 @@ async def get_data(
 
     except Exception as e:
         mcp_err = classify_error(e, context="data")
-        _logger.error(mcp_err.detail)
         return IndicatorDataResponse(data=None, error=mcp_err.detail)
 
 

--- a/src/data360/errors.py
+++ b/src/data360/errors.py
@@ -6,7 +6,10 @@ Follows the pattern from https://github.com/avsolatorio/data-ai-chatbot/blob/dev
 Error codes follow the format: "<type>:<context>" (e.g. "http_error:search", "timeout:metadata").
 """
 
+import logging
 from typing import Any
+
+_logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -56,7 +59,11 @@ class Data360MCPError(Exception):
         error_code: Structured code like "http_error:search".
         detail: Human/LLM-readable error message.
         original_error: The original exception that caused this error, if any.
+        log_level: logging level used when this error is constructed. Subclasses
+            may override (e.g. NotFoundError uses WARNING).
     """
+
+    log_level: int = logging.ERROR
 
     def __init__(
         self,
@@ -68,6 +75,18 @@ class Data360MCPError(Exception):
         self.detail = detail or self._get_message(error_code)
         self.original_error = original_error
         super().__init__(self.detail)
+        exc_info = (
+            (type(original_error), original_error, original_error.__traceback__)
+            if original_error is not None
+            else None
+        )
+        _logger.log(
+            self.log_level,
+            "[%s] %s",
+            self.error_code,
+            self.detail,
+            exc_info=exc_info,
+        )
 
     def _get_message(self, error_code: str) -> str:
         return _ERROR_MESSAGES.get(
@@ -179,6 +198,8 @@ class ValidationError(Data360MCPError):
 
 class NotFoundError(Data360MCPError):
     """Resource not found errors."""
+
+    log_level: int = logging.WARNING
 
     def __init__(
         self,

--- a/src/data360/errors.py
+++ b/src/data360/errors.py
@@ -1,0 +1,230 @@
+"""Centralized error management for the Data360 MCP server.
+
+Provides a unified error hierarchy for consistent, LLM-actionable error messages.
+Follows the pattern from https://github.com/avsolatorio/data-ai-chatbot/blob/dev/backend/app/core/errors.py
+
+Error codes follow the format: "<type>:<context>" (e.g. "http_error:search", "timeout:metadata").
+"""
+
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Message registry - maps error codes to user/LLM-friendly messages
+# ---------------------------------------------------------------------------
+_ERROR_MESSAGES: dict[str, str] = {
+    # HTTP / network errors
+    "http_error:search": "The search request failed with an HTTP error. Please try again.",
+    "http_error:metadata": "Failed to fetch metadata due to an HTTP error. Verify the indicator_id and database_id are correct.",
+    "http_error:disaggregation": "Failed to fetch disaggregation options due to an HTTP error. Verify the indicator_id and database_id are correct.",
+    "http_error:data": "Failed to fetch data due to an HTTP error. Verify the indicator_id, database_id, and filters are correct.",
+    # Timeouts
+    "timeout:search": "The search request timed out. Please try again.",
+    "timeout:metadata": "The metadata request timed out. Please try again.",
+    "timeout:disaggregation": "The disaggregation request timed out. Please try again.",
+    "timeout:data": "The data request timed out. Please try again.",
+    # Request errors (connection issues, DNS, etc.)
+    "request_error:search": "A network error occurred during search. Check connectivity and try again.",
+    "request_error:metadata": "A network error occurred fetching metadata. Check connectivity and try again.",
+    "request_error:disaggregation": "A network error occurred fetching disaggregation options. Check connectivity and try again.",
+    "request_error:data": "A network error occurred fetching data. Check connectivity and try again.",
+    # Parse errors
+    "parse_error:search": "Failed to parse the search API response. The upstream API may be returning unexpected data.",
+    "parse_error:metadata": "Failed to parse the metadata API response.",
+    "parse_error:disaggregation": "Failed to parse the disaggregation API response.",
+    "parse_error:data": "Failed to parse the data API response.",
+    # Validation errors
+    "validation_error:search": "Invalid search parameters. Please check your query and filters.",
+    "validation_error:metadata": "Invalid metadata request parameters. Check the indicator_id and database_id.",
+    "validation_error:data": "Invalid data request parameters. Check the indicator_id, database_id, and filters.",
+    "validation_error:api_response": "The API response failed validation. The data format may have changed.",
+    # Not found
+    "not_found:indicator": "No indicators found matching your query. Try broadening your search terms.",
+    "not_found:metadata": "No metadata found for the specified indicator. Verify the indicator_id is correct.",
+    # Unexpected
+    "unexpected:search": "An unexpected error occurred during search.",
+    "unexpected:metadata": "An unexpected error occurred fetching metadata.",
+    "unexpected:disaggregation": "An unexpected error occurred fetching disaggregation options.",
+    "unexpected:data": "An unexpected error occurred fetching data.",
+}
+
+
+class Data360MCPError(Exception):
+    """Base exception for all Data360 MCP errors.
+
+    Attributes:
+        error_code: Structured code like "http_error:search".
+        detail: Human/LLM-readable error message.
+        original_error: The original exception that caused this error, if any.
+    """
+
+    def __init__(
+        self,
+        error_code: str,
+        detail: str | None = None,
+        original_error: Exception | None = None,
+    ):
+        self.error_code = error_code
+        self.detail = detail or self._get_message(error_code)
+        self.original_error = original_error
+        super().__init__(self.detail)
+
+    def _get_message(self, error_code: str) -> str:
+        return _ERROR_MESSAGES.get(
+            error_code, "Something went wrong. Please try again."
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize error for structured responses."""
+        result: dict[str, Any] = {
+            "error_code": self.error_code,
+            "detail": self.detail,
+        }
+        if self.original_error:
+            result["original_error"] = str(self.original_error)
+        return result
+
+
+class APIError(Data360MCPError):
+    """HTTP errors from the Data360 API (4xx, 5xx responses)."""
+
+    def __init__(
+        self,
+        context: str,
+        status_code: int,
+        response_text: str = "",
+        original_error: Exception | None = None,
+    ):
+        self.status_code = status_code
+        self.response_text = response_text
+        detail = f"HTTP error {status_code}: {response_text}"
+        super().__init__(
+            error_code=f"http_error:{context}",
+            detail=detail,
+            original_error=original_error,
+        )
+
+
+class TimeoutError(Data360MCPError):
+    """Timeout errors when calling the Data360 API."""
+
+    def __init__(
+        self,
+        context: str,
+        original_error: Exception | None = None,
+    ):
+        detail = _ERROR_MESSAGES.get(f"timeout:{context}", f"Request timed out: {context}")
+        super().__init__(
+            error_code=f"timeout:{context}",
+            detail=detail,
+            original_error=original_error,
+        )
+
+
+class RequestError(Data360MCPError):
+    """Network-level errors (DNS, connection refused, etc.)."""
+
+    def __init__(
+        self,
+        context: str,
+        original_error: Exception | None = None,
+    ):
+        detail = _ERROR_MESSAGES.get(
+            f"request_error:{context}", f"Request error: {context}"
+        )
+        super().__init__(
+            error_code=f"request_error:{context}",
+            detail=detail,
+            original_error=original_error,
+        )
+
+
+class ParseError(Data360MCPError):
+    """JSON parsing or response validation errors."""
+
+    def __init__(
+        self,
+        context: str,
+        detail: str | None = None,
+        original_error: Exception | None = None,
+    ):
+        detail = detail or _ERROR_MESSAGES.get(
+            f"parse_error:{context}", f"Failed to parse response: {context}"
+        )
+        super().__init__(
+            error_code=f"parse_error:{context}",
+            detail=detail,
+            original_error=original_error,
+        )
+
+
+class ValidationError(Data360MCPError):
+    """Invalid input parameters or failed response validation."""
+
+    def __init__(
+        self,
+        context: str,
+        detail: str | None = None,
+        original_error: Exception | None = None,
+    ):
+        detail = detail or _ERROR_MESSAGES.get(
+            f"validation_error:{context}", f"Validation error: {context}"
+        )
+        super().__init__(
+            error_code=f"validation_error:{context}",
+            detail=detail,
+            original_error=original_error,
+        )
+
+
+class NotFoundError(Data360MCPError):
+    """Resource not found errors."""
+
+    def __init__(
+        self,
+        context: str,
+        detail: str | None = None,
+        original_error: Exception | None = None,
+    ):
+        detail = detail or _ERROR_MESSAGES.get(
+            f"not_found:{context}", f"Not found: {context}"
+        )
+        super().__init__(
+            error_code=f"not_found:{context}",
+            detail=detail,
+            original_error=original_error,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helper to convert httpx exceptions into Data360MCPError
+# ---------------------------------------------------------------------------
+def from_httpx_error(exc: Exception, context: str) -> Data360MCPError:
+    """Convert an httpx exception into the appropriate Data360MCPError subclass.
+
+    Args:
+        exc: The original httpx exception.
+        context: The operation context (e.g. "search", "metadata", "data").
+
+    Returns:
+        The appropriate Data360MCPError subclass instance.
+    """
+    import httpx
+
+    if isinstance(exc, httpx.HTTPStatusError):
+        return APIError(
+            context=context,
+            status_code=exc.response.status_code,
+            response_text=exc.response.text,
+            original_error=exc,
+        )
+    elif isinstance(exc, httpx.TimeoutException):
+        return TimeoutError(context=context, original_error=exc)
+    elif isinstance(exc, httpx.RequestError):
+        return RequestError(context=context, original_error=exc)
+    else:
+        return Data360MCPError(
+            error_code=f"unexpected:{context}",
+            detail=f"Unexpected error: {str(exc)}",
+            original_error=exc,
+        )

--- a/src/data360/errors.py
+++ b/src/data360/errors.py
@@ -105,7 +105,7 @@ class APIError(Data360MCPError):
         )
 
 
-class TimeoutError(Data360MCPError):
+class Data360TimeoutError(Data360MCPError):
     """Timeout errors when calling the Data360 API."""
 
     def __init__(
@@ -197,10 +197,10 @@ class NotFoundError(Data360MCPError):
 
 
 # ---------------------------------------------------------------------------
-# Helper to convert httpx exceptions into Data360MCPError
+# Helper to convert exceptions into Data360MCPError
 # ---------------------------------------------------------------------------
-def from_httpx_error(exc: Exception, context: str) -> Data360MCPError:
-    """Convert an httpx exception into the appropriate Data360MCPError subclass.
+def classify_error(exc: Exception, context: str) -> Data360MCPError:
+    """Convert an exception into the appropriate Data360MCPError subclass.
 
     Args:
         exc: The original httpx exception.
@@ -219,7 +219,7 @@ def from_httpx_error(exc: Exception, context: str) -> Data360MCPError:
             original_error=exc,
         )
     elif isinstance(exc, httpx.TimeoutException):
-        return TimeoutError(context=context, original_error=exc)
+        return Data360TimeoutError(context=context, original_error=exc)
     elif isinstance(exc, httpx.RequestError):
         return RequestError(context=context, original_error=exc)
     else:

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -22,6 +22,11 @@ from data360 import viz_config
 
 _logger = logging.getLogger(__name__)
 
+_FALLBACK_WARNING = (
+    "Draco could not determine an optimal encoding; "
+    "a default line chart was generated as fallback."
+)
+
 
 def save_specs_to_static(vl_spec: dict) -> str:
     """Save Vega-Lite spec to static/viz_specs/ directory.
@@ -207,8 +212,10 @@ async def get_viz_spec(
         use_default_constraints: If True (default), apply standard encoding heuristics.
 
     Returns:
-        Dict with "url" and "error". On success: url is the chart URL (string), error is None.
+        Dict with "url", "error", and optionally "warning".
+        On success: url is the chart URL (string), error is None.
         On failure: url is None, error is an error message string.
+        If Draco failed and a fallback chart was generated, "warning" contains a message.
     """
 
     def ok(u: str) -> dict[str, str | None]:
@@ -585,10 +592,6 @@ async def get_viz_spec(
         return ok(save_specs_to_static(vl_spec))
 
     except StopIteration:
-        _FALLBACK_WARNING = (
-            "Draco could not determine an optimal encoding; "
-            "a default line chart was generated as fallback."
-        )
         _logger.warning(
             "Draco failed to find a visualization spec. Falling back to manual generation."
         )

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -585,6 +585,10 @@ async def get_viz_spec(
         return ok(save_specs_to_static(vl_spec))
 
     except StopIteration:
+        _FALLBACK_WARNING = (
+            "Draco could not determine an optimal encoding; "
+            "a default line chart was generated as fallback."
+        )
         _logger.warning(
             "Draco failed to find a visualization spec. Falling back to manual generation."
         )
@@ -635,12 +639,16 @@ async def get_viz_spec(
             charts_url = get_mcp_server_settings().charts_api_url
             if charts_url:
                 try:
-                    return ok(await post_spec_to_charts_api(vl_spec))
+                    result = ok(await post_spec_to_charts_api(vl_spec))
+                    result["warning"] = _FALLBACK_WARNING
+                    return result
                 except Exception as e:
                     _logger.warning(
                         f"Charts API store failed, falling back to static: {e}"
                     )
-            return ok(save_specs_to_static(vl_spec))
+            result = ok(save_specs_to_static(vl_spec))
+            result["warning"] = _FALLBACK_WARNING
+            return result
 
         except Exception as fallback_err:
             _logger.exception(f"Fallback generation failed: {fallback_err}")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -214,7 +214,7 @@ class TestSearch:
 
         assert not result.indicators
         assert result.error is not None
-        assert "timeout" in result.error.lower()
+        assert "timed out" in result.error.lower()
 
     @pytest.mark.asyncio
     async def test_search_invalid_json(self, httpx_mock: pytest_httpx.HTTPXMock):
@@ -510,7 +510,7 @@ class TestGetMetadata:
         result = await get_metadata("WB_WDI_SP_POP_TOTL", "WB_WDI")
 
         assert result.error is not None
-        assert "HTTP error fetching metadata" in result.error
+        assert "HTTP error" in result.error
 
     @pytest.mark.asyncio
     async def test_get_metadata_http_error_disaggregation(
@@ -554,7 +554,7 @@ class TestGetMetadata:
 
         assert result.indicator_metadata is not None
         assert result.error is not None
-        assert "HTTP error fetching disaggregations" in result.error
+        assert "HTTP error" in result.error
 
 
 class TestGetData:
@@ -772,7 +772,7 @@ class TestGetData:
 
         assert result.data is None
         assert result.error is not None
-        assert "HTTP error fetching data" in result.error
+        assert "HTTP error" in result.error
 
     @pytest.mark.asyncio
     async def test_get_data_invalid_json(self, httpx_mock: pytest_httpx.HTTPXMock):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,156 @@
+"""Tests for data360.errors module."""
+
+import httpx
+import pytest
+
+from data360.errors import (
+    APIError,
+    Data360MCPError,
+    Data360TimeoutError,
+    NotFoundError,
+    ParseError,
+    RequestError,
+    ValidationError,
+    classify_error,
+)
+
+
+class TestData360MCPError:
+    """Tests for the base error class."""
+
+    def test_uses_registry_message(self):
+        """Known error codes should use messages from the registry."""
+        err = Data360MCPError(error_code="timeout:search")
+        assert "timed out" in err.detail.lower()
+
+    def test_uses_fallback_message(self):
+        """Unknown error codes should use the default fallback message."""
+        err = Data360MCPError(error_code="unknown:foo")
+        assert err.detail == "Something went wrong. Please try again."
+
+    def test_custom_detail_overrides_registry(self):
+        """An explicit detail should override the registry message."""
+        err = Data360MCPError(error_code="timeout:search", detail="Custom message")
+        assert err.detail == "Custom message"
+
+    def test_original_error_preserved(self):
+        """The original exception should be accessible."""
+        original = ValueError("original")
+        err = Data360MCPError(error_code="unexpected:test", original_error=original)
+        assert err.original_error is original
+
+    def test_to_dict(self):
+        """to_dict should return a structured dict."""
+        original = ValueError("boom")
+        err = Data360MCPError(
+            error_code="http_error:search",
+            detail="HTTP error 500",
+            original_error=original,
+        )
+        d = err.to_dict()
+        assert d["error_code"] == "http_error:search"
+        assert d["detail"] == "HTTP error 500"
+        assert d["original_error"] == "boom"
+
+    def test_to_dict_without_original(self):
+        """to_dict without original_error should not include it."""
+        err = Data360MCPError(error_code="unexpected:test")
+        d = err.to_dict()
+        assert "original_error" not in d
+
+
+class TestSubclasses:
+    """Tests for specific error subclasses."""
+
+    def test_api_error(self):
+        err = APIError(context="search", status_code=500, response_text="Internal Server Error")
+        assert err.status_code == 500
+        assert "HTTP error 500" in err.detail
+        assert err.error_code == "http_error:search"
+
+    def test_data360_timeout_error(self):
+        err = Data360TimeoutError(context="metadata")
+        assert err.error_code == "timeout:metadata"
+        assert "timed out" in err.detail.lower()
+
+    def test_request_error(self):
+        err = RequestError(context="data")
+        assert err.error_code == "request_error:data"
+        assert "network error" in err.detail.lower()
+
+    def test_parse_error_default_message(self):
+        err = ParseError(context="search")
+        assert err.error_code == "parse_error:search"
+        assert "parse" in err.detail.lower()
+
+    def test_parse_error_custom_detail(self):
+        err = ParseError(context="search", detail="Custom parse error")
+        assert err.detail == "Custom parse error"
+
+    def test_validation_error(self):
+        err = ValidationError(context="data")
+        assert err.error_code == "validation_error:data"
+
+    def test_not_found_error(self):
+        err = NotFoundError(context="indicator")
+        assert err.error_code == "not_found:indicator"
+        assert "not found" in err.detail.lower() or "no indicators" in err.detail.lower()
+
+
+class TestClassifyError:
+    """Tests for the classify_error helper."""
+
+    def test_http_status_error(self):
+        """httpx.HTTPStatusError should map to APIError."""
+        request = httpx.Request("GET", "http://example.com")
+        response = httpx.Response(status_code=404, text="Not Found", request=request)
+        exc = httpx.HTTPStatusError("Not Found", request=request, response=response)
+
+        result = classify_error(exc, context="search")
+
+        assert isinstance(result, APIError)
+        assert result.status_code == 404
+        assert result.error_code == "http_error:search"
+
+    def test_timeout_exception(self):
+        """httpx.TimeoutException should map to Data360TimeoutError."""
+        exc = httpx.ReadTimeout("read timed out")
+
+        result = classify_error(exc, context="metadata")
+
+        assert isinstance(result, Data360TimeoutError)
+        assert result.error_code == "timeout:metadata"
+
+    def test_request_error(self):
+        """httpx.RequestError (e.g. ConnectError) should map to RequestError."""
+        exc = httpx.ConnectError("Connection refused")
+
+        result = classify_error(exc, context="data")
+
+        assert isinstance(result, RequestError)
+        assert result.error_code == "request_error:data"
+
+    def test_non_httpx_exception(self):
+        """Non-httpx exceptions should map to generic Data360MCPError."""
+        exc = KeyError("missing_key")
+
+        result = classify_error(exc, context="disaggregation")
+
+        assert isinstance(result, Data360MCPError)
+        assert result.error_code == "unexpected:disaggregation"
+        assert result.original_error is exc
+
+    def test_all_subclasses_inherit_base(self):
+        """All error subclasses should be instances of Data360MCPError."""
+        errors = [
+            APIError(context="test", status_code=500),
+            Data360TimeoutError(context="test"),
+            RequestError(context="test"),
+            ParseError(context="test"),
+            ValidationError(context="test"),
+            NotFoundError(context="test"),
+        ]
+        for err in errors:
+            assert isinstance(err, Data360MCPError), (
+                f"{type(err).__name__} is not a Data360MCPError"
+            )

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,5 +1,7 @@
 """Tests for data360.errors module."""
 
+import logging
+
 import httpx
 import pytest
 
@@ -13,6 +15,13 @@ from data360.errors import (
     ValidationError,
     classify_error,
 )
+
+
+@pytest.fixture(autouse=True)
+def suppress_error_logs(caplog):
+    """Suppress data360.errors log output for all tests unless explicitly asserted."""
+    with caplog.at_level(logging.CRITICAL, logger="data360.errors"):
+        yield
 
 
 class TestData360MCPError:
@@ -154,3 +163,48 @@ class TestClassifyError:
             assert isinstance(err, Data360MCPError), (
                 f"{type(err).__name__} is not a Data360MCPError"
             )
+
+
+class TestLogging:
+    """Tests for the automatic logging behaviour in Data360MCPError.__init__."""
+
+    def test_logs_on_construction(self, caplog):
+        """Constructing any Data360MCPError should emit a log record."""
+        with caplog.at_level(logging.ERROR, logger="data360.errors"):
+            Data360MCPError(error_code="timeout:search")
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelno == logging.ERROR
+        assert "timeout:search" in record.message
+
+    def test_not_found_logs_at_warning(self, caplog):
+        """NotFoundError should log at WARNING, not ERROR."""
+        with caplog.at_level(logging.WARNING, logger="data360.errors"):
+            NotFoundError(context="indicator")
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelno == logging.WARNING
+
+    def test_traceback_captured_for_raised_exception(self, caplog):
+        """When original_error was raised, exc_info should include a traceback."""
+        try:
+            raise ValueError("boom")
+        except ValueError as exc:
+            original = exc
+
+        with caplog.at_level(logging.ERROR, logger="data360.errors"):
+            Data360MCPError(
+                error_code="unexpected:test", original_error=original
+            )
+
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        # exc_info is a (type, value, traceback) tuple; traceback must be non-None
+        assert record.exc_info is not None
+        assert record.exc_info[2] is not None, "Expected a real traceback"
+
+    def test_no_exc_info_without_original_error(self, caplog):
+        """When no original_error is provided, exc_info should be None."""
+        with caplog.at_level(logging.ERROR, logger="data360.errors"):
+            Data360MCPError(error_code="unexpected:test")
+        assert len(caplog.records) == 1
+        assert caplog.records[0].exc_info is None

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,0 +1,140 @@
+"""Tests for data360.visualization module."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from data360.visualization import get_viz_spec
+
+
+class TestGetVizSpecDracoFallbackWarning:
+    """Verify that a warning is surfaced when Draco fails and fallback is used."""
+
+    @pytest.fixture
+    def sample_dataframe(self):
+        """Minimal DataFrame with time_period and obs_value."""
+        return pd.DataFrame(
+            {
+                "TIME_PERIOD": ["2020-01-01", "2021-01-01", "2022-01-01"],
+                "OBS_VALUE": [100, 200, 300],
+                "REF_AREA": ["KEN", "KEN", "KEN"],
+            }
+        )
+
+    @pytest.fixture
+    def patches(self, sample_dataframe):
+        """Set up all the mocks needed to isolate the Draco fallback path."""
+        with (
+            patch(
+                "data360.api.get_data_api_url",
+                new_callable=AsyncMock,
+                return_value="http://fake-api/data?DATABASE_ID=WB_WDI&INDICATOR=FAKE",
+            ) as mock_url,
+            patch(
+                "data360.visualization._fetch_data_internal",
+                new_callable=AsyncMock,
+                return_value=sample_dataframe,
+            ) as mock_fetch,
+            patch(
+                "data360.api.get_metadata",
+                new_callable=AsyncMock,
+                return_value=None,
+            ) as mock_meta,
+            patch(
+                "data360.visualization.save_specs_to_static",
+                return_value="http://localhost:8021/static/viz_specs/test.json",
+            ) as mock_save,
+        ):
+            yield {
+                "get_data_api_url": mock_url,
+                "fetch_data": mock_fetch,
+                "get_metadata": mock_meta,
+                "save_specs": mock_save,
+            }
+
+    @pytest.mark.asyncio
+    async def test_fallback_returns_warning(self, patches):
+        """When Draco raises StopIteration, the response should include a warning key."""
+        with patch("data360.visualization.Draco") as MockDraco:
+            draco_instance = MagicMock()
+            draco_instance.complete_spec.return_value = iter([])
+            MockDraco.return_value = draco_instance
+
+            result = await get_viz_spec(
+                database_id="WB_WDI",
+                indicator_id="FAKE_IND",
+            )
+
+        assert result["url"] is not None, "Expected a URL from fallback generation"
+        assert result["error"] is None, "Expected no error from successful fallback"
+        assert "warning" in result, "Expected a 'warning' key when Draco falls back"
+        assert "fallback" in result["warning"].lower(), (
+            f"Warning message should mention fallback, got: {result['warning']}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_draco_success_has_no_warning(self, patches):
+        """When Draco succeeds, no warning key should be present."""
+        # Build a chainable mock chart that returns a valid spec from to_dict()
+        mock_chart = MagicMock()
+        mock_vl_spec = {
+            "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+            "mark": "point",
+            "encoding": {"x": {"field": "year", "type": "temporal"},
+                         "y": {"field": "value", "type": "quantitative"}},
+        }
+        # Chain: chart.properties(...).interactive().encode(...).to_dict()
+        mock_chart.properties.return_value = mock_chart
+        mock_chart.interactive.return_value = mock_chart
+        mock_chart.encode.return_value = mock_chart
+        mock_chart.to_dict.return_value = mock_vl_spec
+
+        with (
+            patch("data360.visualization.Draco") as MockDraco,
+            patch("data360.visualization.answer_set_to_dict") as mock_as2d,
+            patch("data360.visualization.AltairRenderer") as MockRenderer,
+        ):
+            fake_model = MagicMock()
+            draco_instance = MagicMock()
+            draco_instance.complete_spec.return_value = iter([fake_model])
+            MockDraco.return_value = draco_instance
+
+            mock_as2d.return_value = {"view": [{"mark": [{"type": "point", "encoding": []}]}]}
+
+            renderer_instance = MagicMock()
+            renderer_instance.render.return_value = mock_chart
+            MockRenderer.return_value = renderer_instance
+
+            result = await get_viz_spec(
+                database_id="WB_WDI",
+                indicator_id="FAKE_IND",
+            )
+
+        assert result["error"] is None, f"Unexpected error: {result['error']}"
+        assert result["url"] is not None
+        assert "warning" not in result, (
+            f"No warning expected on Draco success, got: {result.get('warning')}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_fallback_also_fails_returns_error(self, patches):
+        """When both Draco and the manual fallback fail, an error is returned."""
+        with (
+            patch("data360.visualization.Draco") as MockDraco,
+            patch("data360.visualization.alt") as MockAlt,
+        ):
+            draco_instance = MagicMock()
+            draco_instance.complete_spec.return_value = iter([])
+            MockDraco.return_value = draco_instance
+
+            MockAlt.Chart.side_effect = RuntimeError("Altair broke")
+
+            result = await get_viz_spec(
+                database_id="WB_WDI",
+                indicator_id="FAKE_IND",
+            )
+
+        assert result["url"] is None
+        assert result["error"] is not None
+        assert "fallback failed" in result["error"].lower()

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -45,12 +45,18 @@ class TestGetVizSpecDracoFallbackWarning:
                 "data360.visualization.save_specs_to_static",
                 return_value="http://localhost:8021/static/viz_specs/test.json",
             ) as mock_save,
+            patch(
+                "data360.providers.get_codelist_mapping",
+                new_callable=AsyncMock,
+                return_value={},
+            ) as mock_codelist,
         ):
             yield {
                 "get_data_api_url": mock_url,
                 "fetch_data": mock_fetch,
                 "get_metadata": mock_meta,
                 "save_specs": mock_save,
+                "get_codelist_mapping": mock_codelist,
             }
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Addresses https://github.com/avsolatorio/data360-mcp/issues/19

> [!NOTE]
> This branch is based on `feat/improve-tool-descriptions` (not yet merged to `dev`). Merge that branch first before merging this PR.

Centralizes error management by introducing a `Data360MCPError` class hierarchy, replacing scattered try/except blocks across the codebase with structured, LLM-actionable error responses.

## Changes

### `src/data360/errors.py` [NEW]
- `Data360MCPError` base exception with `error_code`, `detail`, and `to_dict()` serialization
- Subclasses: `APIError`, `Data360TimeoutError`, `RequestError`, `ParseError`, `ValidationError`, `NotFoundError`
- `classify_error()` converter for clean exception handling
- Message registry mapping error codes to LLM-actionable messages

### `src/data360/api.py`
- Refactored `_search_raw()`, `get_metadata()`, `get_disaggregation()`, `get_data()` to raise/catch `Data360MCPError` subclasses instead of raw exceptions

### `src/data360/visualization.py`
- `get_viz_spec` now returns a `"warning"` key when Draco fails to find an optimal encoding and a fallback line chart is generated

### `tests/test_errors.py` [NEW]
- 18 tests covering all error classes and `classify_error` mapping logic

### `tests/test_visualization.py` [NEW]
- 3 tests: fallback returns warning, Draco success has no warning, both-fail returns error

### `tests/test_api.py`
- Updated assertions to match new error message format

## Test Results

All 41 tests pass with no regressions.
