### PR TITLE
fix(viz): guard empty merge keys; stagger multi-indicator Y-axes

### DIFF
--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -870,6 +870,14 @@ async def get_multi_indicator_viz_spec(
         if all(c in df.columns for df in std_dfs)
     ]
 
+    if not join_keys:
+        return _err(
+            "Indicators could not be merged: no common dimensions (for example, one "
+            "series is time-only and another is geography-only). Choose indicators "
+            "that share at least one of: year, country, or the same disaggregation "
+            "columns."
+        )
+
     merged = std_dfs[0]
     for df in std_dfs[1:]:
         merged = pd.merge(merged, df, on=join_keys, how="outer")

--- a/src/data360/viz_config.py
+++ b/src/data360/viz_config.py
@@ -242,7 +242,7 @@ class ChartStrategy(str, Enum):
 
     TEMPORAL_SINGLE = "temporal_single"  # 1 indicator, ≤8 countries, multi-year → lines
     TEMPORAL_MULTI_IND = (
-        "temporal_multi_indicator"  # 2-3 indicators, 1 country → layered lines
+        "temporal_multi_indicator"  # 2-4 indicators → layered lines (dual Y + offsets)
     )
     CORRELATION = "correlation"  # 2 indicators, multi-country, 1 year → scatter
     CORRELATION_TEMPORAL = "correlation_temporal"  # 2 indicators, multi-country, multi-year → connected scatter
@@ -821,10 +821,12 @@ def build_temporal_multi_indicator_spec(
     indicator_labels: dict[str, str] | None = None,
     y_label: str = "Value",
 ) -> dict:
-    """Layered dual-axis line chart: 2-3 indicators, 1 country, multi-year.
+    """Layered multi-axis line chart: 2-4 indicators, multi-year when applicable.
 
     Uses Vega-Lite layer + independent y-scale resolution.
