### PR TITLE
WIP: feat(tools): add data360_analyze_development_topic with LLM sampling fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ cp .env.example .env
 | `MCP_PORT` | Port for the MCP server | `8000` |
 | `MCP_TRANSPORT` | Transport protocol (`http` or `sse`) | `http` |
 | `MCP_CHARTS_API_URL` | Optional URL for an external chart rendering API | _(none)_ |
+| `OPENAI_API_KEY` | Optional API key for LLM sampling fallback (used by `data360_analyze_development_topic` if client lacks sampling support) | _(none)_ |
 
 ### Run the Server
 
@@ -90,6 +91,7 @@ DEBUG=true uv run scripts/llm_mcp_demo.py
 
 | Tool | Description |
 |---|---|
+| `data360_analyze_development_topic` | End-to-end multi-search and prefetching tool for analyzing vague/abstract topics (e.g. "What makes a country great?"). Decomposes the question using MCP sampling (with OpenAI fallback), evaluates candidates, and ranks indicators. |
 | `data360_search_indicators` | Search indicators with enriched metadata. Pass `required_country` for server-side coverage check. Returns `covers_country`, `latest_data`, `dimensions`. |
 | `data360_get_data` | Fetch data points with filters (country, time period, SEX, AGE, etc.). |
 | `data360_get_metadata` | Get indicator metadata. Use `select_fields` for specific fields. |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -40,6 +40,7 @@ The server starts at `http://localhost:8000/mcp`.
 
 | Tool | What it does |
 |---|---|
+| `data360_analyze_development_topic` | Analyze vague topics using LLM query decomposition |
 | `data360_search_indicators` | Search indicators with country coverage check |
 | `data360_get_data` | Fetch time-series data with filters |
 | `data360_get_metadata` | Get indicator methodology and definitions |

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -1,8 +1,11 @@
 import json
 import logging
+import re
 import zlib
 from typing import Any
 from urllib.parse import urlencode
+
+from fastmcp.server.context import Context
 
 import dotenv
 import httpx
