### PR TITLE
feat: multi-indicator visualization + MCP load-test harness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,9 @@ dependencies = [
   "gunicorn>=23.0.0",
   "langchain-openai>=1.1.7",
   "pydantic-settings>=2.0.0",
-  "draco @ git+https://github.com/avsolatorio/draco2.git@data360-mcp"
+  "draco @ git+https://github.com/avsolatorio/draco2.git@data360-mcp",
+  "opencensus-ext-azure>=1.1.13",
+  "azure-monitor-opentelemetry>=1.6.0",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
   "pytest-cov>=4.1.0",
   "pip-licenses>=5.0.0",
   "pip-audit>=2.10.0",
+  "requests>=2.32.0",
 ]
 
 [tool.ruff.lint]

--- a/scripts/test_rate_limits.py
+++ b/scripts/test_rate_limits.py
@@ -1,0 +1,687 @@
+"""
+Manual MCP load / rate-limit harness for Data360 MCP (JSON-RPC over SSE).
+
+Requires the `requests` package (listed under [dependency-groups] dev in pyproject.toml).
+
+Environment:
+  DATA360_MCP_URL or MCP_SERVER_URL — base URL for MCP POST (default: QA APIM).
+  APIM_SUBSCRIPTION_KEY — if set, sent as Ocp-Apim-Subscription-Key (Azure API Management).
+
+Example:
+  uv run python scripts/test_rate_limits.py --phase all --url https://example/mcp
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import statistics
+import threading
+import time
+from collections import Counter, defaultdict
+from concurrent.futures import (
+    FIRST_COMPLETED,
+    Future,
+    ThreadPoolExecutor,
+    as_completed,
+    wait,
+)
+from dataclasses import dataclass
+from http import HTTPStatus
+from typing import Any, Literal
+
+import requests
+import typer
+
+# ── Defaults ───────────────────────────────────────────────────
+DEFAULT_MCP_URL = "https://azapimqa.worldbank.org/public/data360/mcp"
+
+BASE_SSE_HEADERS: dict[str, str] = {
+    "Accept": "application/json, text/event-stream",
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+}
+
+DEFAULT_REQUEST_TIMEOUT = (5, 30)  # connect, read
+DEFAULT_MAX_WORKERS = 20
+DEFAULT_REQUESTS_PER_PHASE = 100
+DEFAULT_SOAK_DURATION_SECONDS = 300
+DEFAULT_SOAK_CONCURRENCY = DEFAULT_MAX_WORKERS
+DEFAULT_RETRY_ATTEMPTS = 2
+DEFAULT_BACKOFF_BASE = 0.5
+DEFAULT_RAMP_MAX_FAILURE_RATE = 0.10
+DEFAULT_RAMP_MIN_429_COUNT = 1
+
+Phase = Literal["all", "warmup", "ramp", "soak"]
+
+LOAD_TEST_CASES: list[dict[str, Any]] = [
+    {
+        "label": "initialize",
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "load-test-client", "version": "1.0"},
+        },
+    },
+    {"label": "tools/list", "method": "tools/list", "params": {}},
+    {
+        "label": "data360_get_data",
+        "method": "tools/call",
+        "params": {
+            "name": "data360_get_data",
+            "arguments": {
+                "database_id": "WB_WDI",
+                "indicator_id": "WB_WDI_NY_GDP_PCAP_KD",
+                "disaggregation_filters": {"REF_AREA": "KEN"},
+                "start_year": 2015,
+                "end_year": 2022,
+                "limit": 10,
+            },
+        },
+    },
+    {
+        "label": "data360_search_indicators",
+        "method": "tools/call",
+        "params": {
+            "name": "data360_search_indicators",
+            "arguments": {"query": "GDP per capita"},
+        },
+    },
+    {
+        "label": "data360_get_metadata",
+        "method": "tools/call",
+        "params": {
+            "name": "data360_get_metadata",
+            "arguments": {
+                "database_id": "WB_WDI",
+                "indicator_id": "WB_WDI_NY_GDP_PCAP_KD",
+                "fetch_disaggregation": True,
+            },
+        },
+    },
+]
+
+
+@dataclass
+class LoadTestConfig:
+    """Per-run settings passed through the request path."""
+
+    mcp_url: str
+    request_headers: dict[str, str]
+    request_timeout: tuple[float, float]
+    retry_attempts: int
+    backoff_base: float
+    retry_on_429: bool
+
+
+@dataclass
+class RampOptions:
+    """Parameters for the ramp phase."""
+
+    requests_per_phase: int
+    ramp_concurrencies: list[int]
+    min_429_count: int
+    max_failure_rate: float
+    json_phases: list[dict[str, Any]] | None
+
+
+def resolve_mcp_url(url: str | None) -> str:
+    if url:
+        return url
+    return (
+        os.environ.get("DATA360_MCP_URL")
+        or os.environ.get("MCP_SERVER_URL")
+        or DEFAULT_MCP_URL
+    )
+
+
+def build_request_headers(extra: dict[str, str] | None = None) -> dict[str, str]:
+    h = dict(BASE_SSE_HEADERS)
+    key = os.environ.get("APIM_SUBSCRIPTION_KEY")
+    if key:
+        h["Ocp-Apim-Subscription-Key"] = key
+    if extra:
+        h.update(extra)
+    return h
+
+
+def make_thread_local_session_factory(headers: dict[str, str]):
+    """Return a callable that yields a thread-local requests.Session (safe for ThreadPoolExecutor)."""
+
+    local = threading.local()
+
+    def get_session() -> requests.Session:
+        session = getattr(local, "session", None)
+        if session is None:
+            session = requests.Session()
+            session.headers.update(headers)
+            local.session = session
+        return session
+
+    return get_session
+
+
+def classify_result(status_code: int | None, err: str | None, payload: Any) -> str:  # noqa: PLR0911
+    if err:
+        err_l = err.lower()
+        if "timeout" in err_l:
+            return "timeout"
+        if "connection" in err_l:
+            return "connection_error"
+        if "No data in SSE stream" in err:
+            return "empty_sse"
+        return "client_error"
+
+    if status_code == HTTPStatus.TOO_MANY_REQUESTS:
+        return "rate_limited"
+    if status_code is not None and status_code >= HTTPStatus.INTERNAL_SERVER_ERROR:
+        return "server_error"
+    if status_code is not None and status_code >= HTTPStatus.BAD_REQUEST:
+        return f"http_{status_code}"
+
+    if payload is None:
+        return "no_payload"
+    if isinstance(payload, dict) and "error" in payload:
+        return "jsonrpc_error"
+    if (
+        isinstance(payload, dict)
+        and "result" in payload
+        and isinstance(payload["result"], dict)
+        and payload["result"].get("isError")
+    ):
+        return "tool_isError"
+    return "success"
+
+
+def percentile(values: list[float], p: float) -> float | None:
+    if not values:
+        return None
+    values = sorted(values)
+    k = (len(values) - 1) * p
+    f = int(k)
+    c = min(f + 1, len(values) - 1)
+    if f == c:
+        return values[f]
+    return values[f] + (values[c] - values[f]) * (k - f)
+
+
+def mcp_request(
+    session: requests.Session,
+    cfg: LoadTestConfig,
+    method: str,
+    params: dict[str, Any] | None,
+    req_id: int = 1,
+) -> dict[str, Any]:
+    payload = {"jsonrpc": "2.0", "id": req_id, "method": method, "params": params or {}}
+
+    start = time.perf_counter()
+    try:
+        response = session.post(
+            cfg.mcp_url,
+            json=payload,
+            headers=cfg.request_headers,
+            stream=True,
+            timeout=cfg.request_timeout,
+        )
+    except requests.exceptions.Timeout:
+        return {
+            "ok": False,
+            "latency": time.perf_counter() - start,
+            "status_code": None,
+            "err": "timeout",
+            "payload": None,
+        }
+    except requests.exceptions.ConnectionError as e:
+        return {
+            "ok": False,
+            "latency": time.perf_counter() - start,
+            "status_code": None,
+            "err": f"connection error: {e}",
+            "payload": None,
+        }
+    except Exception as e:
+        return {
+            "ok": False,
+            "latency": time.perf_counter() - start,
+            "status_code": None,
+            "err": str(e),
+            "payload": None,
+        }
+
+    status_code = response.status_code
+
+    if status_code != HTTPStatus.OK:
+        return {
+            "ok": False,
+            "latency": time.perf_counter() - start,
+            "status_code": status_code,
+            "err": response.text[:500],
+            "payload": None,
+        }
+
+    try:
+        for line in response.iter_lines():
+            if not line:
+                continue
+            decoded = line.decode("utf-8") if isinstance(line, bytes) else line
+            if decoded.startswith("data:"):
+                data_str = decoded[5:].strip()
+                if not data_str:
+                    continue
+                try:
+                    body = json.loads(data_str)
+                    return {
+                        "ok": True,
+                        "latency": time.perf_counter() - start,
+                        "status_code": status_code,
+                        "err": None,
+                        "payload": body,
+                    }
+                except json.JSONDecodeError:
+                    continue
+
+        return {
+            "ok": False,
+            "latency": time.perf_counter() - start,
+            "status_code": status_code,
+            "err": "No data in SSE stream",
+            "payload": None,
+        }
+    finally:
+        response.close()
+
+
+def request_with_retry(
+    session: requests.Session,
+    test_case: dict[str, Any],
+    req_id: int,
+    cfg: LoadTestConfig,
+) -> dict[str, Any]:
+    attempt = 0
+    last: dict[str, Any] | None = None
+
+    while attempt <= cfg.retry_attempts:
+        result = mcp_request(
+            session, cfg, test_case["method"], test_case["params"], req_id=req_id
+        )
+        result["label"] = test_case["label"]
+        result["attempt"] = attempt + 1
+
+        category = classify_result(
+            result["status_code"], result["err"], result["payload"]
+        )
+        result["category"] = category
+
+        if category == "success":
+            return result
+
+        last = result
+        retryable = {
+            "timeout",
+            "server_error",
+            "empty_sse",
+        }
+        if cfg.retry_on_429:
+            retryable.add("rate_limited")
+
+        if attempt < cfg.retry_attempts and category in retryable:
+            sleep_s = cfg.backoff_base * (2**attempt) + random.uniform(0, 0.2)
+            time.sleep(sleep_s)
+        else:
+            return result
+
+        attempt += 1
+
+    return last  # type: ignore[return-value]
+
+
+def run_batch(
+    concurrency: int,
+    total_requests: int,
+    cfg: LoadTestConfig,
+    get_session,
+    mix_cases: bool = True,
+) -> tuple[list[dict[str, Any]], float]:
+    results: list[dict[str, Any]] = []
+    start_batch = time.perf_counter()
+
+    def worker(i: int) -> dict[str, Any]:
+        case = random.choice(LOAD_TEST_CASES) if mix_cases else LOAD_TEST_CASES[0]
+        session = get_session()
+        return request_with_retry(session, case, i + 1, cfg)
+
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        futures = [executor.submit(worker, i) for i in range(total_requests)]
+        for future in as_completed(futures):
+            results.append(future.result())
+
+    duration = time.perf_counter() - start_batch
+    return results, duration
+
+
+def summarize_results(
+    name: str,
+    results: list[dict[str, Any]],
+    duration: float,
+) -> dict[str, Any]:
+    latencies = [float(r["latency"]) for r in results]
+    categories = Counter(r["category"] for r in results)
+    by_label: dict[str, Counter[str]] = defaultdict(Counter)
+    for r in results:
+        by_label[str(r["label"])][str(r["category"])] += 1
+
+    success_count = categories.get("success", 0)
+    total = len(results)
+    rps = total / duration if duration > 0 else 0
+
+    print(f"\n{'=' * 70}")
+    print(name)
+    print(f"{'=' * 70}")
+    print(f"Total requests      : {total}")
+    print(f"Duration (s)        : {duration:.2f}")
+    print(f"Throughput (req/s)  : {rps:.2f}")
+    print(
+        f"Success rate        : {success_count}/{total} ({(100 * success_count / total):.2f}%)"
+    )
+
+    if latencies:
+        print(f"Latency mean (s)    : {statistics.mean(latencies):.3f}")
+        print(f"Latency median (s)  : {statistics.median(latencies):.3f}")
+        p95 = percentile(latencies, 0.95)
+        p99 = percentile(latencies, 0.99)
+        print(
+            f"Latency p95 (s)     : {p95:.3f}"
+            if p95 is not None
+            else "Latency p95 (s)     : n/a"
+        )
+        print(
+            f"Latency p99 (s)     : {p99:.3f}"
+            if p99 is not None
+            else "Latency p99 (s)     : n/a"
+        )
+        print(f"Latency max (s)     : {max(latencies):.3f}")
+
+    print("\nOutcome counts:")
+    for k, v in categories.most_common():
+        print(f"  - {k}: {v}")
+
+    print("\nBy endpoint/test case:")
+    for label, counter in sorted(by_label.items()):
+        print(f"  {label}:")
+        for k, v in counter.most_common():
+            print(f"    - {k}: {v}")
+
+    return {
+        "name": name,
+        "total_requests": total,
+        "duration_seconds": duration,
+        "throughput_rps": rps,
+        "success_count": success_count,
+        "success_rate": success_count / total if total else 0.0,
+        "outcome_counts": dict(categories),
+        "by_label": {lbl: dict(ct) for lbl, ct in by_label.items()},
+        "latency": {
+            "mean": statistics.mean(latencies) if latencies else None,
+            "median": statistics.median(latencies) if latencies else None,
+            "p95": percentile(latencies, 0.95),
+            "p99": percentile(latencies, 0.99),
+            "max": max(latencies) if latencies else None,
+        },
+    }
+
+
+def ramp_should_stop(
+    results: list[dict[str, Any]],
+    *,
+    min_429_count: int,
+    max_failure_rate: float,
+) -> bool:
+    rate_limited = sum(1 for r in results if r["category"] == "rate_limited")
+    success_n = sum(1 for r in results if r["category"] == "success")
+    total = len(results)
+    failure_rate = 1 - (success_n / total) if total else 0.0
+    return rate_limited >= min_429_count or failure_rate > max_failure_rate
+
+
+def ramp_test(cfg: LoadTestConfig, get_session, options: RampOptions) -> None:
+    print("\n=== RAMP TEST ===")
+    for concurrency in options.ramp_concurrencies:
+        print(f"\nRunning ramp step with concurrency={concurrency}")
+        results, duration = run_batch(
+            concurrency=concurrency,
+            total_requests=options.requests_per_phase,
+            cfg=cfg,
+            get_session=get_session,
+            mix_cases=True,
+        )
+        summary = summarize_results(
+            f"Ramp step @ concurrency={concurrency}", results, duration
+        )
+        if options.json_phases is not None:
+            options.json_phases.append(summary)
+
+        if ramp_should_stop(
+            results,
+            min_429_count=options.min_429_count,
+            max_failure_rate=options.max_failure_rate,
+        ):
+            print(
+                "\nStopping ramp: threshold reached "
+                f"(min_429_count={options.min_429_count}, "
+                f"max_failure_rate={options.max_failure_rate})."
+            )
+            break
+
+
+def soak_test(
+    cfg: LoadTestConfig,
+    get_session,
+    concurrency: int,
+    duration_seconds: float,
+    json_phases: list[dict[str, Any]] | None,
+) -> None:
+    print("\n=== SOAK TEST ===")
+    wall_start = time.perf_counter()
+    deadline = time.time() + duration_seconds
+    all_results: list[dict[str, Any]] = []
+
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        futures: set[Future[dict[str, Any]]] = set()
+        req_id = 1
+
+        while len(futures) < concurrency and time.time() < deadline:
+            case = random.choice(LOAD_TEST_CASES)
+            futures.add(
+                executor.submit(
+                    _soak_once,
+                    get_session,
+                    case,
+                    req_id,
+                    cfg,
+                )
+            )
+            req_id += 1
+
+        while futures:
+            done, _pending = wait(futures, return_when=FIRST_COMPLETED)
+            for f in done:
+                futures.discard(f)
+                all_results.append(f.result())
+
+                if time.time() < deadline:
+                    case = random.choice(LOAD_TEST_CASES)
+                    futures.add(
+                        executor.submit(
+                            _soak_once,
+                            get_session,
+                            case,
+                            req_id,
+                            cfg,
+                        )
+                    )
+                    req_id += 1
+
+    wall_elapsed = time.perf_counter() - wall_start
+    summary = summarize_results(
+        f"Soak test @ concurrency={concurrency} for ~{duration_seconds:.0f}s scheduled "
+        f"(wall {wall_elapsed:.2f}s)",
+        all_results,
+        wall_elapsed,
+    )
+    if json_phases is not None:
+        json_phases.append(summary)
+
+
+def _soak_once(
+    get_session,
+    case: dict[str, Any],
+    req_id: int,
+    cfg: LoadTestConfig,
+) -> dict[str, Any]:
+    session = get_session()
+    return request_with_retry(session, case, req_id, cfg)
+
+
+app = typer.Typer(no_args_is_help=True)
+
+
+@app.command()
+def main(  # noqa: PLR0913
+    phase: Phase = typer.Option(
+        "all",
+        "--phase",
+        "-p",
+        help="Which phases to run: all, warmup, ramp, or soak.",
+    ),
+    url: str | None = typer.Option(
+        None,
+        "--url",
+        "-u",
+        envvar="DATA360_MCP_URL",
+        help="MCP base URL (overrides DATA360_MCP_URL / MCP_SERVER_URL).",
+    ),
+    warmup_concurrency: int = typer.Option(2, "--warmup-concurrency"),
+    warmup_requests: int = typer.Option(10, "--warmup-requests"),
+    ramp_requests: int = typer.Option(
+        DEFAULT_REQUESTS_PER_PHASE,
+        "--ramp-requests",
+        help="Requests per ramp step.",
+    ),
+    ramp_concurrency: str = typer.Option(
+        "1,2,5,10,20,30",
+        "--ramp-concurrency",
+        help="Comma-separated concurrency steps for the ramp.",
+    ),
+    ramp_min_429: int = typer.Option(
+        DEFAULT_RAMP_MIN_429_COUNT,
+        "--ramp-min-429",
+        help="Stop ramp when rate_limited count reaches this (use >1 to ignore sporadic 429s).",
+    ),
+    ramp_max_failure_rate: float = typer.Option(
+        DEFAULT_RAMP_MAX_FAILURE_RATE,
+        "--ramp-max-failure-rate",
+        help="Stop ramp when non-success fraction exceeds this.",
+    ),
+    soak_concurrency: int = typer.Option(
+        DEFAULT_SOAK_CONCURRENCY,
+        "--soak-concurrency",
+        help="Worker threads for soak (high values stress the client OS; start near 20).",
+    ),
+    soak_duration: float = typer.Option(
+        float(DEFAULT_SOAK_DURATION_SECONDS),
+        "--soak-duration",
+        help="Scheduled soak duration in seconds (wall time includes draining in-flight work).",
+    ),
+    retry_attempts: int = typer.Option(DEFAULT_RETRY_ATTEMPTS, "--retry-attempts"),
+    backoff_base: float = typer.Option(DEFAULT_BACKOFF_BASE, "--backoff-base"),
+    retry_429: bool = typer.Option(
+        False,
+        "--retry-429/--no-retry-429",
+        help="Retry on HTTP 429 (off by default; retries add load under throttle).",
+    ),
+    json_out: str | None = typer.Option(
+        None,
+        "--json-out",
+        help="Write a JSON report (config + per-phase summaries) to this path.",
+    ),
+) -> None:
+    mcp_url = resolve_mcp_url(url)
+    headers = build_request_headers()
+    cfg = LoadTestConfig(
+        mcp_url=mcp_url,
+        request_headers=headers,
+        request_timeout=DEFAULT_REQUEST_TIMEOUT,
+        retry_attempts=retry_attempts,
+        backoff_base=backoff_base,
+        retry_on_429=retry_429,
+    )
+    get_session = make_thread_local_session_factory(headers)
+
+    ramp_steps = [int(x.strip()) for x in ramp_concurrency.split(",") if x.strip()]
+
+    json_phases: list[dict[str, Any]] | None = [] if json_out else None
+
+    report: dict[str, Any] = {
+        "mcp_url": mcp_url,
+        "phase": phase,
+        "config": {
+            "retry_attempts": retry_attempts,
+            "backoff_base": backoff_base,
+            "retry_on_429": retry_429,
+            "ramp_requests": ramp_requests,
+            "ramp_concurrency_steps": ramp_steps,
+            "ramp_min_429": ramp_min_429,
+            "ramp_max_failure_rate": ramp_max_failure_rate,
+            "soak_concurrency": soak_concurrency,
+            "soak_duration_seconds": soak_duration,
+        },
+        "phases": json_phases if json_phases is not None else [],
+    }
+
+    print(f"MCP Server URL: {mcp_url}")
+
+    if phase in ("all", "warmup"):
+        warmup_results, warmup_duration = run_batch(
+            warmup_concurrency,
+            warmup_requests,
+            cfg,
+            get_session,
+            mix_cases=True,
+        )
+        wsum = summarize_results("Warmup", warmup_results, warmup_duration)
+        if json_phases is not None:
+            json_phases.append(wsum)
+
+    if phase in ("all", "ramp"):
+        ramp_test(
+            cfg,
+            get_session,
+            RampOptions(
+                requests_per_phase=ramp_requests,
+                ramp_concurrencies=ramp_steps,
+                min_429_count=ramp_min_429,
+                max_failure_rate=ramp_max_failure_rate,
+                json_phases=json_phases,
+            ),
+        )
+
+    if phase in ("all", "soak"):
+        soak_test(
+            cfg,
+            get_session,
+            concurrency=soak_concurrency,
+            duration_seconds=soak_duration,
+            json_phases=json_phases,
+        )
+
+    if json_out:
+        out_path = os.path.expanduser(json_out)
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+        print(f"\nWrote JSON report to {out_path}")
+
+
+if __name__ == "__main__":
+    app()

--- a/src/data360/config.py
+++ b/src/data360/config.py
@@ -30,6 +30,14 @@ class MCPServerSettings(BaseSettings):
         default=None,
         description="URL for external charts API to store Vega-Lite specs (e.g. https://.../api/v1/charts). When set, viz specs are POSTed here instead of saving to static.",
     )
+    env: str | None = Field(
+        default=None,
+        description="Deployment environment (e.g. local, dev, staging, prod). Azure App Insights logging is disabled when set to 'local'.",
+    )
+    azure_connection_string: str | None = Field(
+        default=None,
+        description="Azure Application Insights connection string. If unset, falls back to APPLICATIONINSIGHTS_CONNECTION_STRING env var.",
+    )
 
     model_config = SettingsConfigDict(env_prefix="MCP_")
 
@@ -105,12 +113,20 @@ def get_mcp_server_settings() -> MCPServerSettings:
     return MCPServerSettings()  # pyright: ignore[reportCallIssue]
 
 
-def setup_logging(log_file: str | None = None, log_level: str = "INFO") -> None:
-    """Configure logging to write to a file and/or console.
+def setup_logging(
+    log_file: str | None = None,
+    log_level: str = "INFO",
+    env: str | None = None,
+    azure_connection_string: str | None = None,
+) -> None:
+    """Configure logging to write to a file and/or console, and optionally Azure App Insights.
 
     Args:
         log_file: Path to log file. If None, logs only go to stderr.
         log_level: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+        env: Deployment environment. Azure handler is skipped when 'local'.
+        azure_connection_string: Azure App Insights connection string. Falls back to
+            APPLICATIONINSIGHTS_CONNECTION_STRING env var if not provided.
     """
     # Convert string level to logging constant
     numeric_level = getattr(logging, log_level.upper(), logging.INFO)
@@ -144,3 +160,28 @@ def setup_logging(log_file: str | None = None, log_level: str = "INFO") -> None:
         file_handler.setLevel(numeric_level)
         file_handler.setFormatter(formatter)
         root_logger.addHandler(file_handler)
+
+    # Azure App Insights handler (skipped for local environment or when no key is configured)
+    effective_connection_string = azure_connection_string or os.environ.get(
+        "APPLICATIONINSIGHTS_CONNECTION_STRING"
+    )
+    if env != "local" and effective_connection_string:
+        try:
+            from opencensus.ext.azure.log_exporter import (
+                AzureLogHandler,  # type: ignore[import-untyped]
+            )
+
+            def _callback(_):
+                return True
+
+            azure_handler = AzureLogHandler(
+                connection_string=effective_connection_string
+            )
+            azure_handler.setLevel(numeric_level)
+            azure_handler.add_telemetry_processor(_callback)
+            root_logger.addHandler(azure_handler)
+            root_logger.info("Azure App Insights logging enabled (env=%s).", env)
+        except ImportError:
+            root_logger.warning(
+                "opencensus-ext-azure not installed; skipping Azure App Insights handler."
+            )

--- a/src/data360/config.py
+++ b/src/data360/config.py
@@ -1,5 +1,6 @@
 import functools as ft
 import logging
+import os
 import sys
 from pathlib import Path
 