-    Each indicator gets its own y-axis with the indicator name as the label.
+    Each indicator gets its own y-axis; left + right for the first two, staggered
+    offsets on the right for additional series (Vega-Lite only lays out two
+    independent Y-axes cleanly without offset).
     """
     ind_cols = result.indicator_cols
     if not ind_cols:
@@ -837,6 +839,14 @@ def build_temporal_multi_indicator_spec(
     for i, col in enumerate(ind_cols):
         color = WB_CAT_COLORS[i % len(WB_CAT_COLORS)]
         y_label = lab.get(col, col.replace("_", " ").title())
+        y_axis = {**_axis_style(y_label), "titleColor": color}
+        if i == 0:
+            y_axis["orient"] = "left"
+        elif i == 1:
+            y_axis["orient"] = "right"
+        else:
+            y_axis["orient"] = "right"
+            y_axis["offset"] = 50 * (i - 1)
         layer_enc: dict = {
             "x": {
                 "field": "year",
@@ -846,7 +856,7 @@ def build_temporal_multi_indicator_spec(
             "y": {
                 "field": col,
                 "type": "quantitative",
-                "axis": {**_axis_style(y_label), "titleColor": color},
+                "axis": y_axis,
                 "scale": {"zero": False},
             },
             "color": {"value": color},
@@ -870,7 +880,7 @@ def build_temporal_multi_indicator_spec(
         "data": {"values": rows},
         "layer": layers,
         "resolve": {"scale": {"y": "independent"}},
-        "width": 620,
+        "width": 680 if len(ind_cols) > 2 else 620,
         "height": 380,
     }
     return inject_wb_config(spec)

--- a/tests/test_viz_complex.py
+++ b/tests/test_viz_complex.py
@@ -115,6 +115,23 @@ def _two_ind_ts_df():
     return pd.DataFrame(rows)
 
 
+def _four_ind_ts_df():
+    """Single country, four indicator columns, multi-year (for layered multi-axis)."""
+    rows = []
+    for y in range(2018, 2024):
+        rows.append(
+            {
+                "country": "CountryA",
+                "year": pd.Timestamp(f"{y}-01-01"),
+                "ind_a": float(hash((y, "a")) % 1000),
+                "ind_b": float(hash((y, "b")) % 1000),
+                "ind_c": float(hash((y, "c")) % 1000),
+                "ind_d": float(hash((y, "d")) % 1000),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Strategy Router
 # ─────────────────────────────────────────────────────────────────────────────
@@ -417,6 +434,20 @@ class TestSpecBuilders:
         colors = [layer["mark"]["color"] for layer in spec["layer"]]
         assert len(set(colors)) == 2  # distinct colors
 
+    def test_temporal_multi_indicator_staggered_y_axes_for_four_series(self):
+        df = _four_ind_ts_df()
+        ind_cols = ["ind_a", "ind_b", "ind_c", "ind_d"]
+        r = self._result(ChartStrategy.TEMPORAL_MULTI_IND, indicator_cols=ind_cols)
+        spec = build_temporal_multi_indicator_spec(df, "Test", r)
+        assert len(spec["layer"]) == 4
+        assert spec["width"] == 680
+        axes = [layer["encoding"]["y"]["axis"] for layer in spec["layer"]]
+        assert axes[0]["orient"] == "left"
+        assert axes[1]["orient"] == "right"
+        assert "offset" not in axes[1]
+        assert axes[2]["orient"] == "right" and axes[2]["offset"] == 50
+        assert axes[3]["orient"] == "right" and axes[3]["offset"] == 100
+
     # fallback
     def test_fallback_produces_line(self):
         df = pd.DataFrame({"year": [pd.Timestamp("2020")], "value": [42.0]})
@@ -707,6 +738,27 @@ class TestGetMultiIndicatorVizSpec:
             f"Expected URL, got error: {result.get('error')}"
         )
         assert result["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_disjoint_dimensions_returns_merge_error(self, patches):
+        """No shared merge keys (e.g. time-only vs geography-only) → clear error, no 500."""
+        _, mock_fetch = patches
+        df_time_only = pd.DataFrame(
+            [{"TIME_PERIOD": "2020-01-01", "OBS_VALUE": 10.0}]
+        )
+        df_geo_only = pd.DataFrame([{"REF_AREA": "KEN", "OBS_VALUE": 20.0}])
+        mock_fetch.side_effect = [df_time_only, df_geo_only]
+
+        result = await get_multi_indicator_viz_spec(
+            indicator_ids=[
+                {"database_id": "WB_WDI", "indicator_id": "IND_A"},
+                {"database_id": "WB_WDI", "indicator_id": "IND_B"},
+            ],
+        )
+        assert result.get("url") is None
+        assert result.get("error") is not None
+        err = (result["error"] or "").lower()
+        assert "no common dimensions" in err
 
     @pytest.mark.asyncio
     async def test_returns_strategy_in_result(self, patches):


### PR DESCRIPTION
## Summary

Addresses two review edge cases for multi-indicator visualization:

1. **Empty merge keys** — When indicators have disjoint dimensions (e.g. one time-only, one geography-only), `join_keys` is empty and `pd.merge(..., on=[])` raises `MergeError`, which surfaced as a 500. We now return a clear `_err` before merging.

2. **Overlapping Y-axes (3–4 indicators)** — Vega-Lite only lays out two independent Y-axes cleanly; extra layers were drawn on top of each other. Per-layer Y axes now use `orient` (left / right) and increasing `offset` on the right for the 3rd and 4th series; chart `width` is bumped when there are more than two indicators.

## Test plan

- [x] `tests/test_viz_complex.py`: `test_disjoint_dimensions_returns_merge_error`
- [x] `tests/test_viz_complex.py`: `test_temporal_multi_indicator_staggered_y_axes_for_four_series`
- [x] Full file: `uv run pytest tests/test_viz_complex.py` (or project equivalent)