@@ -486,6 +489,15 @@ async def search(
     Use this first when the user asks for data on a topic (e.g. unemployment, poverty, GDP).
     No other tools are required before this one. After picking an indicator, call
     data360_get_metadata and/or data360_get_disaggregation before fetching data or generating a chart.
+
+    Use when the user already names a specific indicator or metric — for example:
+    "GDP per capita for Kenya", "unemployment rate in Morocco", "life expectancy in Sub-Saharan Africa".
+
+    Do NOT use this tool when the user asks a broad or vague question that does not name a
+    specific indicator — for example: "What makes a country great?",
+    "What are Ghana's economic challenges?", "How is education performing in Africa?"
+    In those cases, use data360_analyze_development_topic instead, which decomposes
+    the question into specific sub-queries and searches for each one.
 
     Args:
         query: Search query (e.g., "unemployment rate", "poverty", "GDP per capita").
@@ -1102,6 +1114,349 @@ async def discover_indicators(
     )
 
     # ... existing implementation ...
+
+
+# --- Topic Analysis Helpers ---
+
+# Conjunctions and stopwords used for rule-based query decomposition
+_SPLIT_CONJUNCTIONS = re.compile(r"\band\b|\bor\b|\b&\b|,|;", re.IGNORECASE)
+_STOPWORDS = frozenset({
+    "what", "are", "the", "main", "is", "a", "an", "of", "for", "in",
+    "to", "how", "does", "do", "its", "their", "has", "been", "being",
+    "with", "on", "at", "by", "from", "about", "between", "which",
+    "facing", "challenges", "issues", "problems", "region", "country",
+    "makes", "great", "key", "major", "most", "important",
+})
+_DEFAULT_SUMMARY_YEARS = 5
+_SAMPLING_SYSTEM_PROMPT = (
+    "You are a development economist. Given the user's question about "
+    "development data or indicators, generate 3-5 specific, measurable "
+    "topics that can be searched in a statistical database (e.g. World "
+    "Bank indicators). Return ONLY a JSON array of short search strings. "
+    'Example: ["GDP per capita", "life expectancy at birth", "school enrollment rate"]\n'
+    "Do not include any other text."
+)
+
+
+def _decompose_query(query: str) -> list[str]:
+    """Split a vague query into searchable sub-queries using rule-based heuristics.
+
+    Splits on conjunctions (and, or, &, commas, semicolons), removes stopwords,
+    and returns non-empty fragments. Falls back to the original query if
+    decomposition produces nothing useful.
+    """
+    # Split on conjunctions
+    fragments = _SPLIT_CONJUNCTIONS.split(query)
+    sub_queries: list[str] = []
+    for frag in fragments:
+        # Remove stopwords and clean up
+        words = [
+            w for w in frag.strip().split()
+            if w.lower() not in _STOPWORDS and len(w) > 1
+        ]
+        cleaned = " ".join(words).strip()
+        if cleaned and len(cleaned) > 2:
+            sub_queries.append(cleaned)
+
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    unique: list[str] = []
+    for sq in sub_queries:
+        key = sq.lower()
+        if key not in seen:
+            seen.add(key)
+            unique.append(sq)
+
+    # If decomposition produced nothing useful, use the original query
+    if not unique:
+        return [query.strip()]
+
+    # Cap at 5 sub-queries to bound search cost
+    return unique[:5]
+
+
+def _score_indicator(
+    indicator: "EnrichedIndicator",
+    query_tokens: set[str],
+) -> float:
+    """Score an indicator for relevance to the original query.
+
+    Scoring factors:
+    - Country coverage: +2 if covers_country is True
+    - Data recency: +1 if latest_data is within the last 3 years
+    - Token overlap: proportion of query tokens found in indicator name + definition
+    """
+    score = 0.0
+
+    # Country coverage
+    if indicator.covers_country:
+        score += 2.0
+
+    # Data recency
+    try:
+        from datetime import datetime
+        latest = int(indicator.latest_data or "0")
+        current_year = datetime.now().year
+        if latest >= current_year - 3:
+            score += 1.0
+        elif latest >= current_year - 10:
+            score += 0.5
+    except (ValueError, TypeError):
+        pass
+
+    # Token overlap between query and indicator name + definition
+    indicator_text = f"{indicator.name} {indicator.truncated_definition}".lower()
+    indicator_tokens = set(indicator_text.split())
+    if query_tokens:
+        overlap = len(query_tokens & indicator_tokens)
+        score += overlap / max(len(query_tokens), 1)
+
+    return score
+
+
+async def analyze_development_topic(
+    query: str,
+    country: str | None = None,
+    max_indicators: int = 4,
+    start_year: int | None = None,
+    end_year: int | None = None,
+    ctx: Context | None = None,
+) -> dict[str, Any]:
+    """Analyze a development topic by finding and fetching relevant indicators.
+
+    Use this tool when the user asks a broad or vague question about development
+    data that does not name a specific indicator — for example:
+    "What makes a country great?", "What are Ghana's economic challenges?",
+    "How is education performing in Sub-Saharan Africa?"
+
+    The tool decomposes the question into specific searchable topics (using the
+    connected LLM when sampling is available, or rule-based heuristics as
+    fallback), searches the Data360 catalog for each topic, scores and ranks
+    the results, and prefetches recent data for the top indicators.
+
+    Do NOT use this tool when the user already names a specific indicator or
+    metric (e.g. "GDP per capita for Kenya") — use data360_search_indicators
+    and data360_get_data directly instead.
+
+    Args:
+        query: The user's development-related question (can be vague/broad).
+        country: Optional country name or 3-letter code (e.g. "Ghana", "GHA").
+        max_indicators: Maximum number of indicators to return (default 4, max 6).
+        start_year: Optional start year for data snapshots. Defaults to last 5 years.
+        end_year: Optional end year for data snapshots. Defaults to current year.
+        ctx: MCP Context object (injected by FastMCP). Used for sampling when available.
+
+    Returns:
+        Dict with:
+            query: The original question.
+            country / country_code: Resolved country info (if provided).
+            sub_queries: The decomposed search terms (from LLM or rule-based).
+            decomposition_method: "sampling" or "rule_based".
+            selected_indicators: List of ranked indicator dicts, each with:
+                rank, indicator_id, database_id, name, definition, reason,
+                data_snapshot (list of recent data points), data_error (if fetch failed).
+            coverage_note: Summary of how many indicators were found.
+            error: Top-level error message if the entire operation failed.
+    """
+    import asyncio
+    from datetime import datetime
+
+    max_indicators = min(max_indicators, 6)
+    current_year = datetime.now().year
+    if end_year is None:
+        end_year = current_year
+    if start_year is None:
+        start_year = current_year - _DEFAULT_SUMMARY_YEARS + 1
+
+    # --- Step 1: Resolve country code ---
+    country_code = None
+    if country:
+        country_code = await _resolve_country_code(country)
+
+    # --- Step 2: Decompose query into sub-queries ---
+    sub_queries: list[str] = []
+    decomposition_method = "rule_based"
+    sampling_error = None
+
+    # Try sampling first (LLM-powered decomposition)
+    _logger.info(
+        "analyze_development_topic: ctx=%s, type=%s",
+        ctx is not None, type(ctx).__name__ if ctx is not None else "None",
+    )
+    if ctx is not None:
+        try:
+            sampling_result = await ctx.sample(
+                f"User question: {query}",
+                system_prompt=_SAMPLING_SYSTEM_PROMPT,
+                max_tokens=256,
+            )
+            # Parse the LLM response as a JSON array
+            raw_text = sampling_result.text or ""
+            # Strip markdown code fences if present
+            cleaned = raw_text.strip()
+            if cleaned.startswith("```"):
+                lines = cleaned.split("\n")
+                # Remove first and last lines (fences)
+                cleaned = "\n".join(lines[1:-1]).strip()
+            parsed = json.loads(cleaned)
+            if isinstance(parsed, list) and all(isinstance(s, str) for s in parsed):
+                sub_queries = [s.strip() for s in parsed if s.strip()][:5]
+                decomposition_method = "sampling"
+                _logger.info(
+                    "Sampling decomposition succeeded: %s", sub_queries
+                )
+        except (ValueError, json.JSONDecodeError) as e:
+            sampling_error = f"{type(e).__name__}: {e}"
+            _logger.warning(
+                "Sampling returned non-JSON response, falling back to rule-based: %s", e
+            )
+        except Exception as e:
+            sampling_error = f"{type(e).__name__}: {e}"
+            _logger.info(
+                "Sampling unavailable (client may not support it), "
+                "falling back to rule-based decomposition: %s (%s)",
+                type(e).__name__, e,
+            )
+
+    # Fall back to rule-based decomposition
+    if not sub_queries:
+        sub_queries = _decompose_query(query)
+        decomposition_method = "rule_based"
+
+    _logger.info(
+        "Analyzing topic with %d sub-queries (%s): %s",
+        len(sub_queries), decomposition_method, sub_queries,
+    )
+
+    # --- Step 3: Multi-search across sub-queries ---
+    search_tasks = [
+        search(
+            query=sq,
+            required_country=country_code or country,
+            limit=max_indicators,
+        )
+        for sq in sub_queries
+    ]
+    search_results = await asyncio.gather(*search_tasks, return_exceptions=True)
+
+    # Pool and deduplicate indicators by indicator ID
+    seen_ids: set[str] = set()
+    all_indicators: list[tuple[EnrichedIndicator, str]] = []  # (indicator, source_query)
+    total_candidates = 0
+
+    for sq, result in zip(sub_queries, search_results):
+        if isinstance(result, Exception):
+            _logger.warning("Search failed for sub-query '%s': %s", sq, result)
+            continue
+        if result.error:
+            _logger.warning("Search error for sub-query '%s': %s", sq, result.error)
+            continue
+        for ind in result.indicators:
+            total_candidates += 1
+            if ind.idno not in seen_ids:
+                seen_ids.add(ind.idno)
+                all_indicators.append((ind, sq))
+
+    if not all_indicators:
+        return {
+            "query": query,
+            "country": country,
+            "country_code": country_code,
+            "sub_queries": sub_queries,
+            "decomposition_method": decomposition_method,
+            "selected_indicators": [],
+            "coverage_note": f"No indicators found across {len(sub_queries)} sub-queries.",
+            "error": "No matching indicators found for this topic.",
+        }
+
+    # --- Step 4: Score and rank ---
+    query_tokens = {
+        w.lower() for w in query.split()
+        if w.lower() not in _STOPWORDS and len(w) > 1
+    }
+
+    scored: list[tuple[float, EnrichedIndicator, str]] = []
+    for ind, source_sq in all_indicators:
+        score = _score_indicator(ind, query_tokens)
+        scored.append((score, ind, source_sq))
+
+    # Sort descending by score
+    scored.sort(key=lambda x: x[0], reverse=True)
+    top = scored[:max_indicators]
+
+    # --- Step 5: Prefetch data for top indicators ---
+    async def _fetch_data_for_indicator(
+        ind: EnrichedIndicator,
+    ) -> dict[str, Any] | None:
+        """Fetch a small data snapshot for one indicator."""
+        try:
+            filters: dict[str, str | None] = {}
+            if country_code:
+                filters["REF_AREA"] = country_code
+
+            data_result = await get_data(
+                database_id=ind.database_id,
+                indicator_id=ind.idno,
+                disaggregation_filters=filters if filters else None,
+                start_year=start_year,
+                end_year=end_year,
+                limit=20,
+            )
+            if data_result.error:
+                return {"error": data_result.error}
+            return {
+                "data": data_result.data,
+                "metadata": data_result.metadata,
+                "count": data_result.count,
+            }
+        except Exception as e:
+            return {"error": str(e)}
+
+    data_tasks = [_fetch_data_for_indicator(ind) for _, ind, _ in top]
+    data_results = await asyncio.gather(*data_tasks, return_exceptions=True)
+
+    # --- Step 6: Build response ---
+    selected_indicators = []
+    for rank, ((score, ind, source_sq), data_res) in enumerate(
+        zip(top, data_results), start=1
+    ):
+        data_snapshot = None
+        data_error = None
+
+        if isinstance(data_res, Exception):
+            data_error = str(data_res)
+        elif data_res is not None and "error" in data_res:
+            data_error = data_res["error"]
+        elif data_res is not None:
+            data_snapshot = data_res
+
+        selected_indicators.append({
+            "rank": rank,
+            "indicator_id": ind.idno,
+            "database_id": ind.database_id,
+            "name": ind.name,
+            "definition": ind.truncated_definition,
+            "matched_sub_query": source_sq,
+            "score": round(score, 2),
+            "data_snapshot": data_snapshot,
+            "data_error": data_error,
+        })
+
+    result = {
+        "query": query,
+        "country": country,
+        "country_code": country_code,
+        "sub_queries": sub_queries,
+        "decomposition_method": decomposition_method,
+        "selected_indicators": selected_indicators,
+        "coverage_note": (
+            f"{len(selected_indicators)} indicators selected from "
+            f"{len(sub_queries)} sub-queries ({total_candidates} candidates)"
+        ),
+    }
+    if sampling_error:
+        result["sampling_error"] = sampling_error
+    return result
 
 
 # --- Visualization Workflow Tools ---

--- a/src/data360/mcp_server/_server_definition.py
+++ b/src/data360/mcp_server/_server_definition.py
@@ -1,4 +1,23 @@
+import os
+import dotenv
 from fastmcp import FastMCP
+from fastmcp.client.sampling.handlers.openai import OpenAISamplingHandler
+
+# Load .env so OPENAI_API_KEY is available
+dotenv.load_dotenv()
+
+# Only instantiate the OpenAI handler if an API key actually exists.
+# Otherwise, AsyncOpenAI() will immediately crash the server on startup.
+sampling_handler = None
+if os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY_MCP"):
+    try:
+        sampling_handler = OpenAISamplingHandler(default_model="gpt-4o-mini")
+    except Exception:
+        pass
 
 # NOTE: base definition to allow for mounting of resources, prompts, tools, independently
-mcp = FastMCP("Data360 MCP Server")
+mcp = FastMCP(
+    "Data360 MCP Server",
+    sampling_handler=sampling_handler,
+    sampling_handler_behavior="fallback",
+)

--- a/src/data360/mcp_server/tools.py
+++ b/src/data360/mcp_server/tools.py
@@ -70,3 +70,9 @@ get_supported_chart_types = mcp.tool(
     name="data360_get_supported_chart_types",
     description=data360_viz.get_supported_chart_types.__doc__,
 )
+
+analyze_development_topic = mcp.tool(
+    data360_api.analyze_development_topic,
+    name="data360_analyze_development_topic",
+    description=data360_api.analyze_development_topic.__doc__,
+)

--- a/tests/test_analyze_topic.py
+++ b/tests/test_analyze_topic.py
@@ -1,0 +1,359 @@
+"""Tests for analyze_development_topic tool."""
+
+import json
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from data360.api import (
+    _decompose_query,
+    _score_indicator,
+    analyze_development_topic,
+)
+from data360.models import EnrichedIndicator, EnrichedSearchResponse
+
+
+# --- Helpers ---
+
+
+def _make_indicator(
+    idno: str = "WB_WDI_NY_GDP_PCAP_KD",
+    name: str = "GDP per capita (constant 2015 US$)",
+    database_id: str = "WB_WDI",
+    definition: str = "GDP per capita is gross domestic product divided by mid-year population",
+    covers_country: bool = True,
+    latest_data: str = "2023",
+) -> EnrichedIndicator:
+    return EnrichedIndicator(
+        idno=idno,
+        database_id=database_id,
+        name=name,
+        truncated_definition=definition[:100],
+        covers_country=covers_country,
+        latest_data=latest_data,
+    )
+
+
+def _make_search_response(
+    indicators: list[EnrichedIndicator] | None = None,
+    error: str | None = None,
+) -> EnrichedSearchResponse:
+    return EnrichedSearchResponse(
+        indicators=indicators or [],
+        error=error,
+        count=len(indicators or []),
+    )
+
+
+@dataclass
+class FakeSamplingResult:
+    text: str | None
+    model: str = "fake-model"
+
+
+class FakeContext:
+    """Fake MCP Context that simulates sampling."""
+
+    def __init__(self, response_text: str | None = None, should_raise: bool = False):
+        self._response_text = response_text
+        self._should_raise = should_raise
+
+    async def sample(self, messages, **kwargs) -> FakeSamplingResult:
+        if self._should_raise:
+            raise ValueError("Client does not support sampling")
+        return FakeSamplingResult(text=self._response_text)
+
+
+# --- Unit tests for _decompose_query ---
+
+
+class TestDecomposeQuery:
+    """Tests for rule-based query decomposition."""
+
+    def test_splits_on_and(self):
+        result = _decompose_query("economic growth and public spending")
+        assert len(result) == 2
+        assert any("economic" in sq.lower() or "growth" in sq.lower() for sq in result)
+        assert any("public" in sq.lower() or "spending" in sq.lower() for sq in result)
+
+    def test_splits_on_comma(self):
+        result = _decompose_query("GDP, poverty, education")
+        assert len(result) == 3
+
+    def test_splits_on_semicolon(self):
+        result = _decompose_query("health outcomes; education access")
+        assert len(result) == 2
+
+    def test_removes_stopwords(self):
+        result = _decompose_query("What are the main challenges facing economic growth")
+        # Should have cleaned fragments, not contain stopwords as standalone terms
+        for sq in result:
+            words = sq.lower().split()
+            # At least the meaningful words should remain
+            assert not all(w in {"what", "are", "the", "main"} for w in words)
+
+    def test_falls_back_to_original_on_single_topic(self):
+        result = _decompose_query("GDP per capita")
+        assert len(result) == 1
+        assert "GDP" in result[0]
+
+    def test_handles_empty_fragments(self):
+        result = _decompose_query("and or and")
+        # All fragments are stopwords, should fall back to original
+        assert len(result) >= 1
+
+    def test_deduplicates(self):
+        result = _decompose_query("growth and growth and growth")
+        # All fragments are the same word, should deduplicate to 1
+        assert len(result) == 1
+
+    def test_caps_at_five(self):
+        result = _decompose_query("a, b, c, d, e, f, g, h")
+        assert len(result) <= 5
+
+
+# --- Unit tests for _score_indicator ---
+
+
+class TestScoreIndicator:
+    """Tests for indicator scoring function."""
+
+    def test_country_coverage_bonus(self):
+        ind_covered = _make_indicator(covers_country=True)
+        ind_not_covered = _make_indicator(covers_country=False)
+        tokens = {"gdp", "growth"}
+
+        score_covered = _score_indicator(ind_covered, tokens)
+        score_not = _score_indicator(ind_not_covered, tokens)
+
+        assert score_covered > score_not
+
+    def test_recency_bonus(self):
+        ind_recent = _make_indicator(latest_data="2025")
+        ind_old = _make_indicator(latest_data="2005")
+        tokens = {"gdp"}
+
+        score_recent = _score_indicator(ind_recent, tokens)
+        score_old = _score_indicator(ind_old, tokens)
+
+        assert score_recent > score_old
+
+    def test_token_overlap(self):
+        ind = _make_indicator(
+            name="GDP per capita growth",
+            definition="Economic growth rate",
+        )
+        high_overlap_tokens = {"gdp", "growth", "economic"}
+        no_overlap_tokens = {"education", "literacy", "enrollment"}
+
+        score_high = _score_indicator(ind, high_overlap_tokens)
+        score_none = _score_indicator(ind, no_overlap_tokens)
+
+        assert score_high > score_none
+
+
+# --- Integration tests for analyze_development_topic ---
+
+
+class TestAnalyzeDevelopmentTopic:
+    """Tests for the main analyze_development_topic function."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_with_sampling(self):
+        """Sampling succeeds and returns LLM-generated sub-queries."""
+        indicators = [
+            _make_indicator(
+                idno="WB_WDI_NY_GDP_PCAP_KD",
+                name="GDP per capita",
+            ),
+            _make_indicator(
+                idno="WB_WDI_SP_DYN_LE00_IN",
+                name="Life expectancy at birth",
+            ),
+        ]
+        mock_search_response = _make_search_response(indicators)
+
+        ctx = FakeContext(
+            response_text=json.dumps(["GDP per capita", "life expectancy"])
+        )
+
+        mock_data_response = AsyncMock()
+        mock_data_response.return_value.data = [
+            {"OBS_VALUE": 1500, "TIME_PERIOD": "2023", "REF_AREA": "GHA"}
+        ]
+        mock_data_response.return_value.error = None
+        mock_data_response.return_value.metadata = {"name": "GDP per capita"}
+        mock_data_response.return_value.count = 1
+
+        with (
+            patch("data360.api.search", return_value=mock_search_response) as mock_search,
+            patch("data360.api.get_data", mock_data_response),
+            patch("data360.api._resolve_country_code", return_value="GHA"),
+        ):
+            result = await analyze_development_topic(
+                query="What makes a country great?",
+                country="Ghana",
+                ctx=ctx,
+            )
+
+        assert result["decomposition_method"] == "sampling"
+        assert len(result["sub_queries"]) == 2
+        assert result["country_code"] == "GHA"
+        assert len(result["selected_indicators"]) > 0
+        assert "error" not in result or result.get("error") is None
+
+    @pytest.mark.asyncio
+    async def test_sampling_fallback(self):
+        """When sampling raises, falls back to rule-based decomposition."""
+        indicators = [
+            _make_indicator(
+                idno="WB_WDI_NY_GDP_PCAP_KD",
+                name="GDP per capita",
+            ),
+        ]
+        mock_search_response = _make_search_response(indicators)
+
+        ctx = FakeContext(should_raise=True)
+
+        mock_data_response = AsyncMock()
+        mock_data_response.return_value.data = []
+        mock_data_response.return_value.error = None
+        mock_data_response.return_value.metadata = {}
+        mock_data_response.return_value.count = 0
+
+        with (
+            patch("data360.api.search", return_value=mock_search_response),
+            patch("data360.api.get_data", mock_data_response),
+        ):
+            result = await analyze_development_topic(
+                query="economic growth and public spending",
+                ctx=ctx,
+            )
+
+        assert result["decomposition_method"] == "rule_based"
+        assert len(result["sub_queries"]) >= 2
+        # Should not crash — graceful fallback
+        assert "error" not in result or result.get("error") is None
+
+    @pytest.mark.asyncio
+    async def test_no_ctx_uses_rule_based(self):
+        """When ctx is None (no MCP context), uses rule-based decomposition."""
+        indicators = [
+            _make_indicator(idno="WB_WDI_NY_GDP_PCAP_KD", name="GDP per capita"),
+        ]
+        mock_search_response = _make_search_response(indicators)
+
+        mock_data_response = AsyncMock()
+        mock_data_response.return_value.data = []
+        mock_data_response.return_value.error = None
+        mock_data_response.return_value.metadata = {}
+        mock_data_response.return_value.count = 0
+
+        with (
+            patch("data360.api.search", return_value=mock_search_response),
+            patch("data360.api.get_data", mock_data_response),
+        ):
+            result = await analyze_development_topic(
+                query="economic growth and education",
+                ctx=None,
+            )
+
+        assert result["decomposition_method"] == "rule_based"
+        assert len(result["sub_queries"]) >= 2
+
+    @pytest.mark.asyncio
+    async def test_empty_search_results(self):
+        """When all searches return no indicators, returns error."""
+        empty_response = _make_search_response(indicators=[])
+
+        with patch("data360.api.search", return_value=empty_response):
+            result = await analyze_development_topic(
+                query="nonexistent topic xyzzy",
+            )
+
+        assert result["selected_indicators"] == []
+        assert result["error"] is not None
+        assert "No matching" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_data_fetch_failure(self):
+        """Data fetch failures are reported per-indicator, do not crash the tool."""
+        indicators = [
+            _make_indicator(idno="WB_WDI_NY_GDP_PCAP_KD", name="GDP per capita"),
+        ]
+        mock_search_response = _make_search_response(indicators)
+
+        mock_data_response = AsyncMock()
+        mock_data_response.return_value.data = None
+        mock_data_response.return_value.error = "HTTP error 500: Internal Server Error"
+        mock_data_response.return_value.metadata = None
+        mock_data_response.return_value.count = 0
+
+        with (
+            patch("data360.api.search", return_value=mock_search_response),
+            patch("data360.api.get_data", mock_data_response),
+        ):
+            result = await analyze_development_topic(
+                query="GDP growth",
+            )
+
+        # Should have an indicator entry but with data_error set
+        assert len(result["selected_indicators"]) == 1
+        assert result["selected_indicators"][0]["data_error"] is not None
+        assert result["selected_indicators"][0]["data_snapshot"] is None
+
+    @pytest.mark.asyncio
+    async def test_max_indicators_capped(self):
+        """max_indicators is respected and capped at 6."""
+        indicators = [
+            _make_indicator(idno=f"WB_WDI_IND_{i}", name=f"Indicator {i}")
+            for i in range(10)
+        ]
+        mock_search_response = _make_search_response(indicators)
+
+        mock_data_response = AsyncMock()
+        mock_data_response.return_value.data = []
+        mock_data_response.return_value.error = None
+        mock_data_response.return_value.metadata = {}
+        mock_data_response.return_value.count = 0
+
+        with (
+            patch("data360.api.search", return_value=mock_search_response),
+            patch("data360.api.get_data", mock_data_response),
+        ):
+            result = await analyze_development_topic(
+                query="everything about development",
+                max_indicators=2,
+            )
+
+        assert len(result["selected_indicators"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_sampling_returns_invalid_json(self):
+        """When sampling returns non-JSON, gracefully falls back to rule-based."""
+        indicators = [
+            _make_indicator(idno="WB_WDI_NY_GDP_PCAP_KD", name="GDP per capita"),
+        ]
+        mock_search_response = _make_search_response(indicators)
+
+        ctx = FakeContext(response_text="This is not JSON at all")
+
+        mock_data_response = AsyncMock()
+        mock_data_response.return_value.data = []
+        mock_data_response.return_value.error = None
+        mock_data_response.return_value.metadata = {}
+        mock_data_response.return_value.count = 0
+
+        with (
+            patch("data360.api.search", return_value=mock_search_response),
+            patch("data360.api.get_data", mock_data_response),
+        ):
+            result = await analyze_development_topic(
+                query="economic growth and trade",
+                ctx=ctx,
+            )
+
+        assert result["decomposition_method"] == "rule_based"
+        assert len(result["sub_queries"]) >= 2


### PR DESCRIPTION
## Summary

Adds a new MCP tool — `data360_analyze_development_topic` — that enables LLM agents to answer broad, vague development questions without needing to decompose them manually before searching.

**Problem:** Tools like `data360_search_indicators` require the user to already know *what* indicator to look for. For vague questions like *"What makes a country great?"* or *"What are Ghana's economic growth challenges?"*, the agent has no obvious search term to start with, and a single-indicator search yields poorly-matched results.

**Solution:** A single tool call that decomposes the question, searches in parallel, ranks by relevance and country coverage, and prefetches recent data — ready for the agent to narrate.

---

## New Tool: `data360_analyze_development_topic`

### Inputs
| Parameter | Type | Description |
|---|---|---|
| `query` | str | The user's development question (vague or broad) |
| `country` | str \| None | Optional country name or 3-letter code |
| `max_indicators` | int | Max indicators to return (default 4, hard cap 6) |
| `start_year` / `end_year` | int \| None | Date range for data snapshots |

### Output
```json
{
  "query": "What are Ghana's economic challenges?",
  "country": "Ghana",
  "country_code": "GHA",
  "sub_queries": ["GDP growth", "fiscal deficit", "public debt", "inflation rate"],
  "decomposition_method": "sampling",
  "selected_indicators": [...],
  "coverage_note": "4 indicators selected from 4 sub-queries (16 candidates)"
}
```

### Decomposition Fallback Hierarchy
```
1. Client sampling (ctx.sample())
   └─ The host LLM decomposes the question. No server-side API key needed.
      Supported by: Claude Desktop, MCP Inspector

2. OpenAI API fallback (server-side)
   └─ If the client does not support sampling, OpenAISamplingHandler
      handles decomposition using OPENAI_API_KEY from the server's .env.
      Only activated when the key is present — server starts normally without it.

3. Rule-based heuristics
   └─ Splits on conjunctions (and/or/commas/semicolons), removes
      stopwords, deduplicates, and caps at 5 sub-queries.
      Always available, no LLM required.
```

---

## Changes

### `src/data360/api.py`
- Direct runtime import of `Context` from `fastmcp.server.context` (required for FastMCP dependency injection — `Any` annotation does not trigger context injection)
- Helpers: `_SAMPLING_SYSTEM_PROMPT`, `_SPLIT_CONJUNCTIONS`, `_STOPWORDS`, `_decompose_query()`, `_score_indicator()`, `_resolve_country_code()`
- Main function: `analyze_development_topic()` (~270 lines)
- Updated `search()` docstring with explicit "Do NOT use for vague questions" routing guidance
- Updated `analyze_development_topic()` docstring with explicit "Do NOT use for specific indicators" routing guidance

### `src/data360/mcp_server/_server_definition.py`
- Added `OpenAISamplingHandler` as a `"fallback"` sampling handler
- Guarded by env var check: `AsyncOpenAI()` is only instantiated when `OPENAI_API_KEY` or `OPENAI_API_KEY_MCP` is set — prevents server startup crash when key is absent

### `src/data360/mcp_server/tools.py`
- Registered `analyze_development_topic` as `data360_analyze_development_topic`

### `README.md` / `docs/overview.md`
- Added `data360_analyze_development_topic` to the MCP Tools table
- Added `OPENAI_API_KEY` to the environment variables table

### `tests/test_analyze_topic.py` (new)
- 18 tests covering all logic paths

---

## Test Results

```
tests/test_analyze_topic.py  18 passed
tests/test_api.py            24 passed
```

---

## Checklist

- [x] New tool is registered and described in `tools.py`
- [x] Docstrings include routing guidance for the agent (`Use when` / `Do NOT use when`)
- [x] Sampling fallback hierarchy is fully implemented (client → OpenAI → rule-based)
- [x] Server does not crash when `OPENAI_API_KEY` is absent
- [x] All new logic has unit test coverage
- [x] `README.md` and `docs/overview.md` updated
- [ ] Tested with Claude Desktop (client-side sampling path)
- [ ] Tested with production chatbot integration