--- a/src/data360/mcp_server/__main__.py
+++ b/src/data360/mcp_server/__main__.py
@@ -17,7 +17,12 @@ def main(
 
     # Setup logging from configuration
     mcp_settings = get_mcp_server_settings()
-    setup_logging(log_file=mcp_settings.log_file, log_level=mcp_settings.log_level)
+    setup_logging(
+        log_file=mcp_settings.log_file,
+        log_level=mcp_settings.log_level,
+        env=mcp_settings.env,
+        azure_connection_string=mcp_settings.azure_connection_string,
+    )
 
     mcp.run(transport=transport, port=port)
 

--- a/src/data360/mcp_server/prompts.py
+++ b/src/data360/mcp_server/prompts.py
@@ -5,7 +5,6 @@ These prompts guide LLMs through common workflows.
 
 from ._server_definition import mcp
 
-
 # System prompt with chain-of-thought guidance for chatbot integration
 # Moved from resources.py and updated with visualization/20-year default logic
 SYSTEM_PROMPT = """## Data360 Assistant
@@ -17,44 +16,62 @@ If the user request requires indicator lookup, metadata, codes, or data values, 
 Do not answer with guesses. Do not stop after describing a plan.
 
 ### Operating loop (repeat until done)
-1) If you need an indicator -> call data360_search_indicators.
-   - **CRITICAL**: When search returns multiple results:
-     - **STOP** and analyze. Do NOT loop through all of them.
-     - Select the **SINGLE BEST** indicator based on relevance and coverage.
-     - Explicitly state: "Selected Indicator: [ID] - [Name]" and "Why: [Reason]".
-2) If you need country/dimension codes -> call data360_find_codelist_value
-   - Country: `codelist_type="REF_AREA"` (e.g. query="Kenya") -> "KEN"
-   - **Multi-Country**: START by passing the comma-separated list (e.g. "Kenya, Uganda"). The tool supports batch lookup.
-   - Unit Measure: `codelist_type="UNIT_MEASURE"` (e.g. query="Current US") -> "CD"
-   - Note: You must pass the resulting code (e.g. "USA") to get_data, not the name.
-3) If you need to confirm availability -> call data360_get_disaggregation
-4) If you need values -> call data360_get_data (default: last 20 years)
-   - **CRITICAL**: You MUST pass `disaggregation_filters={"REF_AREA": "..."}` if a country was requested.
-   - For multiple countries, use comma-separated string: `{"REF_AREA": "KEN,TZA"}`. Perform ONE `get_data` call.
-   - Do not call `get_data` blindly without filters unless you want world/global data.
-   - Note: The response includes the indicator name and definition, so you don't need to fetch metadata separately just for that.
-5) If the result is time-series or comparison:
-   - Call data360_get_supported_chart_types to see options and data requirements.
-   - DECIDE: Does the data match the requirements? (e.g. have 'time_period' and 'obs_value'?)
-   - IF YES: Call data360_get_viz_spec. 
-     - Explicitly pass `relevant_fields=["time_period", "obs_value", ...]` based on your decision.
-     - IF user asked for a specific type (e.g. "bar chart"), pass `chart_type="bar"`.
-     - IF user gave specific rules (e.g. "sort descending"), you can use `custom_constraints`.
-   - IF NO: Just present the data table.
+1) If you need an indicator → call data360_search_indicators.
+   - When results return multiple candidates, STOP, pick the SINGLE BEST, and state:
+     "Selected Indicator: [ID] — [Name]" and "Why: [reason]".
 
-Then provide the final answer to the user.
+2) If you need country/dimension codes → call data360_find_codelist_value.
+   - Country: codelist_type="REF_AREA" (e.g. query="Kenya") → "KEN"
+   - Multi-country: pass comma-separated list in one call.
+
+3) Confirm availability → call data360_get_disaggregation.
+   - CRITICAL: if UNIT_MEASURE has multiple values (e.g. KD/CD), pick ONE and filter for it.
+
+4) If you need raw data values → call data360_get_data (default: last 20 years).
+   - Always pass disaggregation_filters={"REF_AREA": "..."} when a country was requested.
+   - For multiple countries: {"REF_AREA": "KEN,TZA"} in ONE call.
+
+5) Visualization — choose the right tool:
+
+   ┌─ ONE indicator? ──────────────────────────────────────────────────────────┐
+   │  Call data360_get_viz_spec                                                │
+   │  • Multi-year, 1-8 countries  → chart_type="line"  (auto color by cntry) │
+   │  • Single year, ≤8 countries  → chart_type="bar"                         │
+   │  • Single year, >8 countries  → chart_type="strip"                       │
+   │  • Sex/age breakdown present  → chart_type="small_multiples"             │
+   └───────────────────────────────────────────────────────────────────────────┘
+
+   ┌─ TWO OR MORE indicators? ─────────────────────────────────────────────────┐
+   │  Call data360_get_multi_indicator_viz_spec                                │
+   │  • REQUIRED: indicator_ids — JSON array of 2–4 objects (never omit).      │
+   │    Each object MUST be {"database_id": "<db>", "indicator_id": "<id>"}.   │
+   │    Example:                                                               │
+   │    [{"database_id": "WB_WDI", "indicator_id": "WB_WDI_NY_GDP_PCAP_KD"},    │
+   │     {"database_id": "WB_WDI", "indicator_id": "WB_WDI_SP_DYN_LE00_IN"}]   │
+   │  • Optional: country_code, start_year, end_year, disaggregation_filters,  │
+   │    chart_type — same names as data360_get_viz_spec except there is NO     │
+   │    relevant_fields, custom_constraints, or use_default_constraints.       │
+   │                                                                           │
+   │  Chart type selection:                                                    │
+   │  • "Compare X vs Y across countries, one year"  → chart_type="scatter"  │
+   │  • "How X and Y moved together over time"        → chart_type="connected_scatter"│
+   │  • "Show X and Y trends for one country"         → chart_type="layered_lines"│
+   │  • Let the tool auto-select when unsure          → omit chart_type       │
+   └───────────────────────────────────────────────────────────────────────────┘
+
+   Call data360_get_supported_chart_types for the full list of options and requirements.
 
 ### Defaults
 - Time range: last 20 years unless user specifies otherwise.
   start_year = (current_year - 19), end_year = current_year
-- If user requests breakdown (e.g., by sex), use disaggregation_filters like {"SEX": null} to retrieve all groups.
+- Breakdowns (e.g. by sex): use disaggregation_filters={"SEX": null} to get all groups.
 
 ### Output behavior
-- When you decide a tool is needed, your next assistant message must be a tool call (no extra text).
-- After tools return results, continue with the next needed tool call.
+- When a tool is needed, your next message MUST be a tool call (no extra text).
+- After tools return, continue with the next needed tool call.
 - Only produce a normal user-facing response when no further tool calls are required.
+- When presenting a chart, always describe what the visualization shows in 1-2 sentences.
 """
-
 
 
 @mcp.prompt()
@@ -64,14 +81,14 @@ def indicator_search(
     required_dimensions: str = "",
 ) -> str:
     """Guide LLM to find and select the best indicator for a query.
-    
+
     Args:
         query: Search query (e.g., "unemployment rate", "poverty")
         country: Optional country to validate (e.g., "Kenya")
         required_dimensions: Optional comma-separated dimensions (e.g., "SEX,AGE")
     """
     dims_list = required_dimensions.split(",") if required_dimensions else []
-    
+
     return f"""To find the best indicator for '{query}':
 
 1. Use enriched search:
@@ -114,7 +131,7 @@ def indicator_details(
     question: str = "",
 ) -> str:
     """Guide LLM to get appropriate metadata based on user question.
-    
+
     Args:
         indicator_id: Indicator ID (e.g., "WB_GS_NY_GDP_PCAP_KD")
         database_id: Database ID (e.g., "WB_GS")
@@ -150,7 +167,7 @@ def country_data(
     end_year: str = "",
 ) -> str:
     """Guide LLM through end-to-end data retrieval for a country.
-    
+
     Args:
         query: Indicator search query
         country: Country name or comma-separated list (e.g., "Kenya" or "Kenya, Uganda")
@@ -197,7 +214,7 @@ data360_get_data(
 )
 
 **Step 5: Visualize**
-If data is suitable (time series), visualize directly. 
+If data is suitable (time series), visualize directly.
 For multi-country, the tool auto-handles color-coding.
 data360_get_viz_spec(
     database_id=<db_id>,

--- a/src/data360/mcp_server/prompts.py
+++ b/src/data360/mcp_server/prompts.py
@@ -1,12 +1,23 @@
 """Prompts for the Data360 MCP Server.
 
-These prompts guide LLMs through common workflows.
+Exposes:
+
+- ``SYSTEM_PROMPT``: default assistant instructions (search → codes →
+  disaggregation → data → visualization), including single-indicator
+  (``data360_get_viz_spec``) and multi-indicator
+  (``data360_get_multi_indicator_viz_spec``) paths.
+- ``@mcp.prompt()`` functions: reusable templates (indicator search, metadata,
+  country series) that clients can invoke by name.
+
+The system prompt intentionally keeps both **operational detail** (filters, batch
+codes, when to chart vs table) and the **ASCII tool-choice summary** so models
+do not drop ``relevant_fields`` / ``indicator_ids`` when calling viz tools.
 """
 
 from ._server_definition import mcp
 
-# System prompt with chain-of-thought guidance for chatbot integration
-# Moved from resources.py and updated with visualization/20-year default logic
+# Default MCP prompt resource: full loop + viz decision tree (was originally in
+# resources.py; extended for multi-indicator + 20-year defaults).
 SYSTEM_PROMPT = """## Data360 Assistant
 
 You are a tool-using assistant for World Bank Data360 indicators.
@@ -17,21 +28,30 @@ Do not answer with guesses. Do not stop after describing a plan.
 
 ### Operating loop (repeat until done)
 1) If you need an indicator → call data360_search_indicators.
-   - When results return multiple candidates, STOP, pick the SINGLE BEST, and state:
+   - **CRITICAL** when search returns multiple results: STOP — do not loop every row.
+   - Pick the **single best** indicator (relevance + coverage), then state:
      "Selected Indicator: [ID] — [Name]" and "Why: [reason]".
 
 2) If you need country/dimension codes → call data360_find_codelist_value.
    - Country: codelist_type="REF_AREA" (e.g. query="Kenya") → "KEN"
-   - Multi-country: pass comma-separated list in one call.
+   - Multi-country: pass a comma-separated query in **one** call (e.g. "Kenya, Uganda").
+   - Unit: codelist_type="UNIT_MEASURE" (e.g. "Current US$") when you must disambiguate units.
+   - Pass the **codes** (e.g. "KEN", "USA") into get_data filters, not display names.
 
 3) Confirm availability → call data360_get_disaggregation.
-   - CRITICAL: if UNIT_MEASURE has multiple values (e.g. KD/CD), pick ONE and filter for it.
+   - **CRITICAL**: if UNIT_MEASURE has multiple values (e.g. KD vs CD), pick **one** and filter.
 
 4) If you need raw data values → call data360_get_data (default: last 20 years).
-   - Always pass disaggregation_filters={"REF_AREA": "..."} when a country was requested.
-   - For multiple countries: {"REF_AREA": "KEN,TZA"} in ONE call.
+   - **CRITICAL**: pass disaggregation_filters={"REF_AREA": "..."} when the user asked for a geography.
+   - Multiple countries: {"REF_AREA": "KEN,TZA"} in **one** call — not one call per country.
+   - Do not call get_data with no REF_AREA filter unless you intentionally want global/world aggregates.
+   - The response already includes indicator name/definition in many cases; you may not need a separate metadata call only for the title.
 
 5) Visualization — choose the right tool:
+
+   - Call data360_get_supported_chart_types to see every option and required columns.
+   - **DECIDE**: Does the frame support a chart? (e.g. time_period + obs_value for lines.)
+   - If the shape does **not** support a chart, present the **table** — do not force a broken viz.
 
    ┌─ ONE indicator? ──────────────────────────────────────────────────────────┐
    │  Call data360_get_viz_spec                                                │
@@ -39,6 +59,10 @@ Do not answer with guesses. Do not stop after describing a plan.
    │  • Single year, ≤8 countries  → chart_type="bar"                         │
    │  • Single year, >8 countries  → chart_type="strip"                       │
    │  • Sex/age breakdown present  → chart_type="small_multiples"             │
+   │  • Pass relevant_fields=["time_period","obs_value",...] when you must    │
+   │    pin exact columns; the tool can auto-enrich dimensions when needed.   │
+   │  • If the user asked for a style ("bar chart"), pass chart_type="bar".   │
+   │  • Optional: custom_constraints for Draco when the user gave layout rules. │
    └───────────────────────────────────────────────────────────────────────────┘
 
    ┌─ TWO OR MORE indicators? ─────────────────────────────────────────────────┐
@@ -60,6 +84,8 @@ Do not answer with guesses. Do not stop after describing a plan.
    └───────────────────────────────────────────────────────────────────────────┘
 
    Call data360_get_supported_chart_types for the full list of options and requirements.
+
+Then provide the final answer to the user (after tools complete).
 
 ### Defaults
 - Time range: last 20 years unless user specifies otherwise.

--- a/src/data360/mcp_server/tools.py
+++ b/src/data360/mcp_server/tools.py
@@ -59,6 +59,12 @@ get_viz_spec = mcp.tool(
     description=data360_viz.get_viz_spec.__doc__,
 )
 
+get_multi_indicator_viz_spec = mcp.tool(
+    data360_viz.get_multi_indicator_viz_spec,
+    name="data360_get_multi_indicator_viz_spec",
+    description=data360_viz.get_multi_indicator_viz_spec.__doc__,
+)
+
 get_supported_chart_types = mcp.tool(
     data360_viz.get_supported_chart_types,
     name="data360_get_supported_chart_types",

--- a/src/data360/server.py
+++ b/src/data360/server.py
@@ -1,14 +1,86 @@
+import hashlib
+import json
+import logging
 import os
+import uuid
+from datetime import UTC, datetime
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.staticfiles import StaticFiles
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from data360.config import get_mcp_server_settings, setup_logging
 from data360.mcp_server import mcp
 
+_audit_logger = logging.getLogger("audit")
+
 # Setup logging from configuration
 mcp_settings = get_mcp_server_settings()
-setup_logging(log_file=mcp_settings.log_file, log_level=mcp_settings.log_level)
+setup_logging(
+    log_file=mcp_settings.log_file,
+    log_level=mcp_settings.log_level,
+    env=mcp_settings.env,
+    azure_connection_string=mcp_settings.azure_connection_string,
+)
+
+# Configure Azure Monitor OpenTelemetry for request/dependency tracking
+_connection_string = mcp_settings.azure_connection_string or os.environ.get(
+    "APPLICATIONINSIGHTS_CONNECTION_STRING"
+)
+if mcp_settings.env != "local" and _connection_string:
+    try:
+        from azure.monitor.opentelemetry import (
+            configure_azure_monitor,  # type: ignore[import-untyped]
+        )
+
+        configure_azure_monitor(connection_string=_connection_string)
+    except ImportError:
+        pass
+
+
+class AuditLogMiddleware(BaseHTTPMiddleware):
+    """Log structured audit entries for every MCP request."""
+
+    async def dispatch(self, request: Request, call_next):
+        # Only audit MCP tool/resource/prompt calls
+        if not request.url.path.startswith("/mcp"):
+            return await call_next(request)
+        session_id = str(uuid.uuid4())
+        requestor_id = request.headers.get(
+            "X-Forwarded-For", request.client.host if request.client else "unknown"
+        )
+        timestamp = datetime.now(UTC).isoformat()
+        # Read and restore body so downstream handlers still receive it
+        body_bytes = await request.body()
+        prompt = ""
+        prompt_hash = ""
+        try:
+            body = json.loads(body_bytes)
+            method = body.get("method", "")
+            params = body.get("params", {})
+            prompt = json.dumps(
+                {"method": method, "params": params}, separators=(",", ":")
+            )
+            prompt_hash = hashlib.sha256(prompt.encode()).hexdigest()[:16]
+        except Exception:
+            pass
+        response = await call_next(request)
+        _audit_logger.info(
+            "mcp_audit",
+            extra={
+                "custom_dimensions": {
+                    "session_id": session_id,
+                    "requestor_id": requestor_id,
+                    "timestamp": timestamp,
+                    "prompt": prompt,
+                    "prompt_hash": prompt_hash,
+                    "status_code": response.status_code,
+                    "path": request.url.path,
+                }
+            },
+        )
+        return response
+
 
 mcp.settings.stateless_http = True
 
@@ -24,6 +96,18 @@ app = FastAPI(
     redirect_slashes=False,
 )  # pyright: ignore[reportUnusedExpression]
 
+app.add_middleware(AuditLogMiddleware)
+
+# Instrument FastAPI for incoming request tracking
+if mcp_settings.env != "local" and _connection_string:
+    try:
+        from opentelemetry.instrumentation.fastapi import (
+            FastAPIInstrumentor,  # type: ignore[import-untyped]
+        )
+
+        FastAPIInstrumentor.instrument_app(app)
+    except ImportError:
+        pass
 
 # Mount static files FIRST (more specific path must come before catch-all)
 static_dir = os.path.join(os.getcwd(), "static")

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -1,11 +1,21 @@
 """
 Visualization generation for Data360 data.
 
-Two public entry points:
-  get_viz_spec()              – single indicator (original, unchanged interface)
-  get_multi_indicator_viz_spec() – multi-indicator comparison (new)
+Fetches series via the Data360 API (``data360.api.get_data_api_url``), builds
+Vega-Lite specifications, then persists them either through the optional Charts API
+(``charts_api_url``) or as static JSON under ``static/viz_specs/``.
 
-Both return {"url": str, "error": str|None, "warning": str|None}.
+**Public tools**
+
+- ``get_viz_spec`` — one indicator. Uses Draco where appropriate and
+  ``data360.viz_config`` strategy dispatch for patterns Draco does not handle well.
+- ``get_multi_indicator_viz_spec`` — two to four indicators; merges frames and
+  dispatches multi-series strategies (scatter, layered lines, connected scatter, etc.).
+
+Return shape for both: ``{"url": str|None, "error": str|None, ...}``. Before any HTTP
+or ``json.dump``, specs are passed through ``_vega_spec_to_json_safe`` so
+``data.values`` never contains raw ``pandas.Timestamp`` / numpy scalars that would
+break JSON encoding.
 """
 
 from __future__ import annotations
@@ -46,6 +56,13 @@ VizResult = dict[str, str | None]
 
 
 def save_specs_to_static(vl_spec: dict) -> str:
+    """Persist ``vl_spec`` as JSON and return a URL the **browser** can fetch.
+
+    The frontend (or another client) loads this file over HTTP; it is not read
+    only inside Docker. ``WEBSITE_HOSTNAME`` should be a host:port the user's browser
+    can resolve; when unset we default to ``localhost`` and the MCP server port from
+    ``data360.config.get_mcp_server_settings()``.
+    """
     spec_id = str(uuid.uuid4())
     specs_dir = os.path.join(os.getcwd(), "static", "viz_specs")
     os.makedirs(specs_dir, exist_ok=True)
@@ -59,11 +76,19 @@ def save_specs_to_static(vl_spec: dict) -> str:
 
 
 async def post_spec_to_charts_api(vl_spec: dict) -> str:
+    """POST a Vega-Lite spec to the external Charts API (JSON body).
+
+    The service expects standard Vega-Lite keys (``$schema``, ``data``, ``mark``,
+    ``encoding``, …). Many deployments require a non-empty ``title``; we set a default
+    if missing. On success, returns a chart URL from ``Location``, response JSON
+    ``url`` / ``id``, or the configured API base as a last resort.
+    """
     settings = get_mcp_server_settings()
     url = settings.charts_api_url
     if not url:
         raise ValueError("charts_api_url is not configured")
     payload = dict(vl_spec)
+    # Charts API often rejects payloads without title
     payload.setdefault("title", vl_spec.get("title") or "Generated Visualization")
     async with httpx.AsyncClient(timeout=30.0) as client:
         response = await client.post(
@@ -130,7 +155,11 @@ def _vega_spec_to_json_safe(obj: object) -> object:
 
 
 async def _store_spec(vl_spec: dict) -> str:
-    """Store spec: try charts API, fall back to static."""
+    """Persist a Vega-Lite dict: Charts API when configured, else static file.
+
+    Always runs ``_vega_spec_to_json_safe`` first so httpx ``json=`` and
+    ``json.dump`` cannot fail on non-JSON-native types in embedded data.
+    """
     safe = _vega_spec_to_json_safe(vl_spec)
     if not isinstance(safe, dict):
         raise TypeError("Vega spec must serialize to a JSON object")
@@ -524,7 +553,7 @@ async def get_viz_spec(
     except Exception as e:
         _logger.warning(f"Could not fetch metadata for title: {e}")
 
-    # 5. Clean data
+    # 5. Clean data — column selection, bar-vs-temporal time handling, renames (→ year/value/country)
     if "obs_value" in data.columns:
         data["obs_value"] = pd.to_numeric(data["obs_value"], errors="coerce")
 

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -1,54 +1,57 @@
 """
 Visualization generation for Data360 data.
 
-This module fetches data from a Data360 API URL and generates
-Vega-Lite visualization specifications optimized for the data structure.
+Two public entry points:
+  get_viz_spec()              – single indicator (original, unchanged interface)
+  get_multi_indicator_viz_spec() – multi-indicator comparison (new)
+
+Both return {"url": str, "error": str|None, "warning": str|None}.
 """
 
+from __future__ import annotations
+
+import asyncio
 import json
 import logging
+import math
 import os
+import re
 import uuid
+from datetime import date, datetime
 from urllib.parse import parse_qs, urlparse
 
 import altair as alt
 import httpx
+import numpy as np
 import pandas as pd
 from draco import Draco, answer_set_to_dict, dict_to_facts, schema_from_dataframe
 from draco.renderer import AltairRenderer
 
-from data360.config import get_mcp_server_settings
 from data360 import viz_config
+from data360.config import get_mcp_server_settings
 
 _logger = logging.getLogger(__name__)
 
 _FALLBACK_WARNING = (
     "Draco could not determine an optimal encoding; "
-    "a default line chart was generated as fallback."
+    "a default chart was generated as fallback."
 )
+
+VizResult = dict[str, str | None]
+
+
+# ============================================================================
+# STORAGE HELPERS
+# ============================================================================
 
 
 def save_specs_to_static(vl_spec: dict) -> str:
-    """Save Vega-Lite spec to static/viz_specs/ directory.
-
-    Returns:
-        URL for the saved spec
-    """
     spec_id = str(uuid.uuid4())
     specs_dir = os.path.join(os.getcwd(), "static", "viz_specs")
     os.makedirs(specs_dir, exist_ok=True)
-
-    # Save Vega-Lite spec
     vega_path = os.path.join(specs_dir, f"{spec_id}_vega.json")
     with open(vega_path, "w") as f:
         json.dump(vl_spec, f, indent=2)
-
-    # Return URL (assuming server runs on port 8021)
-    # Use host.docker.internal for Docker compatibility, or localhost if running natively
-    # For now, we default to localhost because the Frontend (browser) needs to access this,
-    # and host.docker.internal typically doesn't resolve in the browser on Mac/Windows without /etc/hosts hacks.
-    # HOWEVER, since the user explicitly asked for Docker support, we will stick to localhost
-    # because the browser (client-side) is what fetches this JSON, not the Docker container.
     base_url = os.environ.get(
         "WEBSITE_HOSTNAME", f"http://localhost:{get_mcp_server_settings().port}"
     )
@@ -56,24 +59,12 @@ def save_specs_to_static(vl_spec: dict) -> str:
 
 
 async def post_spec_to_charts_api(vl_spec: dict) -> str:
-    """POST Vega-Lite spec to the external charts API.
-
-    Expects the API to accept JSON with Vega-Lite fields (title, $schema, data,
-    mark, encoding). Returns the chart URL from the response if present, otherwise
-    a fallback URL built from the API base and response id.
-
-    Returns:
-        URL of the stored chart, or an error message on failure.
-    """
     settings = get_mcp_server_settings()
     url = settings.charts_api_url
     if not url:
         raise ValueError("charts_api_url is not configured")
-
-    # Charts API requires a title in the payload
     payload = dict(vl_spec)
     payload.setdefault("title", vl_spec.get("title") or "Generated Visualization")
-
     async with httpx.AsyncClient(timeout=30.0) as client:
         response = await client.post(
             url,
@@ -81,8 +72,6 @@ async def post_spec_to_charts_api(vl_spec: dict) -> str:
             headers={"accept": "application/json", "Content-Type": "application/json"},
         )
         response.raise_for_status()
-
-    # Prefer Location header (e.g. 201 Created)
     location = response.headers.get("Location")
     if location:
         return (
@@ -90,94 +79,336 @@ async def post_spec_to_charts_api(vl_spec: dict) -> str:
             if location.startswith("http")
             else f"{url.rsplit('/', 1)[0]}/{location.lstrip('/')}"
         )
-
     body = response.json() if response.content else {}
     if isinstance(body, dict):
         if body.get("url"):
             return body["url"]
         if body.get("id"):
-            # GET endpoint: /api/v1/charts/{chart_id}
             return f"{url.rstrip('/')}/{body['id']}"
     return url
 
 
-# Chart type parsing is now handled by viz_config module
-# (see viz_config.parse_chart_type_hint)
+def _vega_spec_to_json_safe(obj: object) -> object:
+    """Recursively convert a Vega-Lite spec tree to JSON-serializable Python types.
 
+    Covers pandas/numpy scalars and datetimes that can appear in ``data.values`` or
+    elsewhere after ``DataFrame.to_dict`` (including merged dtypes and edge cases the
+    DataFrame-only sanitizer misses).
+    """
+    if obj is None:
+        return None
+    if isinstance(obj, (bool, str)):
+        return obj
+    if isinstance(obj, (int, float)) and not isinstance(obj, bool):
+        if isinstance(obj, float) and (math.isnan(obj) or math.isinf(obj)):
+            return None
+        return obj
+    if isinstance(obj, pd.Timestamp):
+        return obj.isoformat() if pd.notna(obj) else None
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    if isinstance(obj, np.datetime64):
+        return str(pd.Timestamp(obj))
+    if isinstance(obj, (np.integer, np.floating)):
+        if pd.isna(obj):
+            return None
+        return obj.item()
+    if isinstance(obj, np.bool_):
+        return bool(obj)
+    if isinstance(obj, dict):
+        return {k: _vega_spec_to_json_safe(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_vega_spec_to_json_safe(v) for v in obj]
+    if hasattr(obj, "item"):
+        try:
+            return _vega_spec_to_json_safe(obj.item())
+        except (ValueError, AttributeError, TypeError):
+            pass
+    raise TypeError(
+        f"Vega-Lite spec contains unsupported type for JSON: {type(obj).__name__}"
+    )
+
+
+async def _store_spec(vl_spec: dict) -> str:
+    """Store spec: try charts API, fall back to static."""
+    safe = _vega_spec_to_json_safe(vl_spec)
+    if not isinstance(safe, dict):
+        raise TypeError("Vega spec must serialize to a JSON object")
+    charts_url = get_mcp_server_settings().charts_api_url
+    if charts_url:
+        try:
+            return await post_spec_to_charts_api(safe)
+        except Exception as e:
+            _logger.warning(f"Charts API store failed, falling back to static: {e}")
+    return save_specs_to_static(safe)
+
+
+def _ok(url: str, warning: str | None = None) -> VizResult:
+    r: VizResult = {"url": url, "error": None}
+    if warning:
+        r["warning"] = warning
+    return r
+
+
+def _err(msg: str) -> VizResult:
+    return {"url": None, "error": msg}
+
+
+def _scalar_for_json(value: object) -> object:
+    """Coerce pandas/numpy scalars so stdlib json can encode them."""
+    if isinstance(value, pd.Timestamp):
+        return value.isoformat() if pd.notna(value) else None
+    return value
+
+
+def _sanitize_dataframe_for_json_records(df: pd.DataFrame) -> pd.DataFrame:
+    """Ensure ``DataFrame.to_dict(orient='records')`` is JSON-serializable (no Timestamp)."""
+    out = df.copy()
+    for col in out.columns:
+        if pd.api.types.is_datetime64_any_dtype(out[col]):
+            out[col] = out[col].map(
+                lambda x: x.isoformat() if pd.notna(x) else None
+            )
+        elif out[col].dtype == object:
+            out[col] = out[col].map(_scalar_for_json)
+    return out
+
+
+# ============================================================================
+# DATA FETCHING
+# ============================================================================
 
 
 async def _fetch_data_internal(url: str) -> pd.DataFrame:
-    """Fetch data from a Data360 API URL and return as DataFrame.
-
-    Args:
-        url: Data360 API URL
-
-    Returns:
-        pandas DataFrame with the data
-
-    Raises:
-        ValueError: If no data found or fetch fails
-    """
     async with httpx.AsyncClient(timeout=30.0) as client:
         response = await client.get(url)
         response.raise_for_status()
         data = response.json()
-
     raw_data = data.get("value", [])
     if not raw_data:
         raise ValueError("No data found at the provided URL.")
+    return pd.DataFrame(raw_data)
 
-    df = pd.DataFrame(raw_data)
-    return df
+
+async def _fetch_single_indicator(
+    database_id: str,
+    indicator_id: str,
+    country_code: str | None,
+    start_year: int | None,
+    end_year: int | None,
+    disaggregation_filters: dict | None,
+) -> tuple[pd.DataFrame, str | None, str | None]:
+    """Fetch one indicator and return (DataFrame, title, unit_label).
+
+    Returns (empty_df, None, None) on error — caller checks df.empty.
+    """
+    from data360.api import get_data_api_url, get_metadata
+
+    try:
+        data_url = await get_data_api_url(
+            database_id=database_id,
+            indicator_id=indicator_id,
+            country_code=country_code,
+            start_year=start_year,
+            end_year=end_year,
+            disaggregation_filters=disaggregation_filters,
+        )
+        df = await _fetch_data_internal(data_url)
+        df.columns = [c.lower() for c in df.columns]
+    except Exception as e:
+        _logger.error(f"Failed to fetch {indicator_id}: {e}")
+        return pd.DataFrame(), None, None
+
+    # Fetch title + unit from metadata
+    title, unit = None, None
+    try:
+        parsed = urlparse(data_url)
+        params = parse_qs(parsed.query)
+        db_id = params.get("DATABASE_ID", [database_id])[0]
+        ind_id = (
+            params.get("indicatorId", [None])[0]
+            or params.get("INDICATOR", [None])[0]
+            or indicator_id
+        )
+        meta = await get_metadata(db_id, ind_id)
+        if meta and meta.indicator_metadata:
+            title = meta.indicator_metadata.get("name")
+            unit = meta.indicator_metadata.get(
+                "measurement_unit"
+            ) or meta.indicator_metadata.get("unit_measure")
+    except Exception as e:
+        _logger.warning(f"Could not fetch metadata for {indicator_id}: {e}")
+
+    return df, title, unit
+
+
+# ============================================================================
+# DATA CLEANING HELPERS
+# ============================================================================
+
+
+def _clean_single_df(
+    data: pd.DataFrame,
+    relevant_fields: list[str] | None,
+    chart_type: str | None,
+    data_frequency: str | None,
+) -> tuple[pd.DataFrame, list[str]]:
+    """Clean + rename a single-indicator DataFrame for the Draco path."""
+    if relevant_fields:
+        req = [f.lower() for f in relevant_fields]
+        missing = [f for f in req if f not in data.columns]
+        if missing:
+            raise ValueError(
+                f"Requested fields not found: {missing}. Available: {list(data.columns)}"
+            )
+        valid_cols = req
+        for dim in ["ref_area", "sex", "age", "urbanisation"]:
+            if dim in data.columns and dim not in valid_cols:
+                uv = data[dim].unique()
+                if len(uv) > 1 or (len(uv) == 1 and uv[0] != "_T"):
+                    valid_cols.append(dim)
+        viz_data = data[valid_cols].copy()
+        relevant_cols = valid_cols
+    else:
+        relevant_cols = []
+        for col in ["time_period", "obs_value", "ref_area"]:
+            if col in data.columns:
+                relevant_cols.append(col)
+        for dim in ["sex", "age", "urbanisation"]:
+            if dim in data.columns:
+                uv = data[dim].unique()
+                if len(uv) > 1 or (len(uv) == 1 and uv[0] != "_T"):
+                    relevant_cols.append(dim)
+        viz_data = data[relevant_cols].copy() if relevant_cols else data.copy()
+
+    # Temporal preparation
+    if "time_period" in viz_data.columns:
+        try:
+            user_mark = viz_config.parse_chart_type_hint(chart_type)
+            action = viz_config.get_data_preparation_action(user_mark, data_frequency)
+            if action == "year_strings":
+                viz_data["time_period"] = pd.to_datetime(
+                    viz_data["time_period"]
+                ).dt.year.astype(str)
+            else:
+                viz_data["time_period"] = pd.to_datetime(viz_data["time_period"])
+        except Exception as e:
+            _logger.warning(f"time_period conversion failed: {e}")
+
+    if "obs_value" in viz_data.columns:
+        viz_data["obs_value"] = pd.to_numeric(viz_data["obs_value"], errors="coerce")
+
+    # Rename to friendly names
+    viz_data = viz_data.rename(
+        columns={"time_period": "year", "obs_value": "value", "ref_area": "country"}
+    )
+    relevant_cols = [
+        {"time_period": "year", "obs_value": "value", "ref_area": "country"}.get(c, c)
+        for c in relevant_cols
+    ]
+    return viz_data, relevant_cols
+
+
+async def _map_country_codes(viz_data: pd.DataFrame) -> pd.DataFrame:
+    """Map REF_AREA / country codes to human-readable names."""
+    col = "country" if "country" in viz_data.columns else None
+    if col is None:
+        return viz_data
+    try:
+        from data360.providers import get_codelist_mapping
+
+        country_map = await get_codelist_mapping("REF_AREA")
+        viz_data[col] = viz_data[col].map(lambda x: country_map.get(x, x))
+    except Exception as e:
+        _logger.warning(f"Could not map country codes: {e}")
+    return viz_data
+
+
+def _slugify(name: str) -> str:
+    """Convert indicator name to a safe column name."""
+    s = name.lower().strip()
+    s = re.sub(r"[^a-z0-9]+", "_", s)
+    return s[:40].strip("_") or "indicator"
+
+
+def _make_unique_col(base: str, existing: set[str]) -> str:
+    col, n = base, 1
+    while col in existing:
+        col = f"{base}_{n}"
+        n += 1
+    return col
+
+
+# ============================================================================
+# TOOL: get_supported_chart_types
+# ============================================================================
 
 
 def get_supported_chart_types() -> str:
     """Return supported chart types and their data requirements as JSON.
 
-    Call before data360_get_viz_spec to choose an appropriate chart_type and to verify the
-    indicator has the right fields (e.g. time_period and obs_value for line charts).
-    No other tools are required before this one.
+    Call before data360_get_viz_spec or data360_get_multi_indicator_viz_spec
+    to choose the right chart_type for the data and user intent.
 
     Returns:
-        JSON string with key "chart_types": list of dicts, each with id (e.g. "line", "bar"),
-        description, when_to_use, and data_requirements; and "guidance" for selecting relevant_fields.
+        JSON string with chart_types list and strategy guidance.
     """
     chart_types = {
         "chart_types": [
             {
                 "id": "line",
-                "description": "Line chart for showing trends over time.",
-                "when_to_use": "Use when you have a continuous time variable and a quantitative measure.",
-                "data_requirements": "Requires 'time_period' (or similar date field) and 'obs_value' (metric).",
+                "description": "Line chart for temporal trends.",
+                "when_to_use": "Single indicator, 1+ countries, multiple years.",
+                "data_requirements": "time_period + obs_value. Color-codes countries automatically.",
             },
             {
                 "id": "bar",
-                "description": "Bar chart for comparing values across categories.",
-                "when_to_use": "Use for comparing metrics between discrete categories or time periods.",
-                "data_requirements": "Requires one categorical/ordinal field and 'obs_value'.",
+                "description": "Horizontal bar chart for ranking/comparison.",
+                "when_to_use": "Single indicator, multiple countries, typically one year.",
+                "data_requirements": "obs_value + country dimension.",
             },
             {
-                "id": "point",
-                "description": "Scatter plot (point chart) for correlation.",
-                "when_to_use": "Use to show the relationship between two quantitative variables.",
-                "data_requirements": "Requires two quantitative fields.",
+                "id": "scatter",
+                "description": "Scatterplot for correlation between two indicators.",
+                "when_to_use": "Exactly 2 indicator_ids, multiple countries, single year.",
+                "data_requirements": "Requires indicator_ids list with 2 entries in get_multi_indicator_viz_spec.",
             },
             {
-                "id": "area",
-                "description": "Area chart for cumulative trends.",
-                "when_to_use": "Use to show volume or quantity over time.",
-                "data_requirements": "Similar to line chart: 'time_period' and 'obs_value'.",
+                "id": "connected_scatter",
+                "description": "Connected scatterplot: 2 indicators over time.",
+                "when_to_use": "Exactly 2 indicator_ids, multiple countries, multiple years.",
+                "data_requirements": "Same as scatter but multi-year.",
             },
             {
-                "id": "tick",
-                "description": "Tick plot for distribution.",
-                "when_to_use": "Use to show the distribution of values along an axis.",
-                "data_requirements": "Requires one quantitative field.",
+                "id": "layered_lines",
+                "description": "Dual/multi-axis line chart for 2-3 indicators in one country.",
+                "when_to_use": "2-3 indicator_ids, typically 1 country, multi-year.",
+                "data_requirements": "Requires indicator_ids list in get_multi_indicator_viz_spec.",
+            },
+            {
+                "id": "small_multiples",
+                "description": "Faceted panel chart for breakdown × country comparisons.",
+                "when_to_use": "1 indicator, multiple breakdowns (sex/age) or many countries.",
+                "data_requirements": "Disaggregation dimensions with multiple values.",
+            },
+            {
+                "id": "strip",
+                "description": "Strip/beeswarm chart for cross-country distribution.",
+                "when_to_use": ">8 countries, single year.",
+                "data_requirements": "obs_value + many country values.",
             },
         ],
-        "guidance": "Select the 'relevant_fields' from the available data that match the 'data_requirements' of the desired chart type.",
+        "multi_indicator_note": (
+            "For scatter, connected_scatter, and layered_lines, use "
+            "data360_get_multi_indicator_viz_spec with an indicator_ids list."
+        ),
     }
     return json.dumps(chart_types, indent=2)
+
+
+# ============================================================================
+# TOOL: get_viz_spec (single indicator — original interface preserved)
+# ============================================================================
 
 
 async def get_viz_spec(
@@ -191,13 +422,11 @@ async def get_viz_spec(
     relevant_fields: list[str] | None = None,
     custom_constraints: list[str] | None = None,
     use_default_constraints: bool = True,
-) -> dict[str, str | None]:
-    """Generate a Vega-Lite chart from a Data360 indicator and return a URL to the chart.
+) -> VizResult:
+    """Generate a Vega-Lite chart from a single Data360 indicator.
 
-    Use when the user wants a visualization (line, bar, area, etc.). You need database_id and
-    indicator_id from data360_search_indicators. Optionally call data360_get_supported_chart_types
-    for chart type guidance and data360_get_disaggregation to ensure filter values are valid.
-    The tool builds the data URL, fetches data, cleans it, runs Draco for encoding, and stores the spec.
+    Use when the user wants a visualization for ONE indicator. For comparing multiple
+    indicators (scatter, dual-axis), use data360_get_multi_indicator_viz_spec instead.
 
     Args:
         database_id: Database identifier (e.g., WB_HNP, WB_WDI).
@@ -206,458 +435,462 @@ async def get_viz_spec(
         start_year: Optional start year (inclusive).
         end_year: Optional end year (inclusive).
         disaggregation_filters: Optional dict of dimension filters (e.g. {"SEX": "F"}).
-        chart_type: Optional hint (e.g. "line chart", "bar chart").
-        relevant_fields: Optional list of column names to use in the chart; infer from data structure.
+        chart_type: Optional hint — "line", "bar", "scatter", "strip", "small_multiples".
+        relevant_fields: Optional list of column names to include in the chart.
         custom_constraints: Optional list of raw Draco ASP constraints.
         use_default_constraints: If True (default), apply standard encoding heuristics.
 
     Returns:
-        Dict with "url", "error", and optionally "warning".
-        On success: url is the chart URL (string), error is None.
-        On failure: url is None, error is an error message string.
-        If Draco failed and a fallback chart was generated, "warning" contains a message.
+        Dict with "url" (chart URL on success), "error" (message on failure),
+        and optionally "warning" (if fallback was used).
     """
+    from data360.api import get_data_api_url, get_metadata
 
-    def ok(u: str) -> dict[str, str | None]:
-        return {"url": u, "error": None}
+    # 1. Build URL
+    try:
+        data_url = await get_data_api_url(
+            database_id=database_id,
+            indicator_id=indicator_id,
+            country_code=country_code,
+            start_year=start_year,
+            end_year=end_year,
+            disaggregation_filters=disaggregation_filters,
+        )
+    except ValueError as e:
+        return _err(f"Error: {e}")
 
-    def err(msg: str) -> dict[str, str | None]:
-        return {"url": None, "error": msg}
-
-    # 0. Generate URL internally
-    # Import locally to avoid circular top-level imports if any
-    from data360.api import get_data_api_url
-
-    data_url = await get_data_api_url(
-        database_id=database_id,
-        indicator_id=indicator_id,
-        country_code=country_code,
-        start_year=start_year,
-        end_year=end_year,
-        disaggregation_filters=disaggregation_filters,
-    )
-
-    # 1. Fetch data
+    # 2. Fetch data
     try:
         data = await _fetch_data_internal(data_url)
     except ValueError as e:
-        return err(f"Error: {e}")
+        return _err(f"Error: {e}")
     except httpx.HTTPStatusError as e:
-        return err(f"Error fetching data: {e.response.status_code}")
+        return _err(f"Error fetching data: {e.response.status_code}")
     except Exception as e:
         _logger.exception("Failed to fetch data")
-        return err(f"Error fetching data: {e}")
+        return _err(f"Error fetching data: {e}")
 
-    # 2. Clean data - standardize column names to lowercase
     data.columns = [c.lower() for c in data.columns]
 
-    # --- Detect frequency early for chart-aware data preparation ---
-    data_frequency = None  # Will store: 'A' (Annual), 'M' (Monthly), 'Q' (Quarterly)
+    # 3. Detect frequency
+    data_frequency = None
     try:
-        # Extract params from URL to get metadata
         parsed = urlparse(data_url)
         params = parse_qs(parsed.query)
-        db_id = params.get("DATABASE_ID", [None])[0]
+        db_id = params.get("DATABASE_ID", [database_id])[0]
         ind_id_param = (
             params.get("indicatorId", [None])[0]
             or params.get("INDICATOR", [None])[0]
-            or params.get("indicator", [None])[0]
+            or indicator_id
         )
-
         if db_id and ind_id_param:
-            from data360.api import get_metadata
-
             meta = await get_metadata(db_id, ind_id_param)
-
-            # Extract frequency from disaggregation options (preferred) or metadata
             if meta:
-                # First, try to get frequency from disaggregation options (most reliable)
                 if meta.disaggregation_options:
-                    for disagg in meta.disaggregation_options:
-                        if disagg.get("field_name") == "FREQ":
-                            freq_values = disagg.get("field_value", [])
-                            if freq_values:
-                                # Use the first frequency code (A, M, Q, etc.)
-                                data_frequency = freq_values[0]
-                                _logger.info(f"Detected frequency from FREQ dimension: {data_frequency}")
-                                break
-
-                # Fallback: infer from periodicity field
-                # Fallback: infer from periodicity field using config
+                    for d in meta.disaggregation_options:
+                        if d.get("field_name") == "FREQ" and d.get("field_value"):
+                            data_frequency = d["field_value"][0]
+                            break
                 if not data_frequency and meta.indicator_metadata:
-                    periodicity = meta.indicator_metadata.get("periodicity", "")
-                    data_frequency = viz_config.infer_frequency_from_periodicity(periodicity)
-
-                    if data_frequency:
-                        _logger.info(f"Inferred frequency from periodicity field: {data_frequency} (periodicity: {periodicity})")
+                    data_frequency = viz_config.infer_frequency_from_periodicity(
+                        meta.indicator_metadata.get("periodicity", "")
+                    )
     except Exception as e:
         _logger.warning(f"Could not detect frequency: {e}")
 
-    # --- Chart-aware temporal data preparation ---
-    # Prepare data based on chart type and frequency BEFORE Draco inference
-    # This allows Draco to correctly infer schema and choose optimal encoding
-    if "time_period" in data.columns:
-        try:
-            # Parse chart type hint to determine if it's a bar chart
-            user_mark_type = viz_config.parse_chart_type_hint(chart_type)
-            is_bar_chart = user_mark_type == "bar"
-
-            # Decision logic:
-            # - Bar charts with annual data: use year strings for discrete display
-            # - All other cases: use datetime for temporal encoding
-            if is_bar_chart and data_frequency == "A":
-                # Convert to year strings for discrete categorical display
-                # "2023", "2024" -> Draco will infer ordinal -> discrete bars
-                data["time_period"] = pd.to_datetime(data["time_period"]).dt.year.astype(str)
-                _logger.info("Prepared annual bar chart data as year strings for discrete display")
-            else:
-                # Convert to datetime for temporal encoding
-                # "2012-01-01T00:00:00" -> Draco will infer temporal -> continuous axis
-                data["time_period"] = pd.to_datetime(data["time_period"])
-                _logger.info("Prepared temporal data as datetime for continuous time axis")
-        except (ValueError, TypeError) as e:
-            _logger.warning(f"Error converting time_period: {e}")
-            pass
-
-    if "obs_value" in data.columns:
-        # TODO: to confirm with viz team on how to populate null values from api
-        data["obs_value"] = pd.to_numeric(data["obs_value"], errors="coerce").fillna(0)
-
-    # --- Fetch Indicator Name for Title ---
+    # 4. Fetch title and unit
     chart_title = "Generated Visualization"
+    unit_label = "Value"
     try:
-        # Extract params from URL (reuse parsed values if available)
-        if not db_id or not ind_id_param:
-            parsed = urlparse(data_url)
-            params = parse_qs(parsed.query)
-            db_id = params.get("DATABASE_ID", [None])[0]
-            ind_id_param = (
-                params.get("indicatorId", [None])[0]
-                or params.get("INDICATOR", [None])[0]
-                or params.get("indicator", [None])[0]
-            )
-
+        parsed = urlparse(data_url)
+        params = parse_qs(parsed.query)
+        db_id = params.get("DATABASE_ID", [database_id])[0]
+        ind_id_param = (
+            params.get("indicatorId", [None])[0]
+            or params.get("INDICATOR", [None])[0]
+            or indicator_id
+        )
         if db_id and ind_id_param:
-            from data360.api import get_metadata
-
             meta = await get_metadata(db_id, ind_id_param)
-            # Fix: Access name from indicator_metadata dict if present
-            if meta and meta.indicator_metadata and "name" in meta.indicator_metadata:
-                chart_title = meta.indicator_metadata["name"]
+            if meta and meta.indicator_metadata:
+                chart_title = meta.indicator_metadata.get("name", chart_title)
+                raw_unit = (
+                    meta.indicator_metadata.get("measurement_unit")
+                    or meta.indicator_metadata.get("unit_measure")
+                    or ""
+                )
+                if raw_unit:
+                    unit_label = f"{chart_title} ({raw_unit})"
     except Exception as e:
         _logger.warning(f"Could not fetch metadata for title: {e}")
 
+    # 5. Clean data
+    if "obs_value" in data.columns:
+        data["obs_value"] = pd.to_numeric(data["obs_value"], errors="coerce")
 
-    # 3. Use Draco2 to find optimal visualization
-    d = Draco()
-
-    # Determine relevant columns
-    if relevant_fields:
-        # User/LLM explicitly asked for specific fields
-        # Filter to only those that exist in the dataframe
-        # Lowercase check
-        req_fields = [f.lower() for f in relevant_fields]
-        existing_cols = set(data.columns)
-        missing_fields = [f for f in req_fields if f not in existing_cols]
-
-        if missing_fields:
-            return err(
-                f"Error: The following requested fields were not found in the data: {missing_fields}. Available columns: {list(data.columns)}"
-            )
-
-        valid_cols = req_fields
-
-        # Smart enrichment: If ref_area (country) is in the data but not requested,
-        # check if it's needed to distinguish data points (multi-country) and keep it.
-        # Also check other breakdown dimensions.
-        potential_enrichments = ["ref_area", "sex", "age", "urbanisation"]
-        for dim in potential_enrichments:
-            if dim in data.columns and dim not in valid_cols:
-                # Check if this dimension has multiple values (or is not just "_T")
-                unique_vals = data[dim].unique()
-                if len(unique_vals) > 1 or (
-                    len(unique_vals) == 1 and unique_vals[0] != "_T"
-                ):
-                    valid_cols.append(dim)
-                    _logger.info(f"Auto-enriched relevant_fields with {dim}")
-
-        viz_data = data[valid_cols].copy()
-        # Ensure relevant_cols is defined for downstream logic
-        relevant_cols = valid_cols
-    else:
-        # Auto-selection logic
-        relevant_cols = []
-        if "time_period" in data.columns:
-            relevant_cols.append("time_period")
-        if "obs_value" in data.columns:
-            relevant_cols.append("obs_value")
-        if "ref_area" in data.columns:
-            relevant_cols.append("ref_area")
-
-        # Breakdowns
-        breakdown_dims = ["sex", "age", "urbanisation"]
-        for dim in breakdown_dims:
-            if dim in data.columns:
-                unique_vals = data[dim].unique()
-                if len(unique_vals) > 1 or (
-                    len(unique_vals) == 1 and unique_vals[0] != "_T"
-                ):
-                    relevant_cols.append(dim)
-
-        if relevant_cols:
-            viz_data = data[relevant_cols].copy()
-        else:
-            viz_data = data.copy()
-
-    # Create map for renaming (User friendly labels, but lowercase for Draco/ASP safety)
-    # Vega-Lite will auto-capitalize these for Axis titles (e.g. "year" -> "Year")
-    column_renames = {
-        "time_period": "year",
-        "obs_value": "value",
-        "ref_area": "country",
-    }
-
-    # Task #9: Map REF_AREA codes to Names if present
-    if "ref_area" in viz_data.columns:
-        try:
-            from data360.providers import get_codelist_mapping
-
-            country_map = await get_codelist_mapping("REF_AREA")
-            # Map codes to names, keep original if not found
-            viz_data["ref_area"] = viz_data["ref_area"].map(
-                lambda x: country_map.get(x, x)
-            )
-        except Exception as e:
-            _logger.warning(f"Could not map country codes: {e}")
-
-    # Rename columns in dataframe
-    viz_data = viz_data.rename(columns=column_renames)
-
-    # Update relevant_cols logic to match new names for Draco check
-    # Note: Draco/Altair is case sensitive.
+    try:
+        viz_data, relevant_cols = _clean_single_df(
+            data, relevant_fields, chart_type, data_frequency
+        )
+    except ValueError as e:
+        return _err(str(e))
 
     if viz_data.empty:
-        return err("Error: No data available for visualization after cleaning.")
+        return _err("Error: No data available for visualization after cleaning.")
 
+    # 6. Map country codes
+    viz_data = await _map_country_codes(viz_data)
+
+    # 7. Determine strategy — route around Draco for complex patterns
+    n_indicators = 1
+    strategy_result = viz_config.select_strategy(
+        viz_data,
+        n_indicators=n_indicators,
+        chart_type_hint=chart_type,
+    )
+
+    _logger.info(
+        f"Chart strategy: {strategy_result.strategy.value} — {strategy_result.reason}"
+    )
+
+    # Strategy-based direct spec (bypasses Draco for non-Draco-friendly patterns)
+    bypass_strategies = {
+        viz_config.ChartStrategy.DISTRIBUTION,
+        viz_config.ChartStrategy.CROSS_SECTIONAL,
+        viz_config.ChartStrategy.BREAKDOWN_COMPARISON,
+        viz_config.ChartStrategy.SMALL_MULTIPLES,
+    }
+
+    if strategy_result.strategy in bypass_strategies:
+        spec = viz_config.dispatch_spec(
+            strategy_result.strategy,
+            viz_data,
+            chart_title,
+            strategy_result,
+            y_label=unit_label,
+            x_label=unit_label,
+        )
+        return _ok(await _store_spec(spec))
+
+    # 8. Draco path (temporal_single, fallback)
     try:
         schema = schema_from_dataframe(viz_data)
         facts = dict_to_facts(schema)
     except Exception as e:
-        _logger.exception(f"Error generating data schema: {e}")
-        return err(f"Error generating data schema: {e}")
+        _logger.exception("Error generating schema")
+        return _err(f"Error generating data schema: {e}")
 
-    # Base constraints
+    d = Draco()
     program_constraints = ["entity(view,root,view).", "entity(mark,view,m)."]
 
     if use_default_constraints:
-        # --- EXPLICITLY DEFINE X/Y ROLES FOR DATA360 (UPDATED NAMES) ---
-        # Detect chart type early to determine encoding types
         user_mark_type = viz_config.parse_chart_type_hint(chart_type)
-
-        # Smart x-axis selection: Use temporal (year) or categorical dimension?
-        # This enables cross-sectional comparisons while maintaining time-series support
         use_temporal_x, categorical_x_field = viz_config.should_use_temporal_x_axis(
             viz_data, chart_type, viz_data.columns.tolist()
         )
 
         if use_temporal_x and "year" in viz_data.columns:
-            # Multi-year time series → year on x-axis
-            program_constraints.append("entity(encoding,m,e1).")
-            program_constraints.append("attribute((encoding,channel),e1,x).")
-            program_constraints.append("attribute((encoding,field),e1,year).")
-            _logger.info("Using temporal x-axis (year) for time-series visualization")
+            program_constraints += [
+                "entity(encoding,m,e1).",
+                "attribute((encoding,channel),e1,x).",
+                "attribute((encoding,field),e1,year).",
+            ]
         elif not use_temporal_x and categorical_x_field:
-            # Single year or chart type prefers categorical → use categorical dimension
-            program_constraints.append("entity(encoding,m,e1).")
-            program_constraints.append("attribute((encoding,channel),e1,x).")
-            program_constraints.append(f"attribute((encoding,field),e1,{categorical_x_field}).")
-            _logger.info(f"Using categorical x-axis ({categorical_x_field}) for cross-sectional comparison")
+            program_constraints += [
+                "entity(encoding,m,e1).",
+                "attribute((encoding,channel),e1,x).",
+                f"attribute((encoding,field),e1,{categorical_x_field}).",
+            ]
         elif "year" in viz_data.columns:
-            # Fallback: year exists but no clear preference → use year
-            program_constraints.append("entity(encoding,m,e1).")
-            program_constraints.append("attribute((encoding,channel),e1,x).")
-            program_constraints.append("attribute((encoding,field),e1,year).")
-            _logger.info("Using temporal x-axis (year) as fallback")
+            program_constraints += [
+                "entity(encoding,m,e1).",
+                "attribute((encoding,channel),e1,x).",
+                "attribute((encoding,field),e1,year).",
+            ]
 
         if "value" in viz_data.columns:
-            program_constraints.append("entity(encoding,m,e2).")
-            program_constraints.append("attribute((encoding,channel),e2,y).")
-            program_constraints.append("attribute((encoding,field),e2,value).")
+            program_constraints += [
+                "entity(encoding,m,e2).",
+                "attribute((encoding,channel),e2,y).",
+                "attribute((encoding,field),e2,value).",
+            ]
 
-
-        # Constraint for Color/Breakdown
-        # We iterate through potential breakdown dims that we found relevant earlier
-        # If any are present in viz_data (and not x/y), we map to color
-        # We prioritize by cardinality (skip dims with only 1 unique value)
-        # Priority order: country > sex > age > urbanisation
-        color_dim = None
-        color_candidates = []
-        if "country" in viz_data.columns:
-            color_candidates.append(("country", viz_data["country"].nunique()))
-        if "sex" in viz_data.columns and "sex" in relevant_cols:
-            color_candidates.append(("sex", viz_data["sex"].nunique()))
-        if "age" in viz_data.columns and "age" in relevant_cols:
-            color_candidates.append(("age", viz_data["age"].nunique()))
-        if "urbanisation" in viz_data.columns and "urbanisation" in relevant_cols:
-            color_candidates.append(("urbanisation", viz_data["urbanisation"].nunique()))
-
-        # Pick the first candidate with cardinality > 1; if none, pick first with any data
-        for dim, card in color_candidates:
-            if card > 1:
-                color_dim = dim
-                break
-        if not color_dim and color_candidates:
-            color_dim = color_candidates[0][0]
+        # Color dimension
+        color_dim = strategy_result.color_dim
+        if not color_dim:
+            for dim, _ in [("country", 0), ("sex", 0), ("age", 0), ("urbanisation", 0)]:
+                if dim in viz_data.columns and viz_data[dim].nunique() > 1:
+                    color_dim = dim
+                    break
 
         if color_dim:
-            program_constraints.append("entity(encoding,m,e3).")
-            program_constraints.append("attribute((encoding,channel),e3,color).")
-            program_constraints.append(f"attribute((encoding,field),e3,{color_dim}).")
+            program_constraints += [
+                "entity(encoding,m,e3).",
+                "attribute((encoding,channel),e3,color).",
+                f"attribute((encoding,field),e3,{color_dim}).",
+            ]
 
-        # Optional: Apply user chart type hint
         if chart_type:
             program_constraints.append(f"attribute((mark,type),m,{user_mark_type}).")
 
-    # Apply Custom Constraints from LLM/Developer
     if custom_constraints:
-        _logger.info(f"Applying custom Draco constraints: {custom_constraints}")
         program_constraints.extend(custom_constraints)
 
     program = "\n".join(facts) + "\n" + "\n".join(program_constraints)
 
     try:
-        # Solve
         model = next(d.complete_spec(program))
         draco_spec = answer_set_to_dict(model.answer_set)
-
-        # RENDER USING STANDARD DRACO RENDERER
 
         if "view" in draco_spec:
             for view in draco_spec["view"]:
                 if "mark" in view:
                     for mark in view["mark"]:
                         if "encoding" in mark:
-                            for encoding in mark["encoding"]:
-                                encoding.pop("type", None)
+                            for enc in mark["encoding"]:
+                                enc.pop("type", None)
 
-        # Merge data schema (stats) with the view spec
         full_spec = {**schema, **draco_spec}
-
         renderer = AltairRenderer()
         chart = renderer.render(spec=full_spec, data=viz_data)
-
-        # Apply customizations
-
-        # 1. Custom Interactive + Title
         chart = chart.properties(title=chart_title).interactive()
 
-        # 2. Force Rich Tooltips
-        tooltip_cols = list(viz_data.columns)
-        chart = chart.encode(tooltip=tooltip_cols)
-
-        # 3. Force NOMINAL type for categorical channels (Color) if applicable
-        # Draco renderer might infer ordinal, but users prefer nominal for countries etc.
-        # We manually patch the encoding if the color field is categorical.
-        if color_dim:
-            # We can't easily modify the altair object's encoding type in place deeply?
-            # Easier to patch the dictionary.
-            pass
+        # Structured tooltips
+        mark_type_for_tt = viz_config.parse_chart_type_hint(chart_type)
+        structured_tooltips = viz_config.build_structured_tooltips(
+            list(viz_data.columns), mark_type_for_tt
+        )
+        chart = chart.encode(tooltip=[alt.Tooltip(**t) for t in structured_tooltips])
 
         vl_spec = chart.to_dict()
 
-        # Manual Patching of Types in the final Spec
-        if "encoding" in vl_spec:
-            if "color" in vl_spec["encoding"]:
-                # If color is used, force nominal if it corresponds to our breakdown dims
-                # color_dim var holds the name of the column used for color
-                if color_dim in ["country", "sex", "urbanisation", "ref_area"]:
-                    vl_spec["encoding"]["color"]["type"] = "nominal"
+        # Patch color type
+        if "encoding" in vl_spec and "color" in vl_spec["encoding"]:
+            if color_dim in ["country", "sex", "urbanisation", "ref_area"]:
+                vl_spec["encoding"]["color"]["type"] = "nominal"
 
-        # Apply post-processing rules from viz_config
-        # This is cleaner than hardcoding rules inline
+        # Patch y-axis title
+        if "encoding" in vl_spec and "y" in vl_spec["encoding"]:
+            vl_spec["encoding"]["y"].setdefault("axis", {})["title"] = unit_label
+
+        # Post-processing rules
         for rule in viz_config.POST_PROCESSING_RULES:
             vl_spec = rule.apply(vl_spec, data_frequency)
-            _logger.debug(f"Applied post-processing rule: {rule.name}")
 
-
-
-
-        # Store: prefer external charts API when configured
-        charts_url = get_mcp_server_settings().charts_api_url
-        if charts_url:
-            try:
-                return ok(await post_spec_to_charts_api(vl_spec))
-            except Exception as e:
-                _logger.warning(f"Charts API store failed, falling back to static: {e}")
-        return ok(save_specs_to_static(vl_spec))
+        return _ok(await _store_spec(vl_spec))
 
     except StopIteration:
-        _logger.warning(
-            "Draco failed to find a visualization spec. Falling back to manual generation."
-        )
-        _logger.debug(f"Failed Program:\n{program}")
-
-        # Fallback: Manual Altair Generation
+        _logger.warning("Draco failed → fallback")
+        # Strategy-aware fallback
         try:
-            fc = list(viz_data.columns)
-            base = alt.Chart(viz_data).mark_line().encode(tooltip=fc)
-
-            # Map known columns
-            if "year" in fc:
-                x_enc = alt.X("year", title="Year")
-            elif "time_period" in fc:
-                x_enc = alt.X("time_period", title="Year")
-            else:
-                # Last resort: first column
-                x_enc = alt.X(fc[0])
-
-            if "value" in fc:
-                y_enc = alt.Y("value", title="Value")
-            elif "obs_value" in fc:
-                y_enc = alt.Y("obs_value", title="Value")
-            else:
-                y_enc = alt.Y(fc[1] if len(fc) > 1 else fc[0])
-
-            encoding = {"x": x_enc, "y": y_enc}
-
-            # Add color if breakdown found (prefer dimension with cardinality > 1)
-            color_field = None
-            for dim, title in [("country", "Country"), ("sex", "Sex"), ("age", "Age"), ("urbanisation", "Urbanisation")]:
-                if dim in fc and viz_data[dim].nunique() > 1:
-                    color_field = (dim, title)
-                    break
-            # Fallback: use first available even if single-value
-            if not color_field:
-                for dim, title in [("country", "Country"), ("sex", "Sex"), ("age", "Age"), ("urbanisation", "Urbanisation")]:
-                    if dim in fc:
-                        color_field = (dim, title)
-                        break
-            if color_field:
-                encoding["color"] = alt.Color(
-                    color_field[0], type="nominal", title=color_field[1]
-                )
-
-            chart = base.encode(**encoding).properties(title=chart_title).interactive()
-            vl_spec = chart.to_dict()
-            charts_url = get_mcp_server_settings().charts_api_url
-            if charts_url:
-                try:
-                    result = ok(await post_spec_to_charts_api(vl_spec))
-                    result["warning"] = _FALLBACK_WARNING
-                    return result
-                except Exception as e:
-                    _logger.warning(
-                        f"Charts API store failed, falling back to static: {e}"
-                    )
-            result = ok(save_specs_to_static(vl_spec))
-            result["warning"] = _FALLBACK_WARNING
-            return result
-
+            spec = viz_config.dispatch_spec(
+                viz_config.ChartStrategy.FALLBACK_LINE,
+                viz_data,
+                chart_title,
+                strategy_result,
+                y_label=unit_label,
+            )
+            return _ok(await _store_spec(spec), warning=_FALLBACK_WARNING)
         except Exception as fallback_err:
-            _logger.exception(f"Fallback generation failed: {fallback_err}")
-            return err(
+            _logger.exception(f"Fallback failed: {fallback_err}")
+            return _err(
                 "Error: Draco could not determine a suitable visualization, and fallback failed."
             )
+
     except Exception as e:
-        _logger.exception(f"Draco execution error: {e}")
-        return err(f"Error generating visualization: {e}")
+        _logger.exception(f"Draco error: {e}")
+        return _err(f"Error generating visualization: {e}")
+
+
+# ============================================================================
+# TOOL: get_multi_indicator_viz_spec (NEW)
+# ============================================================================
+
+
+async def get_multi_indicator_viz_spec(
+    indicator_ids: list[dict[str, str]] | None = None,
+    country_code: str | None = None,
+    start_year: int | None = None,
+    end_year: int | None = None,
+    disaggregation_filters: dict[str, str | None] | None = None,
+    chart_type: str | None = None,
+) -> VizResult:
+    """Generate a Vega-Lite chart comparing multiple Data360 indicators.
+
+    REQUIRED for success: indicator_ids (2–4 entries). Call data360_search_indicators first,
+    then pass each series as {"database_id": "...", "indicator_id": "..."}. If you omit
+    indicator_ids or pass fewer than 2 entries, this tool returns {"error": "..."} — fix
+    the arguments and call again (do not rely on country_code alone).
+
+    Use for: scatterplots (2 indicators vs each other), layered/dual-axis line charts
+    (2-3 indicators over time in one country), connected scatter (trajectory charts).
+
+    Args:
+        indicator_ids: List of dicts, each with "database_id" and "indicator_id".
+            Example: [
+                {"database_id": "WB_WDI", "indicator_id": "WB_WDI_NY_GDP_PCAP_KD"},
+                {"database_id": "WB_WDI", "indicator_id": "WB_WDI_SP_DYN_LE00_IN"}
+            ]
+        country_code: Optional 3-letter code or comma-separated list.
+        start_year: Optional start year (inclusive).
+        end_year: Optional end year (inclusive).
+        disaggregation_filters: Optional dimension filters applied to ALL indicators.
+        chart_type: Optional hint — "scatter", "connected_scatter", "layered_lines",
+            "line", "bar". If omitted, auto-selected by data shape.
+
+    Returns:
+        Dict with "url" (chart URL on success), "error" (on failure),
+        "strategy" (which chart type was chosen), "warning" (if applicable).
+    """
+    if indicator_ids is None or len(indicator_ids) < 2:
+        return _err(
+            "indicator_ids is required: pass a JSON array of 2–4 objects, each "
+            '{"database_id":"<db>","indicator_id":"<id>"} from data360_search_indicators '
+            "(use idno + database_id). Example: "
+            '[{"database_id":"WB_WDI","indicator_id":"WB_WDI_NY_GDP_PCAP_KD"},'
+            '{"database_id":"WB_WDI","indicator_id":"WB_WDI_SP_DYN_LE00_IN"}]. '
+            "Then add country_code, start_year, end_year as needed. "
+            "Do not call this tool with only country_code or chart_type."
+        )
+    if len(indicator_ids) > 4:
+        return _err("Maximum 4 indicators supported in one chart.")
+
+    # 1. Fetch all indicators concurrently
+    tasks = [
+        _fetch_single_indicator(
+            ind["database_id"],
+            ind["indicator_id"],
+            country_code,
+            start_year,
+            end_year,
+            disaggregation_filters,
+        )
+        for ind in indicator_ids
+    ]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    dfs: list[pd.DataFrame] = []
+    titles: list[str] = []
+    units: list[str] = []
+    indicator_col_names: list[str] = []
+    used_cols: set[str] = set()
+
+    for i, (res, ind) in enumerate(zip(results, indicator_ids)):
+        if isinstance(res, Exception):
+            return _err(f"Failed to fetch indicator {ind['indicator_id']}: {res}")
+        df, title, unit = res
+        if df.empty:
+            return _err(f"No data returned for indicator {ind['indicator_id']}.")
+
+        ind_name = title or ind["indicator_id"]
+        col_base = _slugify(ind_name)
+        col = _make_unique_col(col_base, used_cols)
+        used_cols.add(col)
+
+        dfs.append(df)
+        titles.append(ind_name)
+        units.append(unit or "")
+        indicator_col_names.append(col)
+
+    # 2. Standardize each DataFrame
+    std_dfs: list[pd.DataFrame] = []
+    for df, col in zip(dfs, indicator_col_names):
+        # Lowercase columns
+        df.columns = [c.lower() for c in df.columns]
+
+        # Parse time
+        if "time_period" in df.columns:
+            try:
+                df["time_period"] = pd.to_datetime(df["time_period"])
+            except Exception:
+                pass
+
+        # Coerce obs_value
+        if "obs_value" in df.columns:
+            df["obs_value"] = pd.to_numeric(df["obs_value"], errors="coerce")
+
+        # Rename to standard
+        df = df.rename(
+            columns={"time_period": "year", "obs_value": col, "ref_area": "country"}
+        )
+
+        # Keep only join keys + value column
+        keep = [
+            c
+            for c in ["year", "country", "sex", "age", "urbanisation"]
+            if c in df.columns
+        ]
+        keep.append(col)
+        std_dfs.append(df[keep])
+
+    # 3. Map country codes (use first df's country column as reference)
+    try:
+        from data360.providers import get_codelist_mapping
+
+        country_map = await get_codelist_mapping("REF_AREA")
+        for df in std_dfs:
+            if "country" in df.columns:
+                df["country"] = df["country"].map(lambda x: country_map.get(x, x))
+    except Exception as e:
+        _logger.warning(f"Country code mapping failed: {e}")
+
+    # 4. Merge on common keys
+    join_keys = [
+        c
+        for c in ["year", "country", "sex", "age", "urbanisation"]
+        if all(c in df.columns for df in std_dfs)
+    ]
+
+    merged = std_dfs[0]
+    for df in std_dfs[1:]:
+        merged = pd.merge(merged, df, on=join_keys, how="outer")
+
+    if merged.empty:
+        return _err("No overlapping data found across indicators after merging.")
+
+    merged = _sanitize_dataframe_for_json_records(merged)
+
+    # 5. Build chart title
+    if len(titles) == 2:
+        chart_title = f"{titles[0]} vs. {titles[1]}"
+    else:
+        chart_title = " | ".join(titles)
+
+    # 6. Build indicator_labels for axis/tooltip
+    indicator_labels = {
+        col: f"{title} ({unit})" if unit else title
+        for col, title, unit in zip(indicator_col_names, titles, units)
+    }
+
+    # 7. Select strategy
+    strategy_result = viz_config.select_strategy(
+        merged,
+        n_indicators=len(indicator_ids),
+        chart_type_hint=chart_type,
+        indicator_cols=indicator_col_names,
+    )
+    _logger.info(
+        f"Multi-indicator strategy: {strategy_result.strategy.value} — {strategy_result.reason}"
+    )
+
+    # 8. Build spec
+    try:
+        spec = viz_config.dispatch_spec(
+            strategy_result.strategy,
+            merged,
+            chart_title,
+            strategy_result,
+            indicator_labels=indicator_labels,
+            y_label=indicator_labels.get(indicator_col_names[1], "Value"),
+            x_label=indicator_labels.get(indicator_col_names[0], "Value"),
+        )
+    except Exception as e:
+        _logger.exception(f"Spec build failed: {e}")
+        return _err(f"Error building chart spec: {e}")
+
+    # 9. Store and return
+    url = await _store_spec(spec)
+    result = _ok(url)
+    result["strategy"] = strategy_result.strategy.value
+    result["reason"] = strategy_result.reason
+    return result

--- a/src/data360/viz_config.py
+++ b/src/data360/viz_config.py
@@ -1,475 +1,1324 @@
 """
 Visualization Configuration Module
 
-This module centralizes all hardcoded rules, constraints, and mappings
-for the Data360 visualization system. This makes the codebase more maintainable,
-testable, and easier to modify without touching core logic.
+Centralizes all rules, strategies, spec builders, and style tokens for the
+Data360 visualization system.
+
+Design principles:
+  - World Bank Data Visualization Style Guide (colors, typography, grid)
+  - FT Visual Vocabulary (chart-type selection by data relationship)
+  - All functions here are pure (no async, no I/O) → fully unit-testable
 """
 
-from dataclasses import dataclass
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
 from typing import Literal
+
 import pandas as pd
 
-
 # ============================================================================
-# FREQUENCY MAPPINGS
+# WORLD BANK COLOR PALETTE
+# Source: https://worldbank.github.io/data-visualization-style-guide/colors
 # ============================================================================
 
-# Map Data360 frequency codes to Vega-Lite timeUnit values
-FREQUENCY_TO_TIMEUNIT: dict[str, str] = {
-    "A": "year",        # Annual: displays as 2012, 2013, 2014, ...
-    "M": "yearmonth",   # Monthly: displays as Jan 2012, Feb 2012, ...
-    "Q": "yearquarter", # Quarterly: displays as Q1 2012, Q2 2012, ...
+WB_CAT_COLORS: list[str] = [
+    "#34A7F2",  # cat1 – blue
+    "#FF9800",  # cat2 – orange
+    "#664AB6",  # cat3 – purple
+    "#4EC2C0",  # cat4 – teal
+    "#F3578E",  # cat5 – pink
+    "#081079",  # cat6 – navy
+    "#0C7C68",  # cat7 – dark green
+    "#AA0000",  # cat8 – red
+    "#DDDA21",  # cat9 – yellow
+]
+
+WB_REGION_COLORS: dict[str, str] = {
+    "NAC": "#34A7F2",
+    "SSF": "#FF9800",
+    "MEA": "#664AB6",
+    "SAS": "#4EC2C0",
+    "EAS": "#F3578E",
+    "LCN": "#0C7C68",
+    "ECS": "#AA0000",
+    "AFW": "#DDDA21",
+    "AFE": "#FF9800",
+    "WLD": "#081079",
 }
 
-# Keywords for inferring frequency from periodicity text (fallback)
+WB_GENDER_COLORS: dict[str, str] = {
+    "F": "#FF9800",
+    "M": "#664AB6",
+    "_T": "#4EC2C0",
+    "female": "#FF9800",
+    "male": "#664AB6",
+}
+
+WB_INCOME_COLORS: dict[str, str] = {
+    "HIC": "#016B6C",
+    "UMC": "#73AF48",
+    "LMC": "#DB95D7",
+    "LIC": "#3B4DA6",
+}
+
+WB_SEQ_GOOD: list[str] = ["#FDF6DB", "#A1CBCF", "#5D99C2", "#2868A0", "#023B6F"]
+WB_SEQ_BAD: list[str] = ["#E3F6FD", "#91C5F0", "#8B8AC0", "#88506E", "#691B15"]
+WB_SEQ_BLUE: list[str] = ["#E3F6FD", "#75CCEC", "#089BD4", "#0169A1", "#023B6F"]
+WB_DIV_DEFAULT: list[str] = [
+    "#920000",
+    "#BD6126",
+    "#E3A763",
+    "#EFEFEF",
+    "#80BDE7",
+    "#3587C3",
+    "#025288",
+]
+
+WB_TEXT = "#111111"
+WB_TEXT_SUBTLE = "#666666"
+WB_GRID_COLOR = "#CED4DE"
+WB_ZERO_COLOR = "#8A969F"
+WB_REFERENCE = "#8A969F"
+WB_NO_DATA = "#CED4DE"
+WB_WHITE = "#FFFFFF"
+WB_BACKGROUND = "#FFFFFF"
+WB_FONT_FAMILY = "Noto Sans, Arial, sans-serif"
+
+
+# ============================================================================
+# WB ALTAIR THEME CONFIG
+# ============================================================================
+
+
+def wb_altair_config() -> dict:
+    """Return World Bank style config dict for injection into Vega-Lite specs."""
+    return {
+        "background": WB_BACKGROUND,
+        "font": WB_FONT_FAMILY,
+        "title": {
+            "fontSize": 16,
+            "fontWeight": "bold",
+            "color": WB_TEXT,
+            "lineHeight": 1.2,
+            "anchor": "start",
+            "offset": 8,
+        },
+        "axis": {
+            "labelColor": WB_TEXT_SUBTLE,
+            "labelFontSize": 12,
+            "labelFont": WB_FONT_FAMILY,
+            "titleColor": WB_TEXT,
+            "titleFontSize": 12,
+            "titleFont": WB_FONT_FAMILY,
+            "titleFontWeight": "bold",
+            "gridColor": WB_GRID_COLOR,
+            "gridDash": [4, 2],
+            "gridWidth": 1,
+            "domainColor": WB_GRID_COLOR,
+            "tickColor": WB_GRID_COLOR,
+            "tickCount": 5,
+        },
+        "legend": {
+            "labelColor": WB_TEXT,
+            "labelFont": WB_FONT_FAMILY,
+            "labelFontSize": 12,
+            "labelFontWeight": "bold",
+            "labelLimit": 200,
+            "titleColor": WB_TEXT,
+            "titleFont": WB_FONT_FAMILY,
+            "titleFontSize": 12,
+            "orient": "top",
+            "direction": "horizontal",
+        },
+        "range": {"category": WB_CAT_COLORS},
+        "view": {"stroke": "transparent"},
+        "line": {"strokeWidth": 3, "strokeCap": "round"},
+        "point": {"size": 60, "stroke": WB_WHITE, "strokeWidth": 1},
+        "bar": {"cornerRadiusTopLeft": 2, "cornerRadiusTopRight": 2},
+    }
+
+
+def inject_wb_config(vl_spec: dict) -> dict:
+    """Merge WB style config into a Vega-Lite spec without overwriting user settings."""
+    wb_cfg = wb_altair_config()
+    if "config" not in vl_spec:
+        vl_spec["config"] = wb_cfg
+    else:
+        for section, props in wb_cfg.items():
+            if section not in vl_spec["config"]:
+                vl_spec["config"][section] = props
+            elif isinstance(props, dict) and isinstance(
+                vl_spec["config"].get(section), dict
+            ):
+                for k, v in props.items():
+                    vl_spec["config"][section].setdefault(k, v)
+    return vl_spec
+
+
+# ============================================================================
+# STRUCTURED TOOLTIPS
+# ============================================================================
+
+_TOOLTIP_SPECS: dict[str, dict] = {
+    "year": {"title": "Year", "format": "%Y", "type": "temporal"},
+    "value": {"title": "Value", "format": ",.2f", "type": "quantitative"},
+    "country": {"title": "Country", "type": "nominal"},
+    "sex": {"title": "Sex", "type": "nominal"},
+    "age": {"title": "Age Group", "type": "nominal"},
+    "urbanisation": {"title": "Urbanisation", "type": "nominal"},
+    "time_period": {"title": "Period", "type": "temporal"},
+    "obs_value": {"title": "Value", "format": ",.2f", "type": "quantitative"},
+    "ref_area": {"title": "Country", "type": "nominal"},
+    "region": {"title": "Region", "type": "nominal"},
+}
+
+_TOOLTIP_PRIORITY = [
+    "year",
+    "time_period",
+    "value",
+    "obs_value",
+    "country",
+    "ref_area",
+    "region",
+    "sex",
+    "age",
+    "urbanisation",
+]
+
+
+def build_structured_tooltips(
+    columns: list[str],
+    mark_type: str,
+    indicator_labels: dict[str, str] | None = None,
+) -> list[dict]:
+    """Build typed, labelled tooltip list for a Vega-Lite encoding.
+
+    indicator_labels: optional {col_name: human_label} for indicator value columns
+    in multi-indicator charts (e.g. {"gdp_per_capita": "GDP per capita (USD)"}).
+    """
+    ordered = [c for c in _TOOLTIP_PRIORITY if c in columns]
+    ordered += [c for c in columns if c not in _TOOLTIP_PRIORITY]
+
+    tooltips = []
+    for col in ordered:
+        if indicator_labels and col in indicator_labels:
+            tip = {
+                "field": col,
+                "title": indicator_labels[col],
+                "format": ",.2f",
+                "type": "quantitative",
+            }
+        elif col in _TOOLTIP_SPECS:
+            spec = _TOOLTIP_SPECS[col]
+            tip = {"field": col, "title": spec["title"], "type": spec["type"]}
+            if "format" in spec:
+                tip["format"] = spec["format"]
+        else:
+            tip = {"field": col, "title": col.replace("_", " ").title()}
+        tooltips.append(tip)
+    return tooltips
+
+
+def apply_structured_tooltips(
+    vl_spec: dict,
+    columns: list[str],
+    mark_type: str,
+    indicator_labels: dict[str, str] | None = None,
+) -> dict:
+    tips = build_structured_tooltips(columns, mark_type, indicator_labels)
+    vl_spec.setdefault("encoding", {})["tooltip"] = tips
+    return vl_spec
+
+
+# ============================================================================
+# CHART STRATEGY ROUTER  (FT Visual Vocabulary aligned)
+# ============================================================================
+
+
+class ChartStrategy(str, Enum):
+    """Named chart strategies mapped to FT Visual Vocabulary categories."""
+
+    TEMPORAL_SINGLE = "temporal_single"  # 1 indicator, ≤8 countries, multi-year → lines
+    TEMPORAL_MULTI_IND = (
+        "temporal_multi_indicator"  # 2-3 indicators, 1 country → layered lines
+    )
+    CORRELATION = "correlation"  # 2 indicators, multi-country, 1 year → scatter
+    CORRELATION_TEMPORAL = "correlation_temporal"  # 2 indicators, multi-country, multi-year → connected scatter
+    CROSS_SECTIONAL = (
+        "cross_sectional"  # 1 indicator, ≤8 countries, 1 year → horizontal bar
+    )
+    DISTRIBUTION = "distribution"  # 1 indicator, >8 countries, 1 year → strip/beeswarm
+    BREAKDOWN_COMPARISON = (
+        "breakdown_comparison"  # 1 indicator, 1 disagg, 2-4 values → grouped bar
+    )
+    SMALL_MULTIPLES = (
+        "small_multiples"  # 1 indicator, 2+ disagg or >4 cntry+breakdown → facet
+    )
+    FALLBACK_LINE = "fallback_line"  # anything else
+
+
+@dataclass
+class StrategyResult:
+    strategy: ChartStrategy
+    reason: str
+    # Enriched context the spec builder needs
+    indicator_cols: list[str] = field(
+        default_factory=list
+    )  # value columns for multi-indicator
+    color_dim: str | None = None
+    facet_dim: str | None = None
+    x_dim: str | None = None
+    y_dim: str | None = None
+
+
+def select_strategy(
+    df: pd.DataFrame,
+    n_indicators: int = 1,
+    chart_type_hint: str | None = None,
+    indicator_cols: list[str] | None = None,
+) -> StrategyResult:
+    """
+    Pure function: inspect DataFrame shape + intent → return ChartStrategy.
+
+    Args:
+        df: The merged/cleaned visualization DataFrame.
+        n_indicators: Number of distinct indicators represented.
+        chart_type_hint: Optional user hint (e.g. "scatter", "bar").
+        indicator_cols: For multi-indicator DFs, the names of the value columns.
+    """
+    hint = parse_chart_type_hint(chart_type_hint)
+    cols = set(df.columns)
+
+    year_count = df["year"].nunique() if "year" in cols else 0
+    country_count = df["country"].nunique() if "country" in cols else 0
+    sex_count = df["sex"].nunique() if "sex" in cols else 0
+    age_count = df["age"].nunique() if "age" in cols else 0
+    urban_count = df["urbanisation"].nunique() if "urbanisation" in cols else 0
+
+    breakdown_counts = {
+        k: v
+        for k, v in [
+            ("sex", sex_count),
+            ("age", age_count),
+            ("urbanisation", urban_count),
+        ]
+        if v > 1
+    }
+    n_breakdowns = len(breakdown_counts)
+    ind_cols = indicator_cols or []
+
+    # ── Explicit scatter hint ──
+    if hint == "point" and n_indicators == 2 and len(ind_cols) == 2:
+        if year_count > 1:
+            return StrategyResult(
+                ChartStrategy.CORRELATION_TEMPORAL,
+                "User requested scatter; 2 indicators, multi-year → connected scatter",
+                indicator_cols=ind_cols,
+                color_dim="country" if country_count > 1 else None,
+            )
+        return StrategyResult(
+            ChartStrategy.CORRELATION,
+            "User requested scatter; 2 indicators, single year → scatterplot",
+            indicator_cols=ind_cols,
+            color_dim="country" if country_count > 1 else None,
+        )
+
+    # ── Multi-indicator: 2-3 indicators ──
+    if n_indicators == 2 and len(ind_cols) == 2:
+        if year_count <= 1 and country_count > 1:
+            return StrategyResult(
+                ChartStrategy.CORRELATION,
+                f"2 indicators, {country_count} countries, single year → scatterplot",
+                indicator_cols=ind_cols,
+                color_dim="country",
+                x_dim=ind_cols[0],
+                y_dim=ind_cols[1],
+            )
+        if year_count > 1 and country_count > 1:
+            return StrategyResult(
+                ChartStrategy.CORRELATION_TEMPORAL,
+                f"2 indicators, {country_count} countries, {year_count} years → connected scatter",
+                indicator_cols=ind_cols,
+                color_dim="country",
+                x_dim=ind_cols[0],
+                y_dim=ind_cols[1],
+            )
+        # 1 country, multi-year → layered lines
+        return StrategyResult(
+            ChartStrategy.TEMPORAL_MULTI_IND,
+            f"2 indicators, 1 country, {year_count} years → layered lines",
+            indicator_cols=ind_cols,
+        )
+
+    if n_indicators >= 2 and len(ind_cols) >= 2:
+        # 3+ indicators, always layered lines (scatter matrix is too complex for now)
+        return StrategyResult(
+            ChartStrategy.TEMPORAL_MULTI_IND,
+            f"{n_indicators} indicators → layered lines",
+            indicator_cols=ind_cols,
+        )
+
+    # ── Single indicator from here ──
+
+    # Small multiples: 2+ meaningful breakdowns, or breakdown + many countries
+    if n_breakdowns >= 2 or (n_breakdowns >= 1 and country_count > 4):
+        facet_dim = "country" if country_count > 1 else list(breakdown_counts.keys())[0]
+        color_dim = list(breakdown_counts.keys())[0] if breakdown_counts else None
+        return StrategyResult(
+            ChartStrategy.SMALL_MULTIPLES,
+            f"{n_breakdowns} breakdowns, {country_count} countries → small multiples",
+            color_dim=color_dim,
+            facet_dim=facet_dim,
+        )
+
+    # Breakdown comparison: 1 disaggregation, 2-4 values, ≤4 countries
+    if n_breakdowns == 1 and country_count <= 4:
+        color_dim = list(breakdown_counts.keys())[0]
+        return StrategyResult(
+            ChartStrategy.BREAKDOWN_COMPARISON,
+            f"1 breakdown ({color_dim}), {breakdown_counts[color_dim]} values → grouped bar",
+            color_dim=color_dim,
+        )
+
+    # Distribution: >8 countries, single year
+    if (
+        country_count > HIGH_CARDINALITY_THRESHOLDS["beeswarm_threshold"]
+        and year_count <= 1
+    ):
+        return StrategyResult(
+            ChartStrategy.DISTRIBUTION,
+            f"{country_count} countries, single year → strip/beeswarm",
+            color_dim="country",
+        )
+
+    # Cross-sectional: ≤8 countries, single year
+    if year_count <= 1 and country_count > 0:
+        return StrategyResult(
+            ChartStrategy.CROSS_SECTIONAL,
+            f"{country_count} countries, single year → horizontal bar",
+            color_dim="country" if country_count > 1 else None,
+        )
+
+    # Multi-year time series
+    if year_count > 1:
+        return StrategyResult(
+            ChartStrategy.TEMPORAL_SINGLE,
+            f"Single indicator, {year_count} years, {country_count} countries → line chart",
+            color_dim="country" if country_count > 1 else None,
+        )
+
+    return StrategyResult(ChartStrategy.FALLBACK_LINE, "Default fallback → line chart")
+
+
+# ============================================================================
+# SPEC BUILDERS — one per strategy, pure functions returning raw VL dicts
+# ============================================================================
+
+
+def _vl_schema() -> str:
+    return "https://vega.github.io/schema/vega-lite/v5.json"
+
+
+def _axis_style(title: str | None = None, temporal: bool = False) -> dict:
+    ax: dict = {
+        "gridColor": WB_GRID_COLOR,
+        "gridDash": [4, 2],
+        "labelColor": WB_TEXT_SUBTLE,
+        "titleColor": WB_TEXT,
+        "titleFontWeight": "bold",
+        "tickCount": 5,
+    }
+    if temporal:
+        ax["title"] = None
+        ax["format"] = "%Y"
+        ax["tickCount"] = 6
+    elif title is not None:
+        ax["title"] = title
+    return ax
+
+
+def _color_encoding(field: str, domain: list | None = None) -> dict:
+    scale = {"range": WB_CAT_COLORS}
+    if domain:
+        scale["domain"] = domain
+    return {
+        "field": field,
+        "type": "nominal",
+        "scale": scale,
+        "legend": {"orient": "top", "direction": "horizontal", "labelLimit": 200},
+    }
+
+
+def build_temporal_single_spec(
+    df: pd.DataFrame,
+    title: str,
+    result: StrategyResult,
+    indicator_labels: dict[str, str] | None = None,
+    y_label: str = "Value",
+) -> dict:
+    """Line chart: 1 indicator, multi-year, ≤8 countries."""
+    rows = df.to_dict(orient="records")
+    encoding: dict = {
+        "x": {"field": "year", "type": "temporal", "axis": _axis_style(temporal=True)},
+        "y": {
+            "field": "value",
+            "type": "quantitative",
+            "axis": _axis_style(y_label),
+            "scale": {"zero": False},
+        },
+        "tooltip": build_structured_tooltips(
+            list(df.columns), "line", indicator_labels
+        ),
+    }
+    if result.color_dim:
+        encoding["color"] = _color_encoding(result.color_dim)
+
+    spec: dict = {
+        "$schema": _vl_schema(),
+        "title": title,
+        "data": {"values": rows},
+        "mark": {
+            "type": "line",
+            "strokeWidth": 3,
+            "strokeCap": "round",
+            "point": False,
+        },
+        "encoding": encoding,
+        "width": 600,
+        "height": 350,
+    }
+    return inject_wb_config(spec)
+
+
+def build_cross_sectional_spec(
+    df: pd.DataFrame,
+    title: str,
+    result: StrategyResult,
+    indicator_labels: dict[str, str] | None = None,
+    x_label: str = "Value",
+) -> dict:
+    """Horizontal bar: 1 indicator, single year, ≤8 countries."""
+    # Sort by value descending
+    sorted_df = df.sort_values("value", ascending=False)
+    rows = sorted_df.to_dict(orient="records")
+
+    color_enc = (
+        _color_encoding(result.color_dim)
+        if result.color_dim
+        else {"value": WB_CAT_COLORS[0]}
+    )
+
+    spec: dict = {
+        "$schema": _vl_schema(),
+        "title": title,
+        "data": {"values": rows},
+        "mark": {
+            "type": "bar",
+            "cornerRadiusTopRight": 3,
+            "cornerRadiusBottomRight": 3,
+        },
+        "encoding": {
+            "y": {
+                "field": "country",
+                "type": "nominal",
+                "sort": "-x",
+                "axis": {
+                    "title": None,
+                    "labelColor": WB_TEXT,
+                    "labelFontWeight": "bold",
+                    "labelLimit": 150,
+                },
+            },
+            "x": {
+                "field": "value",
+                "type": "quantitative",
+                "axis": _axis_style(x_label),
+                "scale": {"zero": True},
+            },
+            "color": color_enc,
+            "tooltip": build_structured_tooltips(
+                list(df.columns), "bar", indicator_labels
+            ),
+        },
+        "width": 500,
+        "height": max(180, len(sorted_df) * 28),
+    }
+    return inject_wb_config(spec)
+
+
+def build_distribution_spec(
+    df: pd.DataFrame,
+    title: str,
+    result: StrategyResult,
+    indicator_labels: dict[str, str] | None = None,
+    x_label: str = "Value",
+) -> dict:
+    """Strip/beeswarm: 1 indicator, >8 countries, single year."""
+    top_n = HIGH_CARDINALITY_THRESHOLDS["top_n_series"]
+    sorted_df = df.sort_values("value", ascending=False).head(top_n)
+    rows = sorted_df.to_dict(orient="records")
+
+    spec: dict = {
+        "$schema": _vl_schema(),
+        "title": title,
+        "data": {"values": rows},
+        "mark": {"type": "tick", "thickness": 3, "bandSize": 18},
+        "encoding": {
+            "x": {
+                "field": "value",
+                "type": "quantitative",
+                "axis": _axis_style(x_label),
+            },
+            "y": {
+                "field": "country",
+                "type": "nominal",
+                "sort": "-x",
+                "axis": {
+                    "title": None,
+                    "labelColor": WB_TEXT,
+                    "labelFontWeight": "bold",
+                    "labelLimit": 160,
+                },
+            },
+            "color": _color_encoding("country"),
+            "tooltip": build_structured_tooltips(
+                list(sorted_df.columns), "tick", indicator_labels
+            ),
+        },
+        "width": 500,
+        "height": max(250, len(sorted_df) * 22),
+    }
+    return inject_wb_config(spec)
+
+
+def build_breakdown_comparison_spec(
+    df: pd.DataFrame,
+    title: str,
+    result: StrategyResult,
+    indicator_labels: dict[str, str] | None = None,
+    y_label: str = "Value",
+) -> dict:
+    """Grouped bar: 1 indicator, 1 breakdown (sex/age/urban), 2-4 values, ≤4 countries."""
+    rows = df.to_dict(orient="records")
+    color_dim = result.color_dim or "sex"
+
+    # Use gender colors if sex breakdown
+    if color_dim == "sex":
+        domain = [k for k in WB_GENDER_COLORS if k in df[color_dim].unique()]
+        color_range = [WB_GENDER_COLORS[k] for k in domain]
+        color_scale = {"domain": domain, "range": color_range}
+    else:
+        color_scale = {"range": WB_CAT_COLORS}
+
+    # x-axis: country if multi-country, else year
+    x_field = "country" if df.get("country", pd.Series()).nunique() > 1 else "year"
+    x_type = "nominal" if x_field == "country" else "ordinal"
+
+    spec: dict = {
+        "$schema": _vl_schema(),
+        "title": title,
+        "data": {"values": rows},
+        "mark": {"type": "bar"},
+        "encoding": {
+            "x": {
+                "field": x_field,
+                "type": x_type,
+                "axis": {"title": None, "labelFontWeight": "bold"},
+            },
+            "xOffset": {"field": color_dim, "type": "nominal"},
+            "y": {
+                "field": "value",
+                "type": "quantitative",
+                "axis": _axis_style(y_label),
+                "scale": {"zero": True},
+            },
+            "color": {
+                "field": color_dim,
+                "type": "nominal",
+                "scale": color_scale,
+                "legend": {"orient": "top", "title": color_dim.title()},
+            },
+            "tooltip": build_structured_tooltips(
+                list(df.columns), "bar", indicator_labels
+            ),
+        },
+        "width": max(300, df[x_field].nunique() * 80),
+        "height": 320,
+    }
+    return inject_wb_config(spec)
+
+
+def build_small_multiples_spec(
+    df: pd.DataFrame,
+    title: str,
+    result: StrategyResult,
+    indicator_labels: dict[str, str] | None = None,
+    y_label: str = "Value",
+) -> dict:
+    """Faceted small multiples: 1 indicator, 2+ breakdowns or breakdown+many countries."""
+    rows = df.to_dict(orient="records")
+    facet_dim = result.facet_dim or "country"
+    color_dim = result.color_dim
+
+    n_facets = df[facet_dim].nunique() if facet_dim in df.columns else 1
+    columns = min(3, n_facets)
+
+    inner: dict = {
+        "mark": {"type": "line", "strokeWidth": 2},
+        "encoding": {
+            "x": {
+                "field": "year",
+                "type": "temporal",
+                "axis": _axis_style(temporal=True),
+            },
+            "y": {
+                "field": "value",
+                "type": "quantitative",
+                "axis": _axis_style(y_label),
+                "scale": {"zero": False},
+            },
+            "tooltip": build_structured_tooltips(
+                list(df.columns), "line", indicator_labels
+            ),
+        },
+    }
+    if color_dim and color_dim != facet_dim:
+        inner["encoding"]["color"] = _color_encoding(color_dim)
+
+    spec: dict = {
+        "$schema": _vl_schema(),
+        "title": title,
+        "data": {"values": rows},
+        "facet": {
+            "field": facet_dim,
+            "type": "nominal",
+            "columns": columns,
+            "header": {
+                "labelFontWeight": "bold",
+                "labelColor": WB_TEXT,
+                "titleColor": WB_TEXT,
+            },
+        },
+        "spec": {**inner, "width": 220, "height": 160},
+    }
+    return inject_wb_config(spec)
+
+
+def build_correlation_spec(
+    df: pd.DataFrame,
+    title: str,
+    result: StrategyResult,
+    indicator_labels: dict[str, str] | None = None,
+) -> dict:
+    """Scatterplot: 2 indicators, single year, multi-country."""
+    ind_cols = result.indicator_cols
+    if len(ind_cols) < 2:
+        raise ValueError("correlation spec requires exactly 2 indicator columns")
+
+    x_col, y_col = ind_cols[0], ind_cols[1]
+    lab = indicator_labels or {}
+    x_label = lab.get(x_col, x_col.replace("_", " ").title())
+    y_label = lab.get(y_col, y_col.replace("_", " ").title())
+
+    rows = df.dropna(subset=[x_col, y_col]).to_dict(orient="records")
+
+    spec: dict = {
+        "$schema": _vl_schema(),
+        "title": title,
+        "data": {"values": rows},
+        "mark": {
+            "type": "circle",
+            "opacity": 0.85,
+            "stroke": WB_WHITE,
+            "strokeWidth": 1,
+        },
+        "encoding": {
+            "x": {
+                "field": x_col,
+                "type": "quantitative",
+                "axis": _axis_style(x_label),
+                "scale": {"zero": False},
+            },
+            "y": {
+                "field": y_col,
+                "type": "quantitative",
+                "axis": _axis_style(y_label),
+                "scale": {"zero": False},
+            },
+            "color": _color_encoding(result.color_dim or "country"),
+            "tooltip": build_structured_tooltips(list(df.columns), "point", lab),
+        },
+        "width": 550,
+        "height": 450,
+    }
+    return inject_wb_config(spec)
+
+
+def build_correlation_temporal_spec(
+    df: pd.DataFrame,
+    title: str,
+    result: StrategyResult,
+    indicator_labels: dict[str, str] | None = None,
+) -> dict:
+    """Connected scatterplot: 2 indicators, multi-country, multi-year."""
+    ind_cols = result.indicator_cols
+    if len(ind_cols) < 2:
+        raise ValueError("correlation_temporal spec requires 2 indicator columns")
+
+    x_col, y_col = ind_cols[0], ind_cols[1]
+    lab = indicator_labels or {}
+    x_label = lab.get(x_col, x_col.replace("_", " ").title())
+    y_label = lab.get(y_col, y_col.replace("_", " ").title())
+
+    rows = df.dropna(subset=[x_col, y_col]).to_dict(orient="records")
+    color_dim = result.color_dim or "country"
+
+    # Layer: lines + points
+    base_enc: dict = {
+        "x": {
+            "field": x_col,
+            "type": "quantitative",
+            "axis": _axis_style(x_label),
+            "scale": {"zero": False},
+        },
+        "y": {
+            "field": y_col,
+            "type": "quantitative",
+            "axis": _axis_style(y_label),
+            "scale": {"zero": False},
+        },
+        "color": _color_encoding(color_dim),
+        "order": {"field": "year", "type": "temporal"},
+        "tooltip": build_structured_tooltips(list(df.columns), "line", lab),
+    }
+
+    spec: dict = {
+        "$schema": _vl_schema(),
+        "title": title,
+        "data": {"values": rows},
+        "layer": [
+            {
+                "mark": {"type": "line", "strokeWidth": 2, "opacity": 0.6},
+                "encoding": {k: v for k, v in base_enc.items() if k != "tooltip"},
+            },
+            {
+                "mark": {"type": "circle", "size": 40, "opacity": 0.9},
+                "encoding": base_enc,
+            },
+        ],
+        "width": 550,
+        "height": 450,
+    }
+    return inject_wb_config(spec)
+
+
+def build_temporal_multi_indicator_spec(
+    df: pd.DataFrame,
+    title: str,
+    result: StrategyResult,
+    indicator_labels: dict[str, str] | None = None,
+    y_label: str = "Value",
+) -> dict:
+    """Layered dual-axis line chart: 2-3 indicators, 1 country, multi-year.
+
+    Uses Vega-Lite layer + independent y-scale resolution.
+    Each indicator gets its own y-axis with the indicator name as the label.
+    """
+    ind_cols = result.indicator_cols
+    if not ind_cols:
+        raise ValueError("temporal_multi_indicator spec requires indicator_cols")
+
+    lab = indicator_labels or {}
+    rows = df.to_dict(orient="records")
+
+    layers = []
+    for i, col in enumerate(ind_cols):
+        color = WB_CAT_COLORS[i % len(WB_CAT_COLORS)]
+        y_label = lab.get(col, col.replace("_", " ").title())
+        layer_enc: dict = {
+            "x": {
+                "field": "year",
+                "type": "temporal",
+                "axis": _axis_style(temporal=True),
+            },
+            "y": {
+                "field": col,
+                "type": "quantitative",
+                "axis": {**_axis_style(y_label), "titleColor": color},
+                "scale": {"zero": False},
+            },
+            "color": {"value": color},
+            "tooltip": build_structured_tooltips(list(df.columns), "line", lab),
+        }
+        layers.append(
+            {
+                "mark": {
+                    "type": "line",
+                    "strokeWidth": 3,
+                    "strokeCap": "round",
+                    "color": color,
+                },
+                "encoding": layer_enc,
+            }
+        )
+
+    spec: dict = {
+        "$schema": _vl_schema(),
+        "title": title,
+        "data": {"values": rows},
+        "layer": layers,
+        "resolve": {"scale": {"y": "independent"}},
+        "width": 620,
+        "height": 380,
+    }
+    return inject_wb_config(spec)
+
+
+def build_fallback_line_spec(
+    df: pd.DataFrame,
+    title: str,
+    result: StrategyResult,
+    indicator_labels: dict[str, str] | None = None,
+    y_label: str = "Value",
+) -> dict:
+    """Fallback: best-effort line chart for unclassified data shapes."""
+    cols = set(df.columns)
+    x_col = (
+        "year"
+        if "year" in cols
+        else ("time_period" if "time_period" in cols else df.columns[0])
+    )
+    y_col = (
+        "value"
+        if "value" in cols
+        else ("obs_value" if "obs_value" in cols else df.columns[-1])
+    )
+
+    encoding: dict = {
+        "x": {
+            "field": x_col,
+            "type": "temporal" if "year" in x_col else "ordinal",
+            "axis": _axis_style(temporal=("year" in x_col)),
+        },
+        "y": {"field": y_col, "type": "quantitative", "axis": _axis_style("Value")},
+        "tooltip": build_structured_tooltips(
+            list(df.columns), "line", indicator_labels
+        ),
+    }
+    if result.color_dim and result.color_dim in cols:
+        encoding["color"] = _color_encoding(result.color_dim)
+
+    spec: dict = {
+        "$schema": _vl_schema(),
+        "title": title,
+        "data": {"values": df.to_dict(orient="records")},
+        "mark": {"type": "line", "strokeWidth": 3, "strokeCap": "round"},
+        "encoding": encoding,
+        "width": 600,
+        "height": 350,
+    }
+    return inject_wb_config(spec)
+
+
+# Dispatch table: strategy → builder function
+STRATEGY_BUILDERS: dict[ChartStrategy, callable] = {
+    ChartStrategy.TEMPORAL_SINGLE: build_temporal_single_spec,
+    ChartStrategy.CROSS_SECTIONAL: build_cross_sectional_spec,
+    ChartStrategy.DISTRIBUTION: build_distribution_spec,
+    ChartStrategy.BREAKDOWN_COMPARISON: build_breakdown_comparison_spec,
+    ChartStrategy.SMALL_MULTIPLES: build_small_multiples_spec,
+    ChartStrategy.CORRELATION: build_correlation_spec,
+    ChartStrategy.CORRELATION_TEMPORAL: build_correlation_temporal_spec,
+    ChartStrategy.TEMPORAL_MULTI_IND: build_temporal_multi_indicator_spec,
+    ChartStrategy.FALLBACK_LINE: build_fallback_line_spec,
+}
+
+
+def dispatch_spec(
+    strategy: ChartStrategy,
+    df: pd.DataFrame,
+    title: str,
+    result: StrategyResult,
+    indicator_labels: dict[str, str] | None = None,
+    y_label: str = "Value",
+    x_label: str = "Value",
+) -> dict:
+    """Call the right spec builder for the given strategy."""
+    builder = STRATEGY_BUILDERS[strategy]
+    # Builders with x/y label parameters
+    if strategy in (
+        ChartStrategy.TEMPORAL_SINGLE,
+        ChartStrategy.TEMPORAL_MULTI_IND,
+        ChartStrategy.BREAKDOWN_COMPARISON,
+        ChartStrategy.SMALL_MULTIPLES,
+        ChartStrategy.FALLBACK_LINE,
+    ):
+        return builder(df, title, result, indicator_labels, y_label)
+    elif strategy in (ChartStrategy.CROSS_SECTIONAL, ChartStrategy.DISTRIBUTION):
+        return builder(df, title, result, indicator_labels, x_label)
+    else:
+        return builder(df, title, result, indicator_labels)
+
+
+# ============================================================================
+# HIGH-CARDINALITY THRESHOLDS
+# ============================================================================
+
+HIGH_CARDINALITY_THRESHOLDS: dict[str, int] = {
+    "line_max_series": 8,
+    "beeswarm_threshold": 8,
+    "facet_threshold": 4,
+    "top_n_series": 12,
+}
+
+
+# Keep legacy aliases for backward compat with existing tests
+def should_use_beeswarm(
+    viz_data: pd.DataFrame,
+    chart_type: str | None = None,
+    color_dim: str | None = None,
+) -> bool:
+    if color_dim is None or color_dim not in viz_data.columns:
+        return False
+    if chart_type and chart_type not in (None, "line", "area"):
+        return False
+    series_count = viz_data[color_dim].nunique()
+    year_count = viz_data["year"].nunique() if "year" in viz_data.columns else 0
+    return (
+        series_count > HIGH_CARDINALITY_THRESHOLDS["beeswarm_threshold"]
+        and year_count <= 1
+    )
+
+
+def build_beeswarm_spec(
+    viz_data: pd.DataFrame,
+    title: str,
+    value_col: str = "value",
+    color_col: str = "country",
+) -> dict:
+    """Legacy alias → delegates to build_distribution_spec."""
+    r = StrategyResult(ChartStrategy.DISTRIBUTION, "beeswarm", color_dim=color_col)
+    # rename value_col if needed
+    df = viz_data.copy()
+    if value_col != "value" and value_col in df.columns:
+        df = df.rename(columns={value_col: "value"})
+    return build_distribution_spec(df, title, r)
+
+
+# ============================================================================
+# FREQUENCY / CHART TYPE MAPPINGS (unchanged from original)
+# ============================================================================
+
+FREQUENCY_TO_TIMEUNIT: dict[str, str] = {
+    "A": "year",
+    "M": "yearmonth",
+    "Q": "yearquarter",
+}
+
 PERIODICITY_KEYWORDS: dict[str, list[str]] = {
     "A": ["annual", "yearly"],
     "M": ["month", "monthly"],
     "Q": ["quarter", "quarterly"],
 }
 
-
-# ============================================================================
-# CHART TYPE MAPPINGS
-# ============================================================================
-
-# Map user-friendly chart type hints to Vega-Lite mark types
 CHART_TYPE_KEYWORDS: dict[str, list[str]] = {
-    "line": ["line", "trend", "time series"],
-    "bar": ["bar", "column", "histogram"],
-    "point": ["scatter", "point", "dot"],
-    "area": ["area", "filled"],
-    "tick": ["tick"],
+    "line": ["line", "trend", "time series", "over time"],
+    "bar": ["bar", "column", "ranking", "compare", "histogram"],
+    "point": ["scatter", "point", "dot", "correlation", "bubble"],
+    "area": ["area", "filled", "cumulative", "stacked"],
+    "tick": ["tick", "strip", "beeswarm", "distribution"],
 }
+DEFAULT_CHART_TYPE: str = "line"
 
-DEFAULT_CHART_TYPE: str = "line"  # Default for time series data
+
+def parse_chart_type_hint(chart_type: str | None) -> str:
+    if not chart_type:
+        return DEFAULT_CHART_TYPE
+    hint = chart_type.lower().strip()
+    for mark_type, keywords in CHART_TYPE_KEYWORDS.items():
+        if any(keyword in hint for keyword in keywords):
+            return mark_type
+    return DEFAULT_CHART_TYPE
+
+
+def infer_frequency_from_periodicity(periodicity: str) -> str | None:
+    pl = periodicity.lower()
+    for code, kws in PERIODICITY_KEYWORDS.items():
+        if any(kw in pl for kw in kws):
+            return code
+    return None
+
+
+def should_use_temporal_x_axis(
+    viz_data: pd.DataFrame, chart_type: str | None, available_dimensions: list[str]
+) -> tuple[bool, str | None]:
+    if "year" not in available_dimensions:
+        return False, _select_categorical_dimension(available_dimensions)
+    year_count = viz_data["year"].nunique() if "year" in viz_data.columns else 0
+    if year_count > 1:
+        return True, None
+    mark_type = parse_chart_type_hint(chart_type) if chart_type else "line"
+    pref = {"tick": 1.0, "point": 0.7, "bar": 0.5, "line": 0.2, "area": 0.1}
+    cat_field = _select_categorical_dimension(available_dimensions)
+    if cat_field is None:
+        return True, None
+    if pref.get(mark_type, 0.5) >= 0.5:
+        return False, cat_field
+    return True, None
+
+
+def _select_categorical_dimension(available_dimensions: list[str]) -> str | None:
+    for dim in ["country", "sex", "age", "urbanisation", "education", "income_group"]:
+        if dim in available_dimensions:
+            return dim
+    for dim in available_dimensions:
+        if dim not in ["year", "value", "time_period", "obs_value"]:
+            return dim
+    return None
 
 
 # ============================================================================
-# DATA PREPARATION RULES
+# DATA PREPARATION RULES (unchanged)
 # ============================================================================
+
 
 @dataclass
 class DataPreparationRule:
-    """Rule for how to prepare temporal data based on chart type and frequency."""
-
     chart_type: str
     frequency: str | None
     action: Literal["year_strings", "datetime"]
     description: str
 
 
-# Rules are evaluated in order; first match wins
 DATA_PREPARATION_RULES: list[DataPreparationRule] = [
     DataPreparationRule(
-        chart_type="bar",
-        frequency="A",
-        action="year_strings",
-        description="Bar charts with annual data use year strings for discrete display"
+        "bar", "A", "year_strings", "Bar charts with annual data use year strings"
     ),
-    # Default: all other cases use datetime
-    DataPreparationRule(
-        chart_type="*",  # Wildcard
-        frequency="*",   # Wildcard
-        action="datetime",
-        description="Default: use datetime for temporal encoding"
-    ),
+    DataPreparationRule("*", "*", "datetime", "Default: datetime"),
 ]
 
 
+def get_data_preparation_action(
+    chart_type: str, frequency: str | None
+) -> Literal["year_strings", "datetime"]:
+    for rule in DATA_PREPARATION_RULES:
+        if (rule.chart_type == "*" or rule.chart_type == chart_type) and (
+            rule.frequency == "*" or rule.frequency == frequency
+        ):
+            return rule.action
+    return "datetime"
+
+
+def should_prepare_as_datetime(
+    viz_data: pd.DataFrame, chart_type: str, frequency: str | None
+) -> bool:
+    return get_data_preparation_action(chart_type, frequency) == "datetime"
+
+
 # ============================================================================
-# POST-PROCESSING RULES
+# POST-PROCESSING RULES (kept for backward compat with existing Draco path)
 # ============================================================================
+
 
 @dataclass
 class PostProcessingRule:
-    """Rule for post-processing Vega-Lite specs after Draco generation."""
-
     name: str
     applies_to_mark_types: list[str]
     description: str
 
     def should_apply(self, mark_type: str, encoding: dict, data: dict) -> bool:
-        """Override in subclasses to determine if rule should apply."""
         raise NotImplementedError
 
     def apply(self, spec: dict, data_frequency: str | None = None) -> dict:
-        """Override in subclasses to apply the transformation."""
         raise NotImplementedError
 
 
 class OrdinalToTemporalRule(PostProcessingRule):
-    """Convert ordinal x-axis to temporal for non-bar charts with datetime data."""
-
     def __init__(self):
         super().__init__(
-            name="ordinal_to_temporal",
-            applies_to_mark_types=["line", "area", "point", "tick"],
-            description="Fix Draco's preference for ordinal on stacked charts"
+            "ordinal_to_temporal",
+            ["line", "area", "point", "tick"],
+            "Fix ordinal→temporal for time fields",
         )
 
-    def should_apply(self, mark_type: str, x_encoding: dict, dataset: list[dict]) -> bool:
-        """Check if we should convert ordinal to temporal."""
+    def should_apply(self, mark_type, x_enc, dataset):
         if mark_type not in self.applies_to_mark_types:
             return False
-
-        if x_encoding.get("type") != "ordinal":
+        if x_enc.get("type") != "ordinal":
             return False
-
-        x_field = x_encoding.get("field")
+        x_field = x_enc.get("field")
         if x_field not in ["year", "time_period"]:
             return False
-
-        # Check if data has datetime values
         if dataset and x_field in dataset[0]:
-            sample_value = dataset[0][x_field]
-            # Datetime strings contain "T"
-            return isinstance(sample_value, str) and "T" in sample_value
-
+            return isinstance(dataset[0][x_field], str) and "T" in dataset[0][x_field]
         return False
 
-    def apply(self, spec: dict, data_frequency: str | None = None) -> dict:
-        """Apply the ordinal->temporal conversion."""
-        mark_type = spec.get("mark", {}).get("type") if isinstance(spec.get("mark"), dict) else spec.get("mark")
-
+    def apply(self, spec, data_frequency=None):
+        mark_type = (
+            spec.get("mark", {}).get("type")
+            if isinstance(spec.get("mark"), dict)
+            else spec.get("mark")
+        )
         if "encoding" not in spec or "x" not in spec["encoding"]:
             return spec
-
         x_enc = spec["encoding"]["x"]
-
-        # Get dataset
-        dataset_name = spec.get("data", {}).get("name")
-        if not dataset_name or "datasets" not in spec:
+        ds_name = spec.get("data", {}).get("name")
+        if not ds_name or "datasets" not in spec:
             return spec
-
-        dataset = spec["datasets"].get(dataset_name, [])
-
+        dataset = spec["datasets"].get(ds_name, [])
         if self.should_apply(mark_type, x_enc, dataset):
             x_enc["type"] = "temporal"
-
         return spec
 
 
 class ApplyTimeUnitRule(PostProcessingRule):
-    """Apply frequency-aware timeUnit to temporal encodings."""
-
     def __init__(self):
         super().__init__(
-            name="apply_timeunit",
-            applies_to_mark_types=["line", "area", "point", "tick"],
-            description="Add timeUnit based on data frequency"
+            "apply_timeunit",
+            ["line", "area", "point", "tick"],
+            "Add timeUnit from frequency",
         )
 
-    def should_apply(self, x_encoding: dict, data_frequency: str | None) -> bool:
-        """Check if we should apply timeUnit."""
-        return (
-            data_frequency is not None
-            and data_frequency in FREQUENCY_TO_TIMEUNIT
-            and x_encoding.get("type") == "temporal"
-        )
+    def should_apply(self, x_enc, freq):
+        return freq in FREQUENCY_TO_TIMEUNIT and x_enc.get("type") == "temporal"
 
-    def apply(self, spec: dict, data_frequency: str | None = None) -> dict:
-        """Apply timeUnit to x-axis encoding."""
+    def apply(self, spec, data_frequency=None):
         if "encoding" not in spec or "x" not in spec["encoding"]:
             return spec
-
         x_enc = spec["encoding"]["x"]
-
         if self.should_apply(x_enc, data_frequency):
             x_enc["timeUnit"] = FREQUENCY_TO_TIMEUNIT[data_frequency]
-
         return spec
 
 
 class FixPointChartEncodingsRule(PostProcessingRule):
-    """Fix common Draco issues with point charts (ordinal y-axis, meaningless size)."""
-
     def __init__(self):
         super().__init__(
-            name="fix_point_chart_encodings",
-            applies_to_mark_types=["point"],
-            description="Fix ordinal y-axis and remove meaningless size encodings"
+            "fix_point_chart_encodings",
+            ["point"],
+            "Fix ordinal y-axis and pointless size",
         )
 
-    def should_apply(self, spec: dict, data_frequency: str | None = None) -> bool:
-        """Apply to point charts."""
-        mark_type = spec.get("mark", {}).get("type") if isinstance(spec.get("mark"), dict) else spec.get("mark")
+    def should_apply(self, spec, data_frequency=None):
+        mark_type = (
+            spec.get("mark", {}).get("type")
+            if isinstance(spec.get("mark"), dict)
+            else spec.get("mark")
+        )
         return mark_type == "point"
 
-    def apply(self, spec: dict, data_frequency: str | None = None) -> dict:
-        """Fix point chart encoding issues."""
-        if not self.should_apply(spec, data_frequency):
+    def apply(self, spec, data_frequency=None):
+        if not self.should_apply(spec):
             return spec
-
         if "encoding" not in spec:
             return spec
-
-        # Fix 1: Convert ordinal y-axis to quantitative if field is 'value'
-        if "y" in spec["encoding"]:
-            y_enc = spec["encoding"]["y"]
-            if y_enc.get("type") == "ordinal" and y_enc.get("field") == "value":
-                y_enc["type"] = "quantitative"
-                # Ensure proper scale
-                if "scale" not in y_enc:
-                    y_enc["scale"] = {"type": "linear", "zero": True}
-
-        # Fix 2: Remove meaningless size:count encoding
-        # (This happens when Draco can't find a good size mapping)
-        if "size" in spec["encoding"]:
-            size_enc = spec["encoding"]["size"]
-            # If size is just aggregate count with no field, remove it
-            if size_enc.get("aggregate") == "count" and "field" not in size_enc:
-                del spec["encoding"]["size"]
-
+        y = spec["encoding"].get("y", {})
+        if y.get("type") == "ordinal" and y.get("field") == "value":
+            y["type"] = "quantitative"
+            y.setdefault("scale", {})["type"] = "linear"
+        sz = spec["encoding"].get("size", {})
+        if sz.get("aggregate") == "count" and "field" not in sz:
+            del spec["encoding"]["size"]
         return spec
 
 
-# Registry of post-processing rules (applied in order)
+class TemporalAxisCleanupRule(PostProcessingRule):
+    def __init__(self):
+        super().__init__(
+            "temporal_axis_cleanup",
+            ["line", "area", "point"],
+            "Remove title from temporal x-axis",
+        )
+
+    def should_apply(self, spec, data_frequency=None):
+        mark_type = (
+            spec.get("mark", {}).get("type")
+            if isinstance(spec.get("mark"), dict)
+            else spec.get("mark")
+        )
+        if mark_type not in self.applies_to_mark_types:
+            return False
+        return spec.get("encoding", {}).get("x", {}).get("type") == "temporal"
+
+    def apply(self, spec, data_frequency=None):
+        if not self.should_apply(spec):
+            return spec
+        x = spec["encoding"]["x"]
+        x.setdefault("axis", {})
+        x["axis"]["title"] = None
+        x["axis"].setdefault("format", "%Y")
+        x["axis"].setdefault("tickCount", 6)
+        return spec
+
+
+class ZeroLineRule(PostProcessingRule):
+    def __init__(self):
+        super().__init__(
+            "zero_line", ["bar", "line", "area"], "Bar charts start at zero"
+        )
+
+    def should_apply(self, spec, data_frequency=None):
+        mark_type = (
+            spec.get("mark", {}).get("type")
+            if isinstance(spec.get("mark"), dict)
+            else spec.get("mark")
+        )
+        return mark_type in self.applies_to_mark_types
+
+    def apply(self, spec, data_frequency=None):
+        if not self.should_apply(spec):
+            return spec
+        y = spec.get("encoding", {}).get("y", {})
+        if y.get("type") == "quantitative":
+            y.setdefault("scale", {})
+            mark_type = (
+                spec.get("mark", {}).get("type")
+                if isinstance(spec.get("mark"), dict)
+                else spec.get("mark")
+            )
+            if mark_type == "bar":
+                y["scale"]["zero"] = True
+        return spec
+
+
+class ApplyWBStyleRule(PostProcessingRule):
+    def __init__(self):
+        super().__init__("apply_wb_style", ["*"], "Inject WB style config")
+
+    def should_apply(self, spec, data_frequency=None):
+        return True
+
+    def apply(self, spec, data_frequency=None):
+        return inject_wb_config(spec)
+
+
 POST_PROCESSING_RULES: list[PostProcessingRule] = [
     OrdinalToTemporalRule(),
     ApplyTimeUnitRule(),
     FixPointChartEncodingsRule(),
+    TemporalAxisCleanupRule(),
+    ZeroLineRule(),
+    ApplyWBStyleRule(),
 ]
 
 
+# ============================================================================
+# DRACO CONSTRAINT CONFIG (unchanged)
+# ============================================================================
 
-# ============================================================================
-# DRACO CONSTRAINT CONFIGURATION
-# ============================================================================
 
 @dataclass
 class DracoConstraintConfig:
-    """Configuration for Draco constraint generation."""
-
-    # Base constraints always applied
     base_constraints: list[str]
-
-    # Fields that should be mapped to nominal color encoding
     nominal_color_fields: list[str]
-
-    # Priority order for color dimension selection
     color_dimension_priority: list[str]
 
     def __init__(self):
-        self.base_constraints = [
-            "entity(view,root,view).",
-            "entity(mark,view,m).",
-        ]
-
-        self.nominal_color_fields = [
-            "country",
-            "sex",
-            "urbanisation",
-            "ref_area",
-        ]
-
-        self.color_dimension_priority = [
-            "country",
-            "sex",
-            "age",
-            "urbanisation",
-        ]
+        self.base_constraints = ["entity(view,root,view).", "entity(mark,view,m)."]
+        self.nominal_color_fields = ["country", "sex", "urbanisation", "ref_area"]
+        self.color_dimension_priority = ["country", "sex", "age", "urbanisation"]
 
 
-# Default configuration instance
 DEFAULT_DRACO_CONFIG = DracoConstraintConfig()
-
-
-# ============================================================================
-# HELPER FUNCTIONS
-# ============================================================================
-
-def parse_chart_type_hint(chart_type: str | None) -> str:
-    """
-    Parse user's chart type hint into Vega-Lite mark type.
-
-    Args:
-        chart_type: User's hint like "line chart", "bar", "scatter", etc.
-
-    Returns:
-        Vega-Lite mark type, defaults to DEFAULT_CHART_TYPE
-    """
-    if not chart_type:
-        return DEFAULT_CHART_TYPE
-
-    hint = chart_type.lower().strip()
-
-    for mark_type, keywords in CHART_TYPE_KEYWORDS.items():
-        if any(keyword in hint for keyword in keywords):
-            return mark_type
-
-    return DEFAULT_CHART_TYPE
-
-
-def get_data_preparation_action(chart_type: str, frequency: str | None) -> Literal["year_strings", "datetime"]:
-    """
-    Determine how to prepare temporal data based on chart type and frequency.
-
-    Args:
-        chart_type: Vega-Lite mark type (line, bar, area, etc.)
-        frequency: Data frequency code (A, M, Q, etc.)
-
-    Returns:
-        Action to take: "year_strings" or "datetime"
-    """
-    for rule in DATA_PREPARATION_RULES:
-        # Check if rule matches
-        type_match = rule.chart_type == "*" or rule.chart_type == chart_type
-        freq_match = rule.frequency == "*" or rule.frequency == frequency
-
-        if type_match and freq_match:
-            return rule.action
-
-    # Fallback (should never reach here with current rules)
-    return "datetime"
-
-
-def infer_frequency_from_periodicity(periodicity: str) -> str | None:
-    """
-    Infer frequency code from periodicity text (fallback method).
-
-    Args:
-        periodicity: Periodicity text from metadata
-
-    Returns:
-        Frequency code (A, M, Q) or None
-    """
-    periodicity_lower = periodicity.lower()
-
-    for freq_code, keywords in PERIODICITY_KEYWORDS.items():
-        if any(keyword in periodicity_lower for keyword in keywords):
-            return freq_code
-
-    return None
-
-
-def should_prepare_as_datetime(viz_data: pd.DataFrame, chart_type: str, frequency: str | None) -> bool:
-    """
-    Determine if time_period column should be prepared as datetime vs year strings.
-
-    Args:
-        viz_data: Visualization dataframe
-        chart_type: Vega-Lite mark type
-        frequency: Data frequency code
-
-    Returns:
-        True if should convert to datetime, False if should convert to year strings
-    """
-    action = get_data_preparation_action(chart_type, frequency)
-    return action == "datetime"
-
-
-# ============================================================================
-# SMART AXIS SELECTION
-# ============================================================================
-
-def should_use_temporal_x_axis(
-    viz_data: pd.DataFrame,
-    chart_type: str | None,
-    available_dimensions: list[str]
-) -> tuple[bool, str | None]:
-    """
-    Determine if x-axis should use temporal (year) or categorical dimension.
-
-    This enables cross-sectional comparisons (single year, multiple countries)
-    while maintaining backward compatibility with time-series visualizations.
-
-    Args:
-        viz_data: Visualization dataframe
-        chart_type: Vega-Lite mark type (line, bar, point, tick, area)
-        available_dimensions: List of available column names
-
-    Returns:
-        Tuple of (use_temporal, categorical_field_suggestion)
-        - use_temporal: True if year should be on x-axis
-        - categorical_field_suggestion: Suggested categorical field if not temporal
-
-    Examples:
-        >>> # Multi-year time series
-        >>> should_use_temporal_x_axis(df_2020_2024, "line", ["year", "country", "value"])
-        (True, None)
-
-        >>> # Single year, multiple countries
-        >>> should_use_temporal_x_axis(df_2024_only, "bar", ["year", "country", "value"])
-        (False, "country")
-
-        >>> # Tick chart with single year
-        >>> should_use_temporal_x_axis(df_2024_only, "tick", ["year", "country", "value"])
-        (False, "country")
-    """
-
-    # If no year column, can't use temporal
-    if "year" not in available_dimensions:
-        # Try to find a good categorical dimension
-        return False, _select_categorical_dimension(available_dimensions)
-
-    # Check year cardinality
-    year_unique_count = viz_data["year"].nunique() if "year" in viz_data.columns else 0
-
-    # Multiple years → strong signal for time series
-    if year_unique_count > 1:
-        return True, None
-
-    # Single year → consider alternatives based on chart type and available dimensions
-
-    # Parse chart type
-    mark_type = parse_chart_type_hint(chart_type) if chart_type else "line"
-
-    # Chart type preferences
-    # line/area: Strongly prefer temporal (even with single year, might want to show trend)
-    # bar: Context-dependent (could be temporal or categorical)
-    # point: Flexible (works well with both)
-    # tick: Strongly prefer categorical (designed for distribution)
-
-    categorical_preference_by_type = {
-        "tick": 1.0,     # Strong preference for categorical
-        "point": 0.7,    # Moderate preference for categorical
-        "bar": 0.5,      # Neutral
-        "line": 0.2,     # Weak preference for categorical
-        "area": 0.1,     # Very weak preference for categorical
-    }
-
-    categorical_score = categorical_preference_by_type.get(mark_type, 0.5)
-
-    # Check if we have good categorical dimensions
-    categorical_field = _select_categorical_dimension(available_dimensions)
-
-    if categorical_field is None:
-        # No categorical dimension available, stick with year
-        return True, None
-
-    # If we have a categorical dimension with decent cardinality and chart type suggests it
-    if categorical_score >= 0.5:
-        # Prefer categorical
-        return False, categorical_field
-
-    # Default to temporal for line/area charts
-    return True, None
-
-
-def _select_categorical_dimension(available_dimensions: list[str]) -> str | None:
-    """
-    Select the most appropriate categorical dimension for x-axis.
-
-    Priority order: country > sex > age > urbanisation > other
-
-    Args:
-        available_dimensions: List of available column names
-
-    Returns:
-        Selected categorical field or None
-    """
-    # Priority order for categorical dimensions
-    priority_order = ["country", "sex", "age", "urbanisation", "education", "income_group"]
-
-    for dim in priority_order:
-        if dim in available_dimensions:
-            return dim
-
-    # Fallback: any non-value, non-year column
-    for dim in available_dimensions:
-        if dim not in ["year", "value", "time_period", "obs_value"]:
-            return dim
-
-    return None

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,11 +1,13 @@
 """Tests for data360.visualization module."""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import numpy as np
 import pandas as pd
 import pytest
 
-from data360.visualization import get_viz_spec
+from data360.visualization import _vega_spec_to_json_safe, get_viz_spec
 
 
 class TestGetVizSpecDracoFallbackWarning:
@@ -87,8 +89,10 @@ class TestGetVizSpecDracoFallbackWarning:
         mock_vl_spec = {
             "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
             "mark": "point",
-            "encoding": {"x": {"field": "year", "type": "temporal"},
-                         "y": {"field": "value", "type": "quantitative"}},
+            "encoding": {
+                "x": {"field": "year", "type": "temporal"},
+                "y": {"field": "value", "type": "quantitative"},
+            },
         }
         # Chain: chart.properties(...).interactive().encode(...).to_dict()
         mock_chart.properties.return_value = mock_chart
@@ -106,7 +110,9 @@ class TestGetVizSpecDracoFallbackWarning:
             draco_instance.complete_spec.return_value = iter([fake_model])
             MockDraco.return_value = draco_instance
 
-            mock_as2d.return_value = {"view": [{"mark": [{"type": "point", "encoding": []}]}]}
+            mock_as2d.return_value = {
+                "view": [{"mark": [{"type": "point", "encoding": []}]}]
+            }
 
             renderer_instance = MagicMock()
             renderer_instance.render.return_value = mock_chart
@@ -125,16 +131,17 @@ class TestGetVizSpecDracoFallbackWarning:
 
     @pytest.mark.asyncio
     async def test_fallback_also_fails_returns_error(self, patches):
-        """When both Draco and the manual fallback fail, an error is returned."""
+        """When both Draco and the dispatch_spec fallback fail, an error is returned."""
         with (
             patch("data360.visualization.Draco") as MockDraco,
-            patch("data360.visualization.alt") as MockAlt,
+            patch(
+                "data360.viz_config.dispatch_spec",
+                side_effect=RuntimeError("dispatch broke"),
+            ),
         ):
             draco_instance = MagicMock()
             draco_instance.complete_spec.return_value = iter([])
             MockDraco.return_value = draco_instance
-
-            MockAlt.Chart.side_effect = RuntimeError("Altair broke")
 
             result = await get_viz_spec(
                 database_id="WB_WDI",
@@ -143,4 +150,421 @@ class TestGetVizSpecDracoFallbackWarning:
 
         assert result["url"] is None
         assert result["error"] is not None
-        assert "fallback failed" in result["error"].lower()
+        assert "fallback" in result["error"].lower()
+
+
+# =============================================================================
+# New tests for improvements: MCP-002, MCP-003, MCP-004 + WB style + null guard
+# =============================================================================
+
+import math
+
+from data360 import viz_config
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helper: small fixture factory
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _make_df(n_countries=3, n_years=5, single_year=False):
+    """Return a tidy DataFrame with country / year / value columns."""
+
+    countries = [f"CTR{i:02d}" for i in range(n_countries)]
+    years = (
+        ["2020-01-01"] if single_year else [f"{2020 + i}-01-01" for i in range(n_years)]
+    )
+    rows = [
+        {"country": c, "year": y, "value": float(i * 10 + j)}
+        for i, c in enumerate(countries)
+        for j, y in enumerate(years)
+    ]
+    df = pd.DataFrame(rows)
+    df["year"] = pd.to_datetime(df["year"])
+    return df
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MCP-002  Structured tooltips
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestStructuredTooltips:
+    """Tooltips must be typed objects, not raw column name strings."""
+
+    def test_value_tooltip_has_number_format(self):
+        tips = viz_config.build_structured_tooltips(
+            ["year", "value", "country"], "line"
+        )
+        value_tip = next(t for t in tips if t["field"] == "value")
+        assert value_tip["format"] == ",.2f", "Value tooltip must use number formatting"
+        assert value_tip["type"] == "quantitative"
+
+    def test_year_tooltip_has_temporal_type(self):
+        tips = viz_config.build_structured_tooltips(["year", "value"], "line")
+        year_tip = next(t for t in tips if t["field"] == "year")
+        assert year_tip["type"] == "temporal"
+        assert year_tip["format"] == "%Y"
+
+    def test_country_tooltip_is_nominal(self):
+        tips = viz_config.build_structured_tooltips(["country", "value"], "bar")
+        country_tip = next(t for t in tips if t["field"] == "country")
+        assert country_tip["type"] == "nominal"
+
+    def test_priority_order_year_first(self):
+        tips = viz_config.build_structured_tooltips(
+            ["value", "country", "year"], "line"
+        )
+        fields = [t["field"] for t in tips]
+        assert fields.index("year") < fields.index("value"), "year must precede value"
+        assert fields.index("value") < fields.index("country"), (
+            "value must precede country"
+        )
+
+    def test_unknown_column_gets_title_cased_label(self):
+        tips = viz_config.build_structured_tooltips(["some_custom_col"], "bar")
+        assert tips[0]["title"] == "Some Custom Col"
+
+    def test_apply_structured_tooltips_injects_into_spec(self):
+        spec = {"mark": "line", "encoding": {"x": {"field": "year"}}}
+        result = viz_config.apply_structured_tooltips(spec, ["year", "value"], "line")
+        assert "tooltip" in result["encoding"]
+        assert isinstance(result["encoding"]["tooltip"], list)
+        assert all(isinstance(t, dict) for t in result["encoding"]["tooltip"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MCP-003  High-cardinality beeswarm routing
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestHighCardinalityChartSelection:
+    """Above threshold + single year → beeswarm; below threshold → normal."""
+
+    def _df(self, n_countries, single_year=True):
+        return _make_df(n_countries=n_countries, single_year=single_year)
+
+    def test_above_threshold_single_year_triggers_beeswarm(self):
+        df = self._df(n_countries=12, single_year=True)
+        assert viz_config.should_use_beeswarm(df, chart_type=None, color_dim="country")
+
+    def test_below_threshold_does_not_trigger_beeswarm(self):
+        df = self._df(n_countries=5, single_year=True)
+        assert not viz_config.should_use_beeswarm(
+            df, chart_type=None, color_dim="country"
+        )
+
+    def test_above_threshold_multi_year_does_not_trigger(self):
+        df = self._df(n_countries=15, single_year=False)
+        assert not viz_config.should_use_beeswarm(
+            df, chart_type=None, color_dim="country"
+        )
+
+    def test_explicit_bar_chart_type_does_not_trigger_beeswarm(self):
+        df = self._df(n_countries=20, single_year=True)
+        assert not viz_config.should_use_beeswarm(
+            df, chart_type="bar", color_dim="country"
+        )
+
+    def test_beeswarm_spec_uses_tick_mark(self):
+        df = self._df(n_countries=15, single_year=True)
+        spec = viz_config.build_beeswarm_spec(df, title="Test Chart")
+        mark = spec["mark"]
+        mark_type = mark["type"] if isinstance(mark, dict) else mark
+        assert mark_type == "tick", f"Expected tick mark for beeswarm, got {mark_type}"
+
+    def test_beeswarm_spec_sorts_y_by_value(self):
+        df = self._df(n_countries=15, single_year=True)
+        spec = viz_config.build_beeswarm_spec(df, title="Test")
+        assert spec["encoding"]["y"]["sort"] == "-x"
+
+    def test_beeswarm_spec_limits_to_top_n(self):
+        top_n = viz_config.HIGH_CARDINALITY_THRESHOLDS["top_n_series"]
+        df = _make_df(n_countries=top_n + 10, single_year=True)
+        spec = viz_config.build_beeswarm_spec(df, title="Test")
+        assert len(spec["data"]["values"]) <= top_n
+
+    def test_beeswarm_spec_includes_structured_tooltips(self):
+        df = self._df(n_countries=15, single_year=True)
+        spec = viz_config.build_beeswarm_spec(df, title="Test")
+        assert "tooltip" in spec["encoding"]
+        tips = spec["encoding"]["tooltip"]
+        assert all(isinstance(t, dict) for t in tips), (
+            "Tooltips must be dicts, not strings"
+        )
+
+    def test_beeswarm_spec_uses_wb_color_palette(self):
+        df = self._df(n_countries=15, single_year=True)
+        spec = viz_config.build_beeswarm_spec(df, title="Test")
+        color_range = spec["encoding"]["color"]["scale"]["range"]
+        assert color_range == viz_config.WB_CAT_COLORS
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# WB Style injection
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestWBStyleInjection:
+    """Every spec must receive WB color palette, typography, and grid settings."""
+
+    def test_inject_adds_config_when_absent(self):
+        spec = {"mark": "line"}
+        result = viz_config.inject_wb_config(spec)
+        assert "config" in result
+
+    def test_inject_sets_wb_category_colors(self):
+        spec = {"mark": "line"}
+        result = viz_config.inject_wb_config(spec)
+        assert result["config"]["range"]["category"] == viz_config.WB_CAT_COLORS
+
+    def test_inject_sets_grid_color(self):
+        spec = {"mark": "line"}
+        result = viz_config.inject_wb_config(spec)
+        assert result["config"]["axis"]["gridColor"] == viz_config.WB_GRID_COLOR
+
+    def test_inject_sets_font_family(self):
+        spec = {"mark": "line"}
+        result = viz_config.inject_wb_config(spec)
+        assert "Noto Sans" in result["config"]["font"]
+
+    def test_inject_does_not_overwrite_existing_config_keys(self):
+        """User-specified config values must survive injection."""
+        spec = {"mark": "line", "config": {"background": "#FF0000"}}
+        result = viz_config.inject_wb_config(spec)
+        assert result["config"]["background"] == "#FF0000", (
+            "inject_wb_config must not overwrite user-set background"
+        )
+
+    def test_inject_does_not_overwrite_existing_axis_keys(self):
+        spec = {"mark": "line", "config": {"axis": {"gridColor": "#AABBCC"}}}
+        result = viz_config.inject_wb_config(spec)
+        assert result["config"]["axis"]["gridColor"] == "#AABBCC", (
+            "inject_wb_config must not overwrite user-set axis.gridColor"
+        )
+
+    def test_apply_wb_style_rule_runs_on_any_mark(self):
+        rule = viz_config.ApplyWBStyleRule()
+        for mark in ["line", "bar", "point", "tick", "area"]:
+            spec = {"mark": mark, "encoding": {}}
+            result = rule.apply(spec)
+            assert "config" in result, f"WB config not injected for mark={mark}"
+
+    def test_wb_cat_colors_has_nine_entries(self):
+        assert len(viz_config.WB_CAT_COLORS) == 9
+
+    def test_wb_cat_colors_first_is_blue(self):
+        assert viz_config.WB_CAT_COLORS[0] == "#34A7F2"
+
+    def test_title_config_is_left_anchored(self):
+        spec = {"mark": "line"}
+        result = viz_config.inject_wb_config(spec)
+        assert result["config"]["title"]["anchor"] == "start"
+
+    def test_temporal_axis_cleanup_removes_title(self):
+        rule = viz_config.TemporalAxisCleanupRule()
+        spec = {
+            "mark": "line",
+            "encoding": {"x": {"field": "year", "type": "temporal"}},
+        }
+        result = rule.apply(spec)
+        assert result["encoding"]["x"]["axis"]["title"] is None
+
+    def test_zero_line_rule_enforces_zero_for_bar(self):
+        rule = viz_config.ZeroLineRule()
+        spec = {
+            "mark": "bar",
+            "encoding": {"y": {"field": "value", "type": "quantitative"}},
+        }
+        result = rule.apply(spec)
+        assert result["encoding"]["y"]["scale"]["zero"] is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Null / missing value guard  (MCP-004 + obs_value fix)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestObsValueNullHandling:
+    """obs_value NaN must NOT be zeroed — gaps are real missing data."""
+
+    @pytest.fixture
+    def patches_with_nulls(self):
+        """Fixture: data with one null obs_value row."""
+        df = pd.DataFrame(
+            {
+                "TIME_PERIOD": ["2020-01-01", "2021-01-01", "2022-01-01"],
+                "OBS_VALUE": [100.0, None, 300.0],
+                "REF_AREA": ["KEN", "KEN", "KEN"],
+            }
+        )
+        with (
+            patch(
+                "data360.api.get_data_api_url",
+                new_callable=AsyncMock,
+                return_value="http://fake/data?DATABASE_ID=WB_WDI&INDICATOR=FAKE",
+            ),
+            patch(
+                "data360.visualization._fetch_data_internal",
+                new_callable=AsyncMock,
+                return_value=df,
+            ),
+            patch(
+                "data360.api.get_metadata", new_callable=AsyncMock, return_value=None
+            ),
+            patch(
+                "data360.visualization.save_specs_to_static",
+                return_value="http://localhost/spec.json",
+            ),
+            patch(
+                "data360.providers.get_codelist_mapping",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+        ):
+            yield df
+
+    @pytest.mark.asyncio
+    async def test_null_obs_value_not_coerced_to_zero(self, patches_with_nulls):
+        """After processing, the 2021 value must remain NaN, not become 0."""
+        captured_data = {}
+
+        original_save = __import__(
+            "data360.visualization", fromlist=["save_specs_to_static"]
+        ).save_specs_to_static
+
+        def capture_spec(spec):
+            captured_data["spec"] = spec
+            return "http://localhost/spec.json"
+
+        with patch(
+            "data360.visualization.save_specs_to_static", side_effect=capture_spec
+        ):
+            with patch("data360.visualization.Draco") as MockDraco:
+                draco_instance = MagicMock()
+                draco_instance.complete_spec.return_value = iter([])
+                MockDraco.return_value = draco_instance
+
+                result = await get_viz_spec(
+                    database_id="WB_WDI",
+                    indicator_id="FAKE_IND",
+                )
+
+        # If spec was captured, verify the data values
+        if "spec" in captured_data:
+            spec = captured_data["spec"]
+            # Find inline data values
+            data_values = None
+            if "data" in spec and "values" in spec["data"]:
+                data_values = spec["data"]["values"]
+            elif "datasets" in spec:
+                for ds in spec["datasets"].values():
+                    data_values = ds
+                    break
+
+            if data_values:
+                value_for_2021 = None
+                for row in data_values:
+                    ts = row.get("year") or row.get("time_period") or ""
+                    if "2021" in str(ts):
+                        value_for_2021 = row.get("value") or row.get("obs_value")
+                        break
+
+                if value_for_2021 is not None:
+                    assert value_for_2021 != 0, (
+                        "Missing obs_value must not be zeroed — "
+                        f"got {value_for_2021} instead of NaN/null"
+                    )
+
+    def test_obs_value_numeric_coercion_preserves_nan(self):
+        """Unit test: pd.to_numeric(errors='coerce') on None keeps NaN, not 0."""
+        series = pd.Series([100.0, None, 300.0])
+        result = pd.to_numeric(series, errors="coerce")
+        assert math.isnan(result.iloc[1]), "None must become NaN after to_numeric"
+        assert result.iloc[0] == 100.0
+        assert result.iloc[2] == 300.0
+
+    def test_fillna_zero_would_corrupt_data(self):
+        """Regression guard: .fillna(0) produces 0 for missing — we must NOT do this."""
+        series = pd.Series([100.0, None, 300.0])
+        bad_result = pd.to_numeric(series, errors="coerce").fillna(0)
+        assert bad_result.iloc[1] == 0.0, "This test documents the old buggy behaviour"
+        # Confirm we're NOT doing this in the real code by checking viz source
+        import inspect
+
+        import data360.visualization as viz_mod
+
+        source = inspect.getsource(viz_mod)
+        assert "fillna(0)" not in source, (
+            "visualization.py must not call .fillna(0) on obs_value — "
+            "it silently converts missing data to zero"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# POST-PROCESSING RULE CHAIN
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPostProcessingRuleChain:
+    """Verify the rule registry runs without errors on typical specs."""
+
+    def _run_rules(self, spec, frequency=None):
+        for rule in viz_config.POST_PROCESSING_RULES:
+            spec = rule.apply(spec, frequency)
+        return spec
+
+    def test_chain_runs_on_line_chart(self):
+        spec = {
+            "mark": "line",
+            "encoding": {
+                "x": {"field": "year", "type": "temporal"},
+                "y": {"field": "value", "type": "quantitative"},
+            },
+        }
+        result = self._run_rules(spec, "A")
+        assert "config" in result
+        assert result["encoding"]["x"]["axis"]["title"] is None
+
+    def test_chain_runs_on_bar_chart(self):
+        spec = {
+            "mark": "bar",
+            "encoding": {
+                "x": {"field": "country", "type": "nominal"},
+                "y": {"field": "value", "type": "quantitative"},
+            },
+        }
+        result = self._run_rules(spec)
+        assert "config" in result
+        assert result["encoding"]["y"]["scale"]["zero"] is True
+
+    def test_chain_does_not_raise_on_empty_encoding(self):
+        spec = {"mark": "point", "encoding": {}}
+        result = self._run_rules(spec)
+        assert "config" in result
+
+    def test_apply_wb_style_is_last_rule(self):
+        last = viz_config.POST_PROCESSING_RULES[-1]
+        assert last.name == "apply_wb_style", (
+            "ApplyWBStyleRule must be last so it doesn't overwrite other fixes"
+        )
+
+
+class TestVegaSpecJsonSafe:
+    """_vega_spec_to_json_safe must match what json.dumps / httpx need for Charts API."""
+
+    def test_nested_timestamp_and_numpy_roundtrip(self):
+        spec = {
+            "data": {
+                "values": [
+                    {
+                        "year": pd.Timestamp("2020-01-01"),
+                        "v": np.float64(3.14),
+                    }
+                ]
+            }
+        }
+        safe = _vega_spec_to_json_safe(spec)
+        json.dumps(safe)
+        y = safe["data"]["values"][0]["year"]
+        assert isinstance(y, str) and y.startswith("2020-01-01")
+        assert isinstance(safe["data"]["values"][0]["v"], float)

--- a/tests/test_viz_complex.py
+++ b/tests/test_viz_complex.py
@@ -1,0 +1,914 @@
+"""
+Tests for complex visualization features:
+  - ChartStrategy router
+  - All spec builders
+  - Multi-indicator merge + dispatch
+  - Fallback path awareness
+  - Axis label threading
+  - Edge cases
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pandas as pd
+import pytest
+
+from data360 import viz_config
+from data360.visualization import get_multi_indicator_viz_spec
+from data360.viz_config import (
+    WB_CAT_COLORS,
+    ChartStrategy,
+    StrategyResult,
+    build_breakdown_comparison_spec,
+    build_correlation_spec,
+    build_correlation_temporal_spec,
+    build_cross_sectional_spec,
+    build_distribution_spec,
+    build_fallback_line_spec,
+    build_small_multiples_spec,
+    build_structured_tooltips,
+    build_temporal_multi_indicator_spec,
+    build_temporal_single_spec,
+    dispatch_spec,
+    select_strategy,
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _ts_df(n_countries=3, n_years=5, value_start=10.0):
+    """Multi-year time-series DataFrame."""
+    rows = []
+    for i, c in enumerate([f"Country{j}" for j in range(n_countries)]):
+        for y in range(2019, 2019 + n_years):
+            rows.append(
+                {
+                    "country": c,
+                    "year": pd.Timestamp(f"{y}-01-01"),
+                    "value": float(value_start + i * n_years + (y - 2019)),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _cs_df(n_countries=5, single_year=True):
+    """Cross-sectional DataFrame."""
+    rows = [
+        {
+            "country": f"Country{i}",
+            "value": float(i * 10 + 5),
+            "year": pd.Timestamp("2022-01-01"),
+        }
+        for i in range(n_countries)
+    ]
+    return pd.DataFrame(rows)
+
+
+def _sex_df(countries=2):
+    """DataFrame with sex breakdown."""
+    rows = []
+    for c in [f"Country{i}" for i in range(countries)]:
+        for s in ["M", "F"]:
+            for y in range(2020, 2023):
+                rows.append(
+                    {
+                        "country": c,
+                        "sex": s,
+                        "year": pd.Timestamp(f"{y}-01-01"),
+                        "value": float(hash((c, s, y)) % 100),
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def _two_ind_df():
+    """DataFrame with two indicator columns (merged multi-indicator)."""
+    rows = [
+        {
+            "country": f"Country{i}",
+            "year": pd.Timestamp("2022-01-01"),
+            "gdp_per_capita": float(i * 1000 + 500),
+            "life_expectancy": float(60 + i * 2),
+        }
+        for i in range(8)
+    ]
+    return pd.DataFrame(rows)
+
+
+def _two_ind_ts_df():
+    """Multi-year two-indicator DataFrame."""
+    rows = []
+    for c in ["CountryA", "CountryB"]:
+        for y in range(2018, 2024):
+            rows.append(
+                {
+                    "country": c,
+                    "year": pd.Timestamp(f"{y}-01-01"),
+                    "gdp_per_capita": float(hash((c, y, "gdp")) % 10000),
+                    "life_expectancy": float(60 + hash((c, y, "life")) % 20),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Strategy Router
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestStrategyRouter:
+    def test_temporal_single_multi_year(self):
+        df = _ts_df(n_countries=3, n_years=5)
+        r = select_strategy(df)
+        assert r.strategy == ChartStrategy.TEMPORAL_SINGLE
+
+    def test_temporal_single_sets_color_dim_to_country(self):
+        df = _ts_df(n_countries=3)
+        r = select_strategy(df)
+        assert r.color_dim == "country"
+
+    def test_cross_sectional_single_year_few_countries(self):
+        df = _cs_df(n_countries=5)
+        r = select_strategy(df)
+        assert r.strategy == ChartStrategy.CROSS_SECTIONAL
+
+    def test_distribution_single_year_many_countries(self):
+        df = _cs_df(n_countries=12)
+        r = select_strategy(df)
+        assert r.strategy == ChartStrategy.DISTRIBUTION
+
+    def test_breakdown_single_disagg(self):
+        df = _sex_df(countries=2)
+        r = select_strategy(df)
+        assert r.strategy == ChartStrategy.BREAKDOWN_COMPARISON
+        assert r.color_dim == "sex"
+
+    def test_small_multiples_many_countries_with_breakdown(self):
+        # 6 countries × 2 sexes → small multiples
+        df = _sex_df(countries=6)
+        r = select_strategy(df)
+        assert r.strategy == ChartStrategy.SMALL_MULTIPLES
+
+    def test_correlation_two_indicators_single_year(self):
+        df = _two_ind_df()
+        ind_cols = ["gdp_per_capita", "life_expectancy"]
+        r = select_strategy(df, n_indicators=2, indicator_cols=ind_cols)
+        assert r.strategy == ChartStrategy.CORRELATION
+        assert r.indicator_cols == ind_cols
+
+    def test_correlation_temporal_two_indicators_multi_year(self):
+        df = _two_ind_ts_df()
+        ind_cols = ["gdp_per_capita", "life_expectancy"]
+        r = select_strategy(df, n_indicators=2, indicator_cols=ind_cols)
+        assert r.strategy == ChartStrategy.CORRELATION_TEMPORAL
+
+    def test_temporal_multi_indicator_single_country(self):
+        df = _two_ind_ts_df()
+        df = df[df["country"] == "CountryA"].copy()
+        ind_cols = ["gdp_per_capita", "life_expectancy"]
+        r = select_strategy(df, n_indicators=2, indicator_cols=ind_cols)
+        assert r.strategy == ChartStrategy.TEMPORAL_MULTI_IND
+
+    def test_explicit_scatter_hint_overrides(self):
+        df = _two_ind_ts_df()  # multi-year but user says scatter
+        ind_cols = ["gdp_per_capita", "life_expectancy"]
+        r = select_strategy(
+            df, n_indicators=2, chart_type_hint="scatter", indicator_cols=ind_cols
+        )
+        assert r.strategy in (
+            ChartStrategy.CORRELATION,
+            ChartStrategy.CORRELATION_TEMPORAL,
+        )
+
+    def test_fallback_for_empty_like_df(self):
+        df = pd.DataFrame({"value": [1.0, 2.0]})
+        r = select_strategy(df)
+        assert r.strategy == ChartStrategy.FALLBACK_LINE
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Spec Builders — structure and WB style
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSpecBuilders:
+    def _result(
+        self,
+        strategy,
+        color_dim=None,
+        indicator_cols=None,
+        facet_dim=None,
+        x_dim=None,
+        y_dim=None,
+    ):
+        return StrategyResult(
+            strategy,
+            "test",
+            indicator_cols=indicator_cols or [],
+            color_dim=color_dim,
+            facet_dim=facet_dim,
+            x_dim=x_dim,
+            y_dim=y_dim,
+        )
+
+    # temporal_single
+    def test_temporal_single_mark_is_line(self):
+        df = _ts_df()
+        r = self._result(ChartStrategy.TEMPORAL_SINGLE, color_dim="country")
+        spec = build_temporal_single_spec(df, "Test", r)
+        assert spec["mark"]["type"] == "line"
+
+    def test_temporal_single_x_is_temporal(self):
+        df = _ts_df()
+        r = self._result(ChartStrategy.TEMPORAL_SINGLE, color_dim="country")
+        spec = build_temporal_single_spec(df, "Test", r)
+        assert spec["encoding"]["x"]["type"] == "temporal"
+
+    def test_temporal_single_x_axis_title_is_none(self):
+        df = _ts_df()
+        r = self._result(ChartStrategy.TEMPORAL_SINGLE, color_dim="country")
+        spec = build_temporal_single_spec(df, "Test", r)
+        assert spec["encoding"]["x"]["axis"]["title"] is None
+
+    def test_temporal_single_y_label_propagates(self):
+        df = _ts_df()
+        r = self._result(ChartStrategy.TEMPORAL_SINGLE)
+        spec = build_temporal_single_spec(df, "Test", r, y_label="GDP (USD)")
+        assert spec["encoding"]["y"]["axis"]["title"] == "GDP (USD)"
+
+    def test_temporal_single_color_encoding_present(self):
+        df = _ts_df(n_countries=3)
+        r = self._result(ChartStrategy.TEMPORAL_SINGLE, color_dim="country")
+        spec = build_temporal_single_spec(df, "Test", r)
+        assert "color" in spec["encoding"]
+        assert spec["encoding"]["color"]["field"] == "country"
+
+    # cross_sectional
+    def test_cross_sectional_mark_is_bar(self):
+        df = _cs_df()
+        r = self._result(ChartStrategy.CROSS_SECTIONAL, color_dim="country")
+        spec = build_cross_sectional_spec(df, "Test", r)
+        assert spec["mark"]["type"] == "bar"
+
+    def test_cross_sectional_y_is_country_nominal(self):
+        df = _cs_df()
+        r = self._result(ChartStrategy.CROSS_SECTIONAL, color_dim="country")
+        spec = build_cross_sectional_spec(df, "Test", r)
+        assert spec["encoding"]["y"]["field"] == "country"
+        assert spec["encoding"]["y"]["type"] == "nominal"
+
+    def test_cross_sectional_sorted_desc(self):
+        df = _cs_df()
+        r = self._result(ChartStrategy.CROSS_SECTIONAL)
+        spec = build_cross_sectional_spec(df, "Test", r)
+        assert spec["encoding"]["y"]["sort"] == "-x"
+
+    # distribution
+    def test_distribution_mark_is_tick(self):
+        df = _cs_df(n_countries=15)
+        r = self._result(ChartStrategy.DISTRIBUTION, color_dim="country")
+        spec = build_distribution_spec(df, "Test", r)
+        assert spec["mark"]["type"] == "tick"
+
+    def test_distribution_limits_rows(self):
+        df = _cs_df(n_countries=20)
+        r = self._result(ChartStrategy.DISTRIBUTION, color_dim="country")
+        spec = build_distribution_spec(df, "Test", r)
+        top_n = viz_config.HIGH_CARDINALITY_THRESHOLDS["top_n_series"]
+        assert len(spec["data"]["values"]) <= top_n
+
+    def test_distribution_uses_wb_colors(self):
+        df = _cs_df(n_countries=15)
+        r = self._result(ChartStrategy.DISTRIBUTION, color_dim="country")
+        spec = build_distribution_spec(df, "Test", r)
+        assert spec["encoding"]["color"]["scale"]["range"] == WB_CAT_COLORS
+
+    # breakdown_comparison
+    def test_breakdown_has_xoffset_for_grouped_bars(self):
+        df = _sex_df(countries=2)
+        r = self._result(ChartStrategy.BREAKDOWN_COMPARISON, color_dim="sex")
+        spec = build_breakdown_comparison_spec(df, "Test", r)
+        assert "xOffset" in spec["encoding"]
+
+    def test_breakdown_gender_colors_for_sex(self):
+        df = _sex_df(countries=2)
+        r = self._result(ChartStrategy.BREAKDOWN_COMPARISON, color_dim="sex")
+        spec = build_breakdown_comparison_spec(df, "Test", r)
+        # Female color should be in the range
+        color_range = spec["encoding"]["color"]["scale"]["range"]
+        assert viz_config.WB_GENDER_COLORS["F"] in color_range
+
+    # small_multiples
+    def test_small_multiples_has_facet_key(self):
+        df = _sex_df(countries=6)
+        r = self._result(
+            ChartStrategy.SMALL_MULTIPLES, color_dim="sex", facet_dim="country"
+        )
+        spec = build_small_multiples_spec(df, "Test", r)
+        assert "facet" in spec
+
+    def test_small_multiples_columns_capped_at_3(self):
+        df = _sex_df(countries=6)
+        r = self._result(
+            ChartStrategy.SMALL_MULTIPLES, color_dim="sex", facet_dim="country"
+        )
+        spec = build_small_multiples_spec(df, "Test", r)
+        assert spec["facet"]["columns"] <= 3
+
+    # correlation
+    def test_correlation_mark_is_circle(self):
+        df = _two_ind_df()
+        r = self._result(
+            ChartStrategy.CORRELATION,
+            color_dim="country",
+            indicator_cols=["gdp_per_capita", "life_expectancy"],
+        )
+        spec = build_correlation_spec(df, "Test", r)
+        assert spec["mark"]["type"] == "circle"
+
+    def test_correlation_x_y_from_indicator_cols(self):
+        df = _two_ind_df()
+        ind_cols = ["gdp_per_capita", "life_expectancy"]
+        r = self._result(
+            ChartStrategy.CORRELATION, color_dim="country", indicator_cols=ind_cols
+        )
+        spec = build_correlation_spec(df, "Test", r)
+        assert spec["encoding"]["x"]["field"] == "gdp_per_capita"
+        assert spec["encoding"]["y"]["field"] == "life_expectancy"
+
+    def test_correlation_axis_labels_from_indicator_labels(self):
+        df = _two_ind_df()
+        ind_cols = ["gdp_per_capita", "life_expectancy"]
+        r = self._result(
+            ChartStrategy.CORRELATION, color_dim="country", indicator_cols=ind_cols
+        )
+        labels = {"gdp_per_capita": "GDP (USD)", "life_expectancy": "Life Exp (years)"}
+        spec = build_correlation_spec(df, "Test", r, indicator_labels=labels)
+        assert spec["encoding"]["x"]["axis"]["title"] == "GDP (USD)"
+        assert spec["encoding"]["y"]["axis"]["title"] == "Life Exp (years)"
+
+    def test_correlation_raises_without_indicator_cols(self):
+        df = _two_ind_df()
+        r = self._result(ChartStrategy.CORRELATION, color_dim="country")
+        with pytest.raises(ValueError, match="2 indicator"):
+            build_correlation_spec(df, "Test", r)
+
+    def test_correlation_drops_rows_with_null_indicator_values(self):
+        df = _two_ind_df().copy()
+        df.loc[0, "gdp_per_capita"] = None
+        r = self._result(
+            ChartStrategy.CORRELATION,
+            color_dim="country",
+            indicator_cols=["gdp_per_capita", "life_expectancy"],
+        )
+        spec = build_correlation_spec(df, "Test", r)
+        # Row with null should be dropped
+        vals = [row["gdp_per_capita"] for row in spec["data"]["values"]]
+        assert all(v is not None for v in vals)
+
+    # correlation_temporal
+    def test_correlation_temporal_has_two_layers(self):
+        df = _two_ind_ts_df()
+        r = self._result(
+            ChartStrategy.CORRELATION_TEMPORAL,
+            color_dim="country",
+            indicator_cols=["gdp_per_capita", "life_expectancy"],
+        )
+        spec = build_correlation_temporal_spec(df, "Test", r)
+        assert "layer" in spec
+        assert len(spec["layer"]) == 2
+
+    def test_correlation_temporal_has_order_encoding(self):
+        df = _two_ind_ts_df()
+        r = self._result(
+            ChartStrategy.CORRELATION_TEMPORAL,
+            color_dim="country",
+            indicator_cols=["gdp_per_capita", "life_expectancy"],
+        )
+        spec = build_correlation_temporal_spec(df, "Test", r)
+        # At least one layer should have order encoding
+        has_order = any("order" in layer.get("encoding", {}) for layer in spec["layer"])
+        assert has_order
+
+    # temporal_multi_indicator
+    def test_temporal_multi_indicator_layers_equal_n_indicators(self):
+        df = _two_ind_ts_df()[lambda x: x["country"] == "CountryA"]
+        ind_cols = ["gdp_per_capita", "life_expectancy"]
+        r = self._result(ChartStrategy.TEMPORAL_MULTI_IND, indicator_cols=ind_cols)
+        spec = build_temporal_multi_indicator_spec(df, "Test", r)
+        assert len(spec["layer"]) == 2
+
+    def test_temporal_multi_indicator_independent_y_scale(self):
+        df = _two_ind_ts_df()[lambda x: x["country"] == "CountryA"]
+        ind_cols = ["gdp_per_capita", "life_expectancy"]
+        r = self._result(ChartStrategy.TEMPORAL_MULTI_IND, indicator_cols=ind_cols)
+        spec = build_temporal_multi_indicator_spec(df, "Test", r)
+        assert spec.get("resolve", {}).get("scale", {}).get("y") == "independent"
+
+    def test_temporal_multi_indicator_each_layer_different_color(self):
+        df = _two_ind_ts_df()[lambda x: x["country"] == "CountryA"]
+        ind_cols = ["gdp_per_capita", "life_expectancy"]
+        r = self._result(ChartStrategy.TEMPORAL_MULTI_IND, indicator_cols=ind_cols)
+        spec = build_temporal_multi_indicator_spec(df, "Test", r)
+        colors = [layer["mark"]["color"] for layer in spec["layer"]]
+        assert len(set(colors)) == 2  # distinct colors
+
+    # fallback
+    def test_fallback_produces_line(self):
+        df = pd.DataFrame({"year": [pd.Timestamp("2020")], "value": [42.0]})
+        r = StrategyResult(ChartStrategy.FALLBACK_LINE, "test")
+        spec = build_fallback_line_spec(df, "Test", r)
+        assert spec["mark"]["type"] == "line"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# dispatch_spec
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDispatch:
+    def test_dispatch_calls_correct_builder_for_each_strategy(self):
+        df_ts = _ts_df()
+        df_cs = _cs_df()
+        df_dist = _cs_df(15)
+        df_sex = _sex_df(2)
+        df_sm = _sex_df(6)
+        df_2i = _two_ind_df()
+        df_2its = _two_ind_ts_df()
+        df_fb = pd.DataFrame({"year": [pd.Timestamp("2020")], "value": [1.0]})
+
+        cases = [
+            (
+                ChartStrategy.TEMPORAL_SINGLE,
+                df_ts,
+                StrategyResult(ChartStrategy.TEMPORAL_SINGLE, "", color_dim="country"),
+            ),
+            (
+                ChartStrategy.CROSS_SECTIONAL,
+                df_cs,
+                StrategyResult(ChartStrategy.CROSS_SECTIONAL, "", color_dim="country"),
+            ),
+            (
+                ChartStrategy.DISTRIBUTION,
+                df_dist,
+                StrategyResult(ChartStrategy.DISTRIBUTION, "", color_dim="country"),
+            ),
+            (
+                ChartStrategy.BREAKDOWN_COMPARISON,
+                df_sex,
+                StrategyResult(ChartStrategy.BREAKDOWN_COMPARISON, "", color_dim="sex"),
+            ),
+            (
+                ChartStrategy.SMALL_MULTIPLES,
+                df_sm,
+                StrategyResult(
+                    ChartStrategy.SMALL_MULTIPLES,
+                    "",
+                    color_dim="sex",
+                    facet_dim="country",
+                ),
+            ),
+            (
+                ChartStrategy.CORRELATION,
+                df_2i,
+                StrategyResult(
+                    ChartStrategy.CORRELATION,
+                    "",
+                    indicator_cols=["gdp_per_capita", "life_expectancy"],
+                    color_dim="country",
+                ),
+            ),
+            (
+                ChartStrategy.CORRELATION_TEMPORAL,
+                df_2its,
+                StrategyResult(
+                    ChartStrategy.CORRELATION_TEMPORAL,
+                    "",
+                    indicator_cols=["gdp_per_capita", "life_expectancy"],
+                    color_dim="country",
+                ),
+            ),
+            (
+                ChartStrategy.TEMPORAL_MULTI_IND,
+                df_2its[lambda x: x.country == "CountryA"],
+                StrategyResult(
+                    ChartStrategy.TEMPORAL_MULTI_IND,
+                    "",
+                    indicator_cols=["gdp_per_capita", "life_expectancy"],
+                ),
+            ),
+            (
+                ChartStrategy.FALLBACK_LINE,
+                df_fb,
+                StrategyResult(ChartStrategy.FALLBACK_LINE, ""),
+            ),
+        ]
+        for strategy, df, result in cases:
+            spec = dispatch_spec(strategy, df, "T", result, y_label="Y", x_label="X")
+            assert "$schema" in spec, f"No $schema for {strategy}"
+            assert "config" in spec, f"No WB config for {strategy}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# WB Style on every spec
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestWBStyleOnAllSpecs:
+    def _all_specs(self):
+        df_ts = _ts_df()
+        df_cs = _cs_df()
+        df_sex = _sex_df(2)
+        df_2i = _two_ind_df()
+        df_2ts = _two_ind_ts_df()
+        return [
+            build_temporal_single_spec(
+                df_ts,
+                "T",
+                StrategyResult(ChartStrategy.TEMPORAL_SINGLE, "", color_dim="country"),
+            ),
+            build_cross_sectional_spec(
+                df_cs,
+                "T",
+                StrategyResult(ChartStrategy.CROSS_SECTIONAL, "", color_dim="country"),
+            ),
+            build_distribution_spec(
+                _cs_df(15),
+                "T",
+                StrategyResult(ChartStrategy.DISTRIBUTION, "", color_dim="country"),
+            ),
+            build_breakdown_comparison_spec(
+                df_sex,
+                "T",
+                StrategyResult(ChartStrategy.BREAKDOWN_COMPARISON, "", color_dim="sex"),
+            ),
+            build_small_multiples_spec(
+                _sex_df(6),
+                "T",
+                StrategyResult(
+                    ChartStrategy.SMALL_MULTIPLES,
+                    "",
+                    color_dim="sex",
+                    facet_dim="country",
+                ),
+            ),
+            build_correlation_spec(
+                df_2i,
+                "T",
+                StrategyResult(
+                    ChartStrategy.CORRELATION,
+                    "",
+                    indicator_cols=["gdp_per_capita", "life_expectancy"],
+                    color_dim="country",
+                ),
+            ),
+            build_correlation_temporal_spec(
+                df_2ts,
+                "T",
+                StrategyResult(
+                    ChartStrategy.CORRELATION_TEMPORAL,
+                    "",
+                    indicator_cols=["gdp_per_capita", "life_expectancy"],
+                    color_dim="country",
+                ),
+            ),
+            build_temporal_multi_indicator_spec(
+                df_2ts[lambda x: x.country == "CountryA"],
+                "T",
+                StrategyResult(
+                    ChartStrategy.TEMPORAL_MULTI_IND,
+                    "",
+                    indicator_cols=["gdp_per_capita", "life_expectancy"],
+                ),
+            ),
+        ]
+
+    def test_all_specs_have_vl_schema(self):
+        for spec in self._all_specs():
+            assert "$schema" in spec, "Missing $schema"
+
+    def test_all_specs_have_wb_config(self):
+        for spec in self._all_specs():
+            assert "config" in spec, "Missing WB config"
+
+    def test_all_specs_have_wb_category_colors(self):
+        for spec in self._all_specs():
+            cat_colors = spec.get("config", {}).get("range", {}).get("category")
+            assert cat_colors == WB_CAT_COLORS, "WB cat colors not injected"
+
+    def test_all_specs_have_wb_font(self):
+        for spec in self._all_specs():
+            assert "Noto Sans" in spec.get("config", {}).get("font", ""), (
+                "WB font not set"
+            )
+
+    def test_all_specs_have_tooltips(self):
+        for spec in self._all_specs():
+            enc = spec.get("encoding") or spec.get("spec", {}).get("encoding", {}) or {}
+            layer_enc = None
+            if "layer" in spec:
+                # last layer has tooltips
+                layer_enc = spec["layer"][-1].get("encoding", {})
+            check_enc = layer_enc or enc
+            assert "tooltip" in check_enc, (
+                f"Missing tooltip in spec: {spec.get('title')}"
+            )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Structured Tooltips (multi-indicator variant)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestMultiIndicatorTooltips:
+    def test_indicator_label_replaces_col_name(self):
+        labels = {"gdp_per_capita": "GDP per capita (USD)"}
+        tips = build_structured_tooltips(["gdp_per_capita", "country"], "point", labels)
+        gdp_tip = next(t for t in tips if t["field"] == "gdp_per_capita")
+        assert gdp_tip["title"] == "GDP per capita (USD)"
+
+    def test_indicator_label_tip_has_number_format(self):
+        labels = {"life_exp": "Life Expectancy"}
+        tips = build_structured_tooltips(["life_exp"], "point", labels)
+        assert tips[0]["format"] == ",.2f"
+
+    def test_indicator_label_tip_is_quantitative(self):
+        labels = {"some_ind": "Some Indicator"}
+        tips = build_structured_tooltips(["some_ind"], "point", labels)
+        assert tips[0]["type"] == "quantitative"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Multi-indicator merge & dispatch integration (mocked fetches)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestGetMultiIndicatorVizSpec:
+    """Integration tests for get_multi_indicator_viz_spec with mocked I/O."""
+
+    def _make_df(self, col_name, countries, years):
+        rows = [
+            {
+                "TIME_PERIOD": f"{y}-01-01",
+                "REF_AREA": c,
+                "OBS_VALUE": float(hash((c, y)) % 100),
+            }
+            for c in countries
+            for y in years
+        ]
+        return pd.DataFrame(rows)
+
+    @pytest.fixture
+    def patches(self):
+        with (
+            patch(
+                "data360.api.get_data_api_url",
+                new_callable=AsyncMock,
+                return_value="http://fake/data?DATABASE_ID=WB&INDICATOR=X",
+            ) as mock_url,
+            patch(
+                "data360.visualization._fetch_data_internal", new_callable=AsyncMock
+            ) as mock_fetch,
+            patch(
+                "data360.api.get_metadata", new_callable=AsyncMock, return_value=None
+            ),
+            patch(
+                "data360.providers.get_codelist_mapping",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+            patch(
+                "data360.visualization.save_specs_to_static",
+                return_value="http://localhost/spec.json",
+            ),
+        ):
+            yield mock_url, mock_fetch
+
+    @pytest.mark.asyncio
+    async def test_returns_url_for_two_indicators(self, patches):
+        _, mock_fetch = patches
+        countries = ["KEN", "TZA", "UGA"]
+        years = [2022]
+        df1 = self._make_df("ind1", countries, years)
+        df2 = self._make_df("ind2", countries, years)
+        mock_fetch.side_effect = [df1, df2]
+
+        result = await get_multi_indicator_viz_spec(
+            indicator_ids=[
+                {"database_id": "WB_WDI", "indicator_id": "IND_A"},
+                {"database_id": "WB_WDI", "indicator_id": "IND_B"},
+            ]
+        )
+        assert result["url"] is not None, (
+            f"Expected URL, got error: {result.get('error')}"
+        )
+        assert result["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_returns_strategy_in_result(self, patches):
+        _, mock_fetch = patches
+        countries = ["KEN", "TZA", "UGA"]
+        years = [2022]
+        df1 = self._make_df("ind1", countries, years)
+        df2 = self._make_df("ind2", countries, years)
+        mock_fetch.side_effect = [df1, df2]
+
+        result = await get_multi_indicator_viz_spec(
+            indicator_ids=[
+                {"database_id": "WB", "indicator_id": "A"},
+                {"database_id": "WB", "indicator_id": "B"},
+            ]
+        )
+        assert "strategy" in result, "Result should include 'strategy' field"
+
+    @pytest.mark.asyncio
+    async def test_error_with_fewer_than_two_indicators(self):
+        result = await get_multi_indicator_viz_spec(
+            indicator_ids=[{"database_id": "WB", "indicator_id": "A"}]
+        )
+        assert result["url"] is None
+        assert result["error"] is not None
+
+    @pytest.mark.asyncio
+    async def test_error_when_indicator_ids_omitted(self):
+        result = await get_multi_indicator_viz_spec(indicator_ids=None)
+        assert result["url"] is None
+        assert result["error"] is not None
+        assert "indicator_ids is required" in (result["error"] or "")
+
+    @pytest.mark.asyncio
+    async def test_error_with_more_than_four_indicators(self):
+        result = await get_multi_indicator_viz_spec(
+            indicator_ids=[
+                {"database_id": "WB", "indicator_id": f"IND{i}"} for i in range(5)
+            ]
+        )
+        assert result["url"] is None
+        assert "Maximum 4" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_uses_scatter_strategy_for_multi_country_single_year(self, patches):
+        _, mock_fetch = patches
+        countries = [f"C{i}" for i in range(10)]
+        df1 = self._make_df("ind1", countries, [2022])
+        df2 = self._make_df("ind2", countries, [2022])
+        mock_fetch.side_effect = [df1, df2]
+
+        result = await get_multi_indicator_viz_spec(
+            indicator_ids=[
+                {"database_id": "WB", "indicator_id": "A"},
+                {"database_id": "WB", "indicator_id": "B"},
+            ]
+        )
+        assert result.get("strategy") in (
+            "correlation",
+            "cross_sectional",
+            "distribution",
+            "temporal_single",
+            "temporal_multi_indicator",
+            "correlation_temporal",
+        ), f"Unexpected strategy: {result.get('strategy')}"
+
+    @pytest.mark.asyncio
+    async def test_empty_data_returns_error(self, patches):
+        _, mock_fetch = patches
+        # First indicator has data, second returns empty
+        df1 = self._make_df("ind1", ["KEN"], [2022])
+        mock_fetch.side_effect = [df1, pd.DataFrame()]
+
+        result = await get_multi_indicator_viz_spec(
+            indicator_ids=[
+                {"database_id": "WB", "indicator_id": "A"},
+                {"database_id": "WB", "indicator_id": "B"},
+            ]
+        )
+        assert result["url"] is None
+        assert result["error"] is not None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Axis label threading
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAxisLabelThreading:
+    """Y-axis must show indicator name + unit, not just 'Value'."""
+
+    def test_temporal_single_y_axis_reflects_y_label(self):
+        df = _ts_df()
+        r = StrategyResult(ChartStrategy.TEMPORAL_SINGLE, "", color_dim="country")
+        spec = build_temporal_single_spec(
+            df, "T", r, y_label="GDP per capita (2017 USD)"
+        )
+        assert "GDP per capita" in spec["encoding"]["y"]["axis"]["title"]
+
+    def test_correlation_x_label_from_indicator_labels(self):
+        df = _two_ind_df()
+        r = StrategyResult(
+            ChartStrategy.CORRELATION,
+            "",
+            color_dim="country",
+            indicator_cols=["gdp_per_capita", "life_expectancy"],
+        )
+        spec = build_correlation_spec(
+            df,
+            "T",
+            r,
+            indicator_labels={
+                "gdp_per_capita": "GDP (USD)",
+                "life_expectancy": "Life Exp",
+            },
+        )
+        assert spec["encoding"]["x"]["axis"]["title"] == "GDP (USD)"
+        assert spec["encoding"]["y"]["axis"]["title"] == "Life Exp"
+
+    def test_multi_ind_layer_y_axis_per_indicator(self):
+        df = _two_ind_ts_df()[lambda x: x.country == "CountryA"]
+        r = StrategyResult(
+            ChartStrategy.TEMPORAL_MULTI_IND,
+            "",
+            indicator_cols=["gdp_per_capita", "life_expectancy"],
+        )
+        spec = build_temporal_multi_indicator_spec(
+            df,
+            "T",
+            r,
+            indicator_labels={
+                "gdp_per_capita": "GDP (USD)",
+                "life_expectancy": "Life Exp (yr)",
+            },
+        )
+        y_titles = [layer["encoding"]["y"]["axis"]["title"] for layer in spec["layer"]]
+        assert "GDP (USD)" in y_titles
+        assert "Life Exp (yr)" in y_titles
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Null / NaN handling
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestNullHandling:
+    def test_correlation_drops_nulls_before_plotting(self):
+        df = _two_ind_df().copy()
+        df.loc[2, "gdp_per_capita"] = None
+        r = StrategyResult(
+            ChartStrategy.CORRELATION,
+            "",
+            color_dim="country",
+            indicator_cols=["gdp_per_capita", "life_expectancy"],
+        )
+        spec = build_correlation_spec(df, "T", r)
+        assert all(r["gdp_per_capita"] is not None for r in spec["data"]["values"])
+
+    def test_distribution_with_all_valid_values(self):
+        df = _cs_df(15)
+        assert not df["value"].isna().any()
+        r = StrategyResult(ChartStrategy.DISTRIBUTION, "", color_dim="country")
+        spec = build_distribution_spec(df, "T", r)
+        assert len(spec["data"]["values"]) > 0
+
+    def test_obs_value_not_fillna_zero_in_viz_module(self):
+        """Regression guard: .fillna(0) must not exist on obs_value."""
+        import inspect
+
+        import data360.visualization as viz_mod
+
+        src = inspect.getsource(viz_mod)
+        assert "fillna(0)" not in src
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# get_supported_chart_types updated content
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestGetSupportedChartTypes:
+    def test_returns_valid_json(self):
+        import json
+
+        from data360.visualization import get_supported_chart_types
+
+        data = json.loads(get_supported_chart_types())
+        assert "chart_types" in data
+
+    def test_includes_scatter_type(self):
+        import json
+
+        from data360.visualization import get_supported_chart_types
+
+        data = json.loads(get_supported_chart_types())
+        ids = [ct["id"] for ct in data["chart_types"]]
+        assert "scatter" in ids
+
+    def test_includes_multi_indicator_note(self):
+        import json
+
+        from data360.visualization import get_supported_chart_types
+
+        data = json.loads(get_supported_chart_types())
+        assert "multi_indicator" in data.get("multi_indicator_note", "")

--- a/uv.lock
+++ b/uv.lock
@@ -586,6 +586,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-httpx" },
+    { name = "requests" },
     { name = "ruff" },
 ]
 
@@ -614,6 +615,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-httpx", specifier = ">=0.27.0" },
+    { name = "requests", specifier = ">=2.32.0" },
     { name = "ruff", specifier = ">=0.14.8" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -5,9 +5,12 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -58,6 +61,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -85,6 +97,89 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bb/9b/b1661026ff24bc641b76b78c5222d614776b0c085bcfdac9bd15a1cb4b35/authlib-1.6.6.tar.gz", hash = "sha256:45770e8e056d0f283451d9996fbb59b70d45722b45d854d58f32878d0a40c38e", size = 164894, upload-time = "2025-12-12T08:01:41.464Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/51/321e821856452f7386c4e9df866f196720b1ad0c5ea1623ea7399969ae3b/authlib-1.6.6-py2.py3-none-any.whl", hash = "sha256:7d9e9bc535c13974313a87f53e8430eb6ea3d1cf6ae4f6efcd793f2e949143fd", size = 244005, upload-time = "2025-12-12T08:01:40.209Z" },
+]
+
+[[package]]
+name = "azure-core"
+version = "1.39.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/83/bbde3faa84ddcb8eb0eca4b3ffb3221252281db4ce351300fe248c5c70b1/azure_core-1.39.0.tar.gz", hash = "sha256:8a90a562998dd44ce84597590fff6249701b98c0e8797c95fcdd695b54c35d74", size = 367531, upload-time = "2026-03-19T01:31:29.461Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/d6/8ebcd05b01a580f086ac9a97fb9fac65c09a4b012161cc97c21a336e880b/azure_core-1.39.0-py3-none-any.whl", hash = "sha256:4ac7b70fab5438c3f68770649a78daf97833caa83827f91df9c14e0e0ea7d34f", size = 218318, upload-time = "2026-03-19T01:31:31.25Z" },
+]
+
+[[package]]
+name = "azure-core-tracing-opentelemetry"
+version = "1.0.0b12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/7f/5de13a331a5f2919417819cc37dcf7c897018f02f83aa82b733e6629a6a6/azure_core_tracing_opentelemetry-1.0.0b12.tar.gz", hash = "sha256:bb454142440bae11fd9d68c7c1d67ae38a1756ce808c5e4d736730a7b4b04144", size = 26010, upload-time = "2025-03-21T00:18:37.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/5e/97a471f66935e7f89f521d0e11ae49c7f0871ca38f5c319dccae2155c8d8/azure_core_tracing_opentelemetry-1.0.0b12-py3-none-any.whl", hash = "sha256:38fd42709f1cc4bbc4f2797008b1c30a6a01617e49910c05daa3a0d0c65053ac", size = 11962, upload-time = "2025-03-21T00:18:38.581Z" },
+]
+
+[[package]]
+name = "azure-identity"
+version = "1.25.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "msal" },
+    { name = "msal-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/0e/3a63efb48aa4a5ae2cfca61ee152fbcb668092134d3eb8bfda472dd5c617/azure_identity-1.25.3.tar.gz", hash = "sha256:ab23c0d63015f50b630ef6c6cf395e7262f439ce06e5d07a64e874c724f8d9e6", size = 286304, upload-time = "2026-03-13T01:12:20.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/9a/417b3a533e01953a7c618884df2cb05a71e7b68bdbce4fbdb62349d2a2e8/azure_identity-1.25.3-py3-none-any.whl", hash = "sha256:f4d0b956a8146f30333e071374171f3cfa7bdb8073adb8c3814b65567aa7447c", size = 192138, upload-time = "2026-03-13T01:12:22.951Z" },
+]
+
+[[package]]
+name = "azure-monitor-opentelemetry"
+version = "1.8.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "azure-core-tracing-opentelemetry" },
+    { name = "azure-monitor-opentelemetry-exporter" },
+    { name = "opentelemetry-instrumentation-django" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-flask" },
+    { name = "opentelemetry-instrumentation-logging" },
+    { name = "opentelemetry-instrumentation-psycopg2" },
+    { name = "opentelemetry-instrumentation-requests" },
+    { name = "opentelemetry-instrumentation-urllib" },
+    { name = "opentelemetry-instrumentation-urllib3" },
+    { name = "opentelemetry-resource-detector-azure" },
+    { name = "opentelemetry-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/42/ea67bebb400a7561b1ad1dd59d06b67e880daf8081ec0d41d3b0ce8fcc26/azure_monitor_opentelemetry-1.8.7.tar.gz", hash = "sha256:d0a430c69451f8fa09362769d2d65471713989fb78e4ad0f50832b597921efbb", size = 76970, upload-time = "2026-03-19T21:43:57.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/22/245a4f75a834430759a6fab9c5ab10e18719786ae684cf234c7bb6a693d1/azure_monitor_opentelemetry-1.8.7-py3-none-any.whl", hash = "sha256:0d3a228a183d76cf22698a3eed6e836d1cf57608b8ee879c634609b26f384eb2", size = 41268, upload-time = "2026-03-19T21:43:58.188Z" },
+]
+
+[[package]]
+name = "azure-monitor-opentelemetry-exporter"
+version = "1.0.0b51"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "azure-identity" },
+    { name = "msrest" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "psutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/a4/a6cd2d389bc1009300bcd57c9e2ace4b7e7ae1e5dc0bda415ee803629cf2/azure_monitor_opentelemetry_exporter-1.0.0b51.tar.gz", hash = "sha256:a6171c34326bcd6216938bb40d715c15f1f22984ac1986fc97231336d8ac4c3c", size = 319837, upload-time = "2026-04-06T21:45:46.378Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/1a/6b0b7a6181b42709103a65a676c89fd5055cb1d1b281ebe10c49254a170f/azure_monitor_opentelemetry_exporter-1.0.0b51-py2.py3-none-any.whl", hash = "sha256:6572cac11f96e3b18ae1187cb35cf3b40d0004655dae8048896c41c765bea530", size = 242104, upload-time = "2026-04-06T21:45:47.856Z" },
 ]
 
 [[package]]
@@ -563,6 +658,7 @@ name = "data360-mcp"
 version = "0.1.2"
 source = { editable = "." }
 dependencies = [
+    { name = "azure-monitor-opentelemetry" },
     { name = "draco" },
     { name = "fastapi" },
     { name = "fastmcp" },
@@ -570,6 +666,7 @@ dependencies = [
     { name = "langchain-mcp-adapters" },
     { name = "langchain-openai" },
     { name = "mcp" },
+    { name = "opencensus-ext-azure" },
     { name = "pydantic-settings" },
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
@@ -592,6 +689,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-monitor-opentelemetry", specifier = ">=1.6.0" },
     { name = "draco", git = "https://github.com/avsolatorio/draco2.git?rev=data360-mcp" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastmcp", specifier = ">=2.12.4" },
@@ -599,6 +697,7 @@ requires-dist = [
     { name = "langchain-mcp-adapters", specifier = ">=0.1.13" },
     { name = "langchain-openai", specifier = ">=1.1.7" },
     { name = "mcp", specifier = ">=1.18.0" },
+    { name = "opencensus-ext-azure", specifier = ">=1.1.13" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "typer", specifier = ">=0.20.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
@@ -790,6 +889,47 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.30.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/2e/83ca41eb400eb228f9279ec14ed66f6475218b59af4c6daec2d5a509fe83/google_api_core-2.30.2.tar.gz", hash = "sha256:9a8113e1a88bdc09a7ff629707f2214d98d61c7f6ceb0ea38c42a095d02dc0f9", size = 176862, upload-time = "2026-04-02T21:23:44.876Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/e1/ebd5100cbb202e561c0c8b59e485ef3bd63fa9beb610f3fdcaea443f0288/google_api_core-2.30.2-py3-none-any.whl", hash = "sha256:a4c226766d6af2580577db1f1a51bf53cd262f722b49731ce7414c43068a9594", size = 173236, upload-time = "2026-04-02T21:23:06.395Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/80/6a696a07d3d3b0a92488933532f03dbefa4a24ab80fb231395b9a2a1be77/google_auth-2.49.1.tar.gz", hash = "sha256:16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64", size = 333825, upload-time = "2026-03-12T19:30:58.135Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/eb/c6c2478d8a8d633460be40e2a8a6f8f429171997a35a96f81d3b680dec83/google_auth-2.49.1-py3-none-any.whl", hash = "sha256:195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7", size = 240737, upload-time = "2026-03-12T19:30:53.159Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.74.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254, upload-time = "2026-04-02T21:23:26.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743, upload-time = "2026-04-02T21:22:49.108Z" },
+]
+
+[[package]]
 name = "gunicorn"
 version = "23.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -920,6 +1060,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
 ]
 
 [[package]]
@@ -1416,6 +1565,32 @@ wheels = [
 ]
 
 [[package]]
+name = "msal"
+version = "1.35.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/aa/5a646093ac218e4a329391d5a31e5092a89db7d2ef1637a90b82cd0b6f94/msal-1.35.1.tar.gz", hash = "sha256:70cac18ab80a053bff86219ba64cfe3da1f307c74b009e2da57ef040eb1b5656", size = 165658, upload-time = "2026-03-04T23:38:51.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/86/16815fddf056ca998853c6dc525397edf0b43559bb4073a80d2bc7fe8009/msal-1.35.1-py3-none-any.whl", hash = "sha256:8f4e82f34b10c19e326ec69f44dc6b30171f2f7098f3720ea8a9f0c11832caa3", size = 119909, upload-time = "2026-03-04T23:38:50.452Z" },
+]
+
+[[package]]
+name = "msal-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", size = 23315, upload-time = "2025-03-14T23:51:03.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/75/bd9b7bb966668920f06b200e84454c8f3566b102183bc55c5473d96cb2b9/msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca", size = 20583, upload-time = "2025-03-14T23:51:03.016Z" },
+]
+
+[[package]]
 name = "msgpack"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1466,6 +1641,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
     { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
     { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
+]
+
+[[package]]
+name = "msrest"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "certifi" },
+    { name = "isodate" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/77/8397c8fb8fc257d8ea0fa66f8068e073278c65f05acb17dcb22a02bfdc42/msrest-0.7.1.zip", hash = "sha256:6e7661f46f3afd88b75667b7187a92829924446c7ea1d169be8c4bb7eeb788b9", size = 175332, upload-time = "2022-06-13T22:41:25.111Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/cf/f2966a2638144491f8696c27320d5219f48a072715075d168b31d3237720/msrest-0.7.1-py3-none-any.whl", hash = "sha256:21120a810e1233e5e6cc7fe40b474eeb4ec6f757a15d7cf86702c369f9567c32", size = 85384, upload-time = "2022-06-13T22:41:22.42Z" },
 ]
 
 [[package]]
@@ -1566,6 +1757,15 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1597,35 +1797,74 @@ wheels = [
 ]
 
 [[package]]
+name = "opencensus"
+version = "0.11.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "opencensus-context" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/a7/a46dcffa1b63084f9f17fe3c8cb20724c4c8f91009fd0b2cfdb27d5d2b35/opencensus-0.11.4.tar.gz", hash = "sha256:cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2", size = 64966, upload-time = "2024-01-03T18:04:07.085Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/ed/9fbdeb23a09e430d87b7d72d430484b88184633dc50f6bfb792354b6f661/opencensus-0.11.4-py2.py3-none-any.whl", hash = "sha256:a18487ce68bc19900336e0ff4655c5a116daf10c1b3685ece8d971bddad6a864", size = 128225, upload-time = "2024-01-03T18:04:05.127Z" },
+]
+
+[[package]]
+name = "opencensus-context"
+version = "0.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/96/3b6f638f6275a8abbd45e582448723bffa29c1fb426721dedb5c72f7d056/opencensus-context-0.1.3.tar.gz", hash = "sha256:a03108c3c10d8c80bb5ddf5c8a1f033161fa61972a9917f9b9b3a18517f0088c", size = 4066, upload-time = "2022-08-03T22:20:22.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/68/162c97ea78c957d68ecf78a5c5041d2e25bd5562bdf5d89a6cbf7f8429bf/opencensus_context-0.1.3-py2.py3-none-any.whl", hash = "sha256:073bb0590007af276853009fac7e4bab1d523c3f03baf4cb4511ca38967c6039", size = 5060, upload-time = "2022-08-03T22:20:20.352Z" },
+]
+
+[[package]]
+name = "opencensus-ext-azure"
+version = "1.1.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "azure-identity" },
+    { name = "opencensus" },
+    { name = "psutil" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/bf/719a4a3885e6da101c47944e902ecd09287db237e766585951152b506a11/opencensus_ext_azure-1.1.15.tar.gz", hash = "sha256:8d108af15875ea3c52238646fba924c3ba9fbfaaf1fd0d350707dc5b7880ade7", size = 50987, upload-time = "2025-06-03T18:28:09.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/7a/bd1dffd6a1ad07c1fd652054a33b7024745e989404c3681296d247a08895/opencensus_ext_azure-1.1.15-py2.py3-none-any.whl", hash = "sha256:6cf6102987ed2b9b64a7757291a0a67b09bf7a6869c3e9e2dac32888cafc06f6", size = 43209, upload-time = "2025-06-03T18:28:07.921Z" },
+]
+
+[[package]]
 name = "opentelemetry-api"
-version = "1.39.1"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/b9/3161be15bb8e3ad01be8be5a968a9237c3027c5be504362ff800fca3e442/opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c", size = 65767, upload-time = "2025-12-11T13:32:39.182Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/1d/4049a9e8698361cc1a1aa03a6c59e4fa4c71e0c0f94a30f988a6876a2ae6/opentelemetry_api-1.40.0.tar.gz", hash = "sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f", size = 70851, upload-time = "2026-03-04T14:17:21.555Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950", size = 66356, upload-time = "2025-12-11T13:32:17.304Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/bf/93795954016c522008da367da292adceed71cca6ee1717e1d64c83089099/opentelemetry_api-1.40.0-py3-none-any.whl", hash = "sha256:82dd69331ae74b06f6a874704be0cfaa49a1650e1537d4a813b86ecef7d0ecf9", size = 68676, upload-time = "2026-03-04T14:17:01.24Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-prometheus"
-version = "0.60b1"
+version = "0.61b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
     { name = "prometheus-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/39/7dafa6fff210737267bed35a8855b6ac7399b9e582b8cf1f25f842517012/opentelemetry_exporter_prometheus-0.60b1.tar.gz", hash = "sha256:a4011b46906323f71724649d301b4dc188aaa068852e814f4df38cc76eac616b", size = 14976, upload-time = "2025-12-11T13:32:42.944Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/20/9e818fd364d12e8d0cfdce4a3b2d82e24d98c4ceebb315de6b6770b5f214/opentelemetry_exporter_prometheus-0.61b0.tar.gz", hash = "sha256:7c4919bd8e79abd62b610767e80f42c9c3a06c5183f4dd9141eedeb57aea284b", size = 15136, upload-time = "2026-03-04T14:17:26.275Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/0d/4be6bf5477a3eb3d917d2f17d3c0b6720cd6cb97898444a61d43cc983f5c/opentelemetry_exporter_prometheus-0.60b1-py3-none-any.whl", hash = "sha256:49f59178de4f4590e3cef0b8b95cf6e071aae70e1f060566df5546fad773b8fd", size = 13019, upload-time = "2025-12-11T13:32:23.974Z" },
+    { url = "https://files.pythonhosted.org/packages/02/4a/b65d40e94d1d930aee73a1a2857211ee6ab10ce3686cbdae5eea78cd9d34/opentelemetry_exporter_prometheus-0.61b0-py3-none-any.whl", hash = "sha256:3013b41f4370143d48d219a2351473761423e5882fa4c213811eaefacba39cb7", size = 13149, upload-time = "2026-03-04T14:17:08.983Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation"
-version = "0.60b1"
+version = "0.61b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1633,36 +1872,225 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/0f/7e6b713ac117c1f5e4e3300748af699b9902a2e5e34c9cf443dde25a01fa/opentelemetry_instrumentation-0.60b1.tar.gz", hash = "sha256:57ddc7974c6eb35865af0426d1a17132b88b2ed8586897fee187fd5b8944bd6a", size = 31706, upload-time = "2025-12-11T13:36:42.515Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/37/6bf8e66bfcee5d3c6515b79cb2ee9ad05fe573c20f7ceb288d0e7eeec28c/opentelemetry_instrumentation-0.61b0.tar.gz", hash = "sha256:cb21b48db738c9de196eba6b805b4ff9de3b7f187e4bbf9a466fa170514f1fc7", size = 32606, upload-time = "2026-03-04T14:20:16.825Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl", hash = "sha256:04480db952b48fb1ed0073f822f0ee26012b7be7c3eac1a3793122737c78632d", size = 33096, upload-time = "2025-12-11T13:35:33.067Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/3e/f6f10f178b6316de67f0dfdbbb699a24fbe8917cf1743c1595fb9dcdd461/opentelemetry_instrumentation-0.61b0-py3-none-any.whl", hash = "sha256:92a93a280e69788e8f88391247cc530fd81f16f2b011979d4d6398f805cfbc63", size = 33448, upload-time = "2026-03-04T14:19:02.447Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/3e/143cf5c034e58037307e6a24f06e0dd64b2c49ae60a965fc580027581931/opentelemetry_instrumentation_asgi-0.61b0.tar.gz", hash = "sha256:9d08e127244361dc33976d39dd4ca8f128b5aa5a7ae425208400a80a095019b5", size = 26691, upload-time = "2026-03-04T14:20:21.038Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/78/154470cf9d741a7487fbb5067357b87386475bbb77948a6707cae982e158/opentelemetry_instrumentation_asgi-0.61b0-py3-none-any.whl", hash = "sha256:e4b3ce6b66074e525e717efff20745434e5efd5d9df6557710856fba356da7a4", size = 16980, upload-time = "2026-03-04T14:19:10.894Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-dbapi"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/ed/ba91c9e4a3ec65781e9c59982109f0a36de9fa574f622596b33d1985dab5/opentelemetry_instrumentation_dbapi-0.61b0.tar.gz", hash = "sha256:02fa800682c1de87dcad0e59f2092b3b6fb8b8ea0636518f989e1166b418dcb9", size = 16761, upload-time = "2026-03-04T14:20:29.782Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/a5/d26c68f3fd33eb7410985cef7700bb426e2c4a26de9207902cbbffb19a3f/opentelemetry_instrumentation_dbapi-0.61b0-py3-none-any.whl", hash = "sha256:8f762c39c8edd20c6aef3282550a2cfbfec76c3f431bf5c36327dcf9ece2e5a0", size = 14134, upload-time = "2026-03-04T14:19:24.718Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-django"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-wsgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/ef/6bc1a6560630f26b1c010af86b28f42bfbe6a601bd1647d1436e0d3436aa/opentelemetry_instrumentation_django-0.61b0.tar.gz", hash = "sha256:9885154dc128578de0e6b5ce49e965c786f8ab071175bec005dcd454510be951", size = 25996, upload-time = "2026-03-04T14:20:30.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/3b/74dad6d98fdee1d137f1c2748548d4159578508f21e3aef581c110e64041/opentelemetry_instrumentation_django-0.61b0-py3-none-any.whl", hash = "sha256:26c1b0b325a9783d4a2f4df660ba05cf929c3eda2ae9b07916b649bb44e1c5b6", size = 20773, upload-time = "2026-03-04T14:19:25.675Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/35/aa727bb6e6ef930dcdc96a617b83748fece57b43c47d83ba8d83fbeca657/opentelemetry_instrumentation_fastapi-0.61b0.tar.gz", hash = "sha256:3a24f35b07c557ae1bbc483bf8412221f25d79a405f8b047de8b670722e2fa9f", size = 24800, upload-time = "2026-03-04T14:20:32.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/05/acfeb2cccd434242a0a7d0ea29afaf077e04b42b35b485d89aee4e0d9340/opentelemetry_instrumentation_fastapi-0.61b0-py3-none-any.whl", hash = "sha256:a1a844d846540d687d377516b2ff698b51d87c781b59f47c214359c4a241047c", size = 13485, upload-time = "2026-03-04T14:19:30.351Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-flask"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-wsgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/33/d6852d8f2c3eef86f2f8c858d6f5315983c7063e07e595519e96d4c31c06/opentelemetry_instrumentation_flask-0.61b0.tar.gz", hash = "sha256:e9faf58dfd9860a1868442d180142645abdafc1a652dd73d469a5efd106a7d49", size = 24071, upload-time = "2026-03-04T14:20:33.437Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/41/619f3530324a58491f2d20f216a10dd7393629b29db4610dda642a27f4ed/opentelemetry_instrumentation_flask-0.61b0-py3-none-any.whl", hash = "sha256:e8ce474d7ce543bfbbb3e93f8a6f8263348af9d7b45502f387420cf3afa71253", size = 15996, upload-time = "2026-03-04T14:19:31.304Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-logging"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/e0/69473f925acfe2d4edf5c23bcced36906ac3627aa7c5722a8e3f60825f3b/opentelemetry_instrumentation_logging-0.61b0.tar.gz", hash = "sha256:feaa30b700acd2a37cc81db5f562ab0c3a5b6cc2453595e98b72c01dcf649584", size = 17906, upload-time = "2026-03-04T14:20:37.398Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/0e/2137db5239cc5e564495549a4d11488a7af9b48fc76520a0eea20e69ddae/opentelemetry_instrumentation_logging-0.61b0-py3-none-any.whl", hash = "sha256:6d87e5ded6a0128d775d41511f8380910a1b610671081d16efb05ac3711c0074", size = 17076, upload-time = "2026-03-04T14:19:36.765Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-psycopg2"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-dbapi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/28/f28d52b1088e7a09761566f8700507b54d3d83a6f9c93c0ce02f53619e83/opentelemetry_instrumentation_psycopg2-0.61b0.tar.gz", hash = "sha256:863ccf9687b71e73dd489c7bb117278768bdf26aa0dafe7dc974a2425e05b5d7", size = 11676, upload-time = "2026-03-04T14:20:41.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/f1/4341d0584c288765c73e28c30ba58e7aedb50c01108f17f947b872657f79/opentelemetry_instrumentation_psycopg2-0.61b0-py3-none-any.whl", hash = "sha256:36b96983beda05c927179bb66b6c72f07a8d9a591f76ce9da88b1dd1587cb083", size = 11491, upload-time = "2026-03-04T14:19:42.018Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-requests"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/c7/7a47cb85c7aa93a9c820552e414889185bcf91245271d12e5d443e5f834d/opentelemetry_instrumentation_requests-0.61b0.tar.gz", hash = "sha256:15f879ce8fb206bd7e6fdc61663ea63481040a845218c0cf42902ce70bd7e9d9", size = 18379, upload-time = "2026-03-04T14:20:46.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/a1/a7a133b273d1f53950f16a370fc94367eff472c9c2576e8e9e28c62dcc9f/opentelemetry_instrumentation_requests-0.61b0-py3-none-any.whl", hash = "sha256:cce19b379949fe637eb73ba39b02c57d2d0805447ca6d86534aa33fcb141f683", size = 14207, upload-time = "2026-03-04T14:19:51.765Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-urllib"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/37/77cd326b083390e74280c08bbd585153809619dad068e2d1b253fec1164d/opentelemetry_instrumentation_urllib-0.61b0.tar.gz", hash = "sha256:6a15ff862fc1603e0ea5ea75558f76f36436b02e0ae48daecedcb5e574cce160", size = 16894, upload-time = "2026-03-04T14:20:52.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/fc/a88fbfd8b9eb16ba1c21f0514c12696441be7fc42c7e319f3ee793bf9e96/opentelemetry_instrumentation_urllib-0.61b0-py3-none-any.whl", hash = "sha256:d7e409876580fb41102e3522ce81a756e53a74073c036a267a1c280cc0fa09b0", size = 13970, upload-time = "2026-03-04T14:20:01.24Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-urllib3"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/80/7ad8da30f479c6117768e72d6f2f3f0bd3495338707d6f61de042149578a/opentelemetry_instrumentation_urllib3-0.61b0.tar.gz", hash = "sha256:f00037bc8ff813153c4b79306f55a14618c40469a69c6c03a3add29dc7e8b928", size = 19325, upload-time = "2026-03-04T14:20:53.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/0c/01359e55b9f2fb2b1d4d9e85e77773a96697207895118533f3be718a3326/opentelemetry_instrumentation_urllib3-0.61b0-py3-none-any.whl", hash = "sha256:9644f8c07870266e52f129e6226859ff3a35192555abe46fa0ef9bbbf5b6b46d", size = 14339, upload-time = "2026-03-04T14:20:02.681Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-wsgi"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/e5/189f2845362cfe78e356ba127eab21456309def411c6874aa4800c3de816/opentelemetry_instrumentation_wsgi-0.61b0.tar.gz", hash = "sha256:380f2ae61714e5303275a80b2e14c58571573cd1fddf496d8c39fb9551c5e532", size = 19898, upload-time = "2026-03-04T14:20:54.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/75/d6b42ba26f3c921be6d01b16561b7bb863f843bad7ac3a5011f62617bcab/opentelemetry_instrumentation_wsgi-0.61b0-py3-none-any.whl", hash = "sha256:bd33b0824166f24134a3400648805e8d2e6a7951f070241294e8b8866611d7fa", size = 14628, upload-time = "2026-03-04T14:20:03.934Z" },
+]
+
+[[package]]
+name = "opentelemetry-resource-detector-azure"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e4/0d359d48d03d447225b30c3dd889d5d454e3b413763ff721f9b0e4ac2e59/opentelemetry_resource_detector_azure-0.1.5.tar.gz", hash = "sha256:e0ba658a87c69eebc806e75398cd0e9f68a8898ea62de99bc1b7083136403710", size = 11503, upload-time = "2024-05-16T21:54:58.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/ae/c26d8da88ba2e438e9653a408b0c2ad6f17267801250a8f3cc6405a93a72/opentelemetry_resource_detector_azure-0.1.5-py3-none-any.whl", hash = "sha256:4dcc5d54ab5c3b11226af39509bc98979a8b9e0f8a24c1b888783755d3bf00eb", size = 14252, upload-time = "2024-05-16T21:54:57.208Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.39.1"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/fd/3c3125b20ba18ce2155ba9ea74acb0ae5d25f8cd39cfd37455601b7955cc/opentelemetry_sdk-1.40.0.tar.gz", hash = "sha256:18e9f5ec20d859d268c7cb3c5198c8d105d073714db3de50b593b8c1345a48f2", size = 184252, upload-time = "2026-03-04T14:17:31.87Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/98/e91cf858f203d86f4eccdf763dcf01cf03f1dae80c3750f7e635bfa206b6/opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c", size = 132565, upload-time = "2025-12-11T13:32:35.069Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c5/6a852903d8bfac758c6dc6e9a68b015d3c33f2f1be5e9591e0f4b69c7e0a/opentelemetry_sdk-1.40.0-py3-none-any.whl", hash = "sha256:787d2154a71f4b3d81f20524a8ce061b7db667d24e46753f32a7bc48f1c1f3f1", size = 141951, upload-time = "2026-03-04T14:17:17.961Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.60b1"
+version = "0.61b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/c0/4ae7973f3c2cfd2b6e321f1675626f0dab0a97027cc7a297474c9c8f3d04/opentelemetry_semantic_conventions-0.61b0.tar.gz", hash = "sha256:072f65473c5d7c6dc0355b27d6c9d1a679d63b6d4b4b16a9773062cb7e31192a", size = 145755, upload-time = "2026-03-04T14:17:32.664Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/37/cc6a55e448deaa9b27377d087da8615a3416d8ad523d5960b78dbeadd02a/opentelemetry_semantic_conventions-0.61b0-py3-none-any.whl", hash = "sha256:fa530a96be229795f8cef353739b618148b0fe2b4b3f005e60e262926c4d38e2", size = 231621, upload-time = "2026-03-04T14:17:19.33Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/3c/f0196223efc5c4ca19f8fad3d5462b171ac6333013335ce540c01af419e9/opentelemetry_util_http-0.61b0.tar.gz", hash = "sha256:1039cb891334ad2731affdf034d8fb8b48c239af9b6dd295e5fabd07f1c95572", size = 11361, upload-time = "2026-03-04T14:20:57.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/e5/c08aaaf2f64288d2b6ef65741d2de5454e64af3e050f34285fb1907492fe/opentelemetry_util_http-0.61b0-py3-none-any.whl", hash = "sha256:8e715e848233e9527ea47e275659ea60a57a75edf5206a3b937e236a6da5fc33", size = 9281, upload-time = "2026-03-04T14:20:08.364Z" },
 ]
 
 [[package]]
@@ -1974,6 +2402,61 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/0d/94dfe80193e79d55258345901acd2917523d56e8381bc4dee7fd38e3868a/proto_plus-1.27.2.tar.gz", hash = "sha256:b2adde53adadf75737c44d3dcb0104fde65250dfc83ad59168b4aa3e574b6a24", size = 57204, upload-time = "2026-03-26T22:18:57.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/f3/1fba73eeffafc998a25d59703b63f8be4fe8a5cb12eaff7386a0ba0f7125/proto_plus-1.27.2-py3-none-any.whl", hash = "sha256:6432f75893d3b9e70b9c412f1d2f03f65b11fb164b793d14ae2ca01821d22718", size = 50450, upload-time = "2026-03-26T22:13:42.927Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
 name = "py-key-value-aio"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2024,6 +2507,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -2552,6 +3056,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Summary

This branch updates `origin/dev` with two main additions: (1) expanded visualization support for multi-indicator comparison, including new MCP tooling and prompts, and (2) a manual HTTP/SSE load script for exercising the Data360 MCP endpoint under concurrency (warmup, ramp, soak).

### Multi-indicator visualization

- Extends the visualization layer (`src/data360/visualization.py`, `src/data360/viz_config.py`) to support multi-indicator comparison workflows.
- Registers and documents the new capability via MCP (`src/data360/mcp_server/tools.py`, `src/data360/mcp_server/prompts.py`).
- Adds broad automated coverage (`tests/test_visualization.py` updates and new `tests/test_viz_complex.py`).

### Load testing script

- Adds `scripts/test_rate_limits.py`: Typer CLI, thread-local `requests.Session` for safe concurrency, configurable phases (warmup / ramp / soak), optional JSON report, APIM subscription key via `APIM_SUBSCRIPTION_KEY`, URL resolution via `DATA360_MCP_URL` / `MCP_SERVER_URL`, and dev dependency on `requests` in `pyproject.toml` (see `uv.lock`).

### How to test

- **Unit / integration:** `uv run pytest` (focus on `tests/test_visualization.py` and `tests/test_viz_complex.py` if time is limited).
- **Load script (optional, hits real network):**  
  `uv run python scripts/test_rate_limits.py --help`  
  then run against a non-production URL as appropriate.
