### PR TITLE
feat(search): multi-query search with per-country scoping, API resilience, and LLM-optimised docstrings

### DIFF
--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -621,17 +621,26 @@ async def search(  # noqa: PLR0911
     In those cases, use data360_analyze_development_topic instead, which decomposes
     the question into specific sub-queries and searches for each one.
 
-    IMPORTANT — parameter selection: pass exactly ONE of query, queries, or query_groups.
-    Do NOT pass the others at all (not even as empty string "" or empty list []).
-    Sending query="" alongside query_groups, or queries=[] alongside query_groups,
-    is treated as a conflict and will be normalised, but it is better to simply omit unused params.
+    PARAMETER SELECTION — follow this decision tree strictly:
+    1. ONE topic, any number of countries → use `query` + `required_country`.
+    2. MULTIPLE topics, ALL in the SAME country → use `queries` + `required_country`.
+    3. Topics targeting DIFFERENT countries → MUST use `query_groups`. Do NOT use `queries`.
+       Example — "GDP for Japan and population for Philippines":
+         query_groups=[
+           {"queries": ["GDP per capita"], "country": "Japan"},
+           {"queries": ["population"], "country": "Philippines"}
+         ]
+       Using `queries` for cross-country requests will lose per-country coverage data.
+
+    Pass exactly ONE of query, queries, or query_groups. Omit the other two entirely.
 
     Args:
         query: Single search query (e.g., "unemployment rate", "poverty", "GDP per capita").
             Use this for ONE topic. If using this, do not pass queries or query_groups.
         queries: List of search terms for multi-topic search in one call (e.g.
             ["GDP growth", "inflation rate", "unemployment"]).
-            Use this for MULTIPLE topics that share the same country scope.
+            Use ONLY when ALL topics target the SAME country (set via required_country).
+            If topics span different countries, use query_groups instead.
             Requires at least 2 non-empty strings.
             If using this, do not pass query or query_groups.
         query_groups: List of QueryGroup objects, each binding one or more search terms to

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -617,12 +617,19 @@ async def search(  # noqa: PLR0911
     In those cases, use data360_analyze_development_topic instead, which decomposes
     the question into specific sub-queries and searches for each one.
 
+    IMPORTANT — parameter selection: pass exactly ONE of query, queries, or query_groups.
+    Do NOT pass the others at all (not even as empty string "" or empty list []).
+    Sending query="" alongside query_groups, or queries=[] alongside query_groups,
+    is treated as a conflict and will be normalised, but it is better to simply omit unused params.
+
     Args:
         query: Single search query (e.g., "unemployment rate", "poverty", "GDP per capita").
-            Mutually exclusive with queries and query_groups.
+            Use this for ONE topic. If using this, do not pass queries or query_groups.
         queries: List of search terms for multi-topic search in one call (e.g.
-            ["GDP growth", "inflation rate", "unemployment"]). Mutually exclusive with query
-            and query_groups. Requires at least 2 non-empty strings.
+            ["GDP growth", "inflation rate", "unemployment"]).
+            Use this for MULTIPLE topics that share the same country scope.
+            Requires at least 2 non-empty strings.
+            If using this, do not pass query or query_groups.
         query_groups: List of QueryGroup objects, each binding one or more search terms to
             an optional country scope. Use when different queries target different countries.
             Use this instead of queries when each query targets a different country.
@@ -631,8 +638,8 @@ async def search(  # noqa: PLR0911
                 {"queries": ["GDP per capita", "inflation"], "country": "Kenya"},
                 {"queries": ["Gini coefficient"], "country": "Morocco"}
             ]
-            Mutually exclusive with query and queries. Requires at least 2 non-empty queries
-            total across all groups. required_country is ignored when query_groups is used.
+            Requires at least 2 non-empty queries total across all groups.
+            If using this, do not pass query or queries. required_country is ignored.
         required_country: Optional country name or 3-letter code (e.g. "Kenya", "KEN").
             Use comma-separated names or codes to check multiple countries in one call (e.g. "China, USA").
             Shared across all queries — only when all topics share the same geographic scope.
@@ -654,6 +661,7 @@ async def search(  # noqa: PLR0911
             Each indicator has requested_country showing which group's country it was evaluated against.
         error: Error message string if the request failed; otherwise None.
     """
+
     # --- Validation ---
     # Normalise LLM-hallucinated empty defaults before mode detection.
     # When a client sends query="" or queries=[] alongside the real parameter

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -603,8 +603,11 @@ async def search(  # noqa: PLR0911
     """Search for Data360 indicators with enriched metadata for selection.
 
     Use this first when the user asks for data on a topic (e.g. unemployment, poverty, GDP).
-    No other tools are required before this one. After picking an indicator, call
-    data360_get_metadata and/or data360_get_disaggregation before fetching data or generating a chart.
+    No other tools are required before this one.
+
+    ENRICHED DATA VS. FETCHING DATA:
+    - For METADATA questions (e.g. "What is the definition of the unemployment rate indicator?", "How frequently is it updated?"): The enriched data returned by this search tool is often sufficient! You can directly use the `truncated_definition`, `name`, `periodicity`, `database_id`, and `latest_data` fields from the search results to answer the user WITHOUT needing to call `data360_get_metadata` or `data360_get_data`.
+    - For DATA questions (e.g. "What was Kenya's GDP in 2020?", "Show me the trend of poverty"): The enriched data does NOT contain actual data values (OBS_VALUE). You MUST proceed to call `data360_get_disaggregation` and then `data360_get_data` (or `data360_get_viz_spec` for charts) to retrieve real numbers.
 
     Use when the user already names a specific indicator or metric — for example:
     "GDP per capita for Kenya", "unemployment rate in Morocco", "life expectancy in Sub-Saharan Africa".
@@ -1012,9 +1015,9 @@ async def get_metadata(
 ) -> MetadataResponse:
     """Get metadata and disaggregation options for a Data360 indicator.
 
-    Call after data360_search_indicators when you have chosen an indicator (you need its
-    database_id and indicator_id). For valid filter values (years, country codes, SEX/AGE/URBANISATION),
-    prefer data360_get_disaggregation. data360_get_data and data360_get_viz_spec call get_metadata internally.
+    Call after data360_search_indicators only when you need deep metadata NOT included in the enriched search results (e.g. methodology, source notes). If the user asks a basic metadata question (like definition or periodicity), simply answer using the fields provided by data360_search_indicators.
+
+    For valid filter values (years, country codes, SEX/AGE/URBANISATION), prefer data360_get_disaggregation. data360_get_data and data360_get_viz_spec call get_metadata internally.
 
     Args:
         database_id: Database identifier (e.g., IPC_IPC, WB_GS).

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -24,6 +24,8 @@ from .models import (
     IndicatorDataResponse,
     MetadataRequest,
     MetadataResponse,
+    MultiQuerySearchResponse,
+    QueryGroupResult,
     SearchRequest,
     SearchResponse,
     SeriesDescription,
@@ -465,11 +467,97 @@ async def _resolve_country_code(country_query: str) -> str | None:
     return None
 
 
+def _enrich_search_results(
+    search_result: "SearchResponse",
+    country_code: str | None,
+) -> list[EnrichedIndicator]:
+    """Convert raw SearchResponse items into a list of EnrichedIndicator objects.
+
+    Extracted to avoid duplicating enrichment logic between the single-query
+    and multi-query paths in search().
+
+    Args:
+        search_result: Raw response from _search_raw().
+        country_code: Resolved country code (or None). Used to compute covers_country.
+
+    Returns:
+        List of EnrichedIndicator objects. Empty if search_result.items is falsy.
+    """
+    if not search_result.items:
+        return []
+
+    _label_to_code = {
+        "sex": "SEX",
+        "age": "AGE",
+        "residential area": "URBANISATION",
+        "urbanisation": "URBANISATION",
+        "education": "EDUCATION",
+    }
+
+    indicators: list[EnrichedIndicator] = []
+    for item in search_result.items:
+        raw = item.model_dump()
+
+        # Extract latest_data and time_period_range
+        time_periods = raw.get("time_periods", [])
+        latest_data = None
+        time_period_range = None
+        if time_periods and isinstance(time_periods, list):
+            tp = time_periods[0] if isinstance(time_periods[0], dict) else {}
+            latest_data = tp.get("LATEST_DATA_POINT") or tp.get("end")
+            start = tp.get("start")
+            end = tp.get("end")
+            if start and end:
+                time_period_range = f"{start}-{end}"
+
+        # Check covers_country from ref_country
+        covers_country = None
+        ref_country = raw.get("ref_country", [])
+        if country_code and ref_country and isinstance(ref_country, list):
+            country_codes = {
+                c.get("code") if isinstance(c, dict) else c for c in ref_country
+            }
+            requested_codes = {c.strip() for c in country_code.split(",")}
+            covers_country = bool(country_codes & requested_codes)
+        elif country_code:
+            covers_country = False
+
+        # Extract dimension names
+        dimensions = raw.get("dimensions", [])
+        useful_dims: list[str] = []
+        if dimensions and isinstance(dimensions, list):
+            for dim in dimensions:
+                if isinstance(dim, dict):
+                    label = (dim.get("label") or "").lower()
+                    if label in _label_to_code:
+                        useful_dims.append(_label_to_code[label])
+
+        indicators.append(
+            EnrichedIndicator(
+                idno=raw.get("idno", ""),
+                database_id=raw.get("database_id", ""),
+                name=raw.get("name", ""),
+                truncated_definition=(raw.get("definition_long") or "")[:100],
+                periodicity=raw.get("periodicity"),
+                latest_data=latest_data,
+                time_period_range=time_period_range,
+                covers_country=covers_country,
+                dimensions=useful_dims if useful_dims else None,
+            )
+        )
+
+    return indicators
+
+
 async def search(
-    query: str,
+    query: str | None = None,
     required_country: str | None = None,
     limit: int = DEFAULT_SEARCH_LIMIT,
     offset: int = 0,
+    # New multi-query parameters
+    queries: list[str] | None = None,
+    result_layout: str = "merged",
+    dedupe: bool = True,
     # The following parameters are accepted for robustness; LLM clients sometimes
     # hallucinate them from the internal SearchRequest model.
     # n_results/skip are treated as aliases for limit/offset when the primary
@@ -481,29 +569,163 @@ async def search(
     select: str | None = None,
     skip: int | None = None,
     odata_options: dict[str, str] | None = None,
-) -> "EnrichedSearchResponse":
+) -> "EnrichedSearchResponse | MultiQuerySearchResponse":
     """Search for Data360 indicators with enriched metadata for selection.
 
     Use this first when the user asks for data on a topic (e.g. unemployment, poverty, GDP).
     No other tools are required before this one. After picking an indicator, call
     data360_get_metadata and/or data360_get_disaggregation before fetching data or generating a chart.
 
+    Use when the user already names a specific indicator or metric — for example:
+    "GDP per capita for Kenya", "unemployment rate in Morocco", "life expectancy in Sub-Saharan Africa".
+
+    For multiple topics in one call (e.g. "GDP, inflation, employment for Kenya"), pass them as
+    queries=["GDP growth", "inflation rate", "unemployment"] instead of making separate calls.
+
+    Do NOT use this tool when the user asks a broad or vague question that does not name a
+    specific indicator — for example: "What makes a country great?",
+    "What are Ghana's economic challenges?", "How is education performing in Africa?"
+    In those cases, use data360_analyze_development_topic instead, which decomposes
+    the question into specific sub-queries and searches for each one.
+
     Args:
-        query: Search query (e.g., "unemployment rate", "poverty", "GDP per capita").
+        query: Single search query (e.g., "unemployment rate", "poverty", "GDP per capita").
+            Mutually exclusive with queries.
+        queries: List of search terms for multi-topic search in one call (e.g.
+            ["GDP growth", "inflation rate", "unemployment"]). Mutually exclusive with query.
+            Requires at least 2 non-empty strings.
         required_country: Optional country name or 3-letter code (e.g. "Kenya", "KEN").
             Use comma-separated names or codes to check multiple countries in one call (e.g. "China, USA").
-        limit: Maximum number of indicators to return (default 5).
-        offset: Number of results to skip for pagination (default 0).
+            Shared across all queries — this tool is for multiple topics in the same geographic scope.
+            For different countries per query, make separate search() calls.
+
+            Open question: Whether to support per-query country codes (e.g., "GDP for Kenya AND
+            inflation for Morocco") is an open design decision. The current recommendation is to
+            make separate search() calls for that case, as mixing country scopes in a single call
+            complicates result interpretation and the enrichment pipeline.
+        limit: Maximum number of indicators per query (default 5).
+        offset: Number of results to skip per query for pagination (default 0).
+        result_layout: Only used with queries. "merged" (default) returns a flat deduped list.
+            "by_query" returns one group per input query. In both cases, dedupe=True performs
+            cross-group deduplication (first-seen wins).
+        dedupe: Only used with queries. When True (default), deduplicates by (database_id, idno)
+            across all query groups. First-seen order is preserved (queries processed in order).
 
     Returns:
-        EnrichedSearchResponse:
-            indicators: List of EnrichedIndicator, each with idno, database_id, name,
-                truncated_definition, unit, periodicity, latest_data, time_period_range,
-                covers_country (True/False if required_country was given), and dimensions (e.g. SEX, AGE).
-            required_country: Resolved country code(s) if required_country was provided.
-            count, total_count, offset, has_more, next_offset: Pagination fields.
-            error: Error message string if the request failed; otherwise None.
+        With query: EnrichedSearchResponse with indicators, required_country, pagination fields.
+        With queries: MultiQuerySearchResponse with indicators (merged) or results (by_query),
+            total_candidates, deduplicated_count, and per-group errors.
+        error: Error message string if the request failed; otherwise None.
     """
+    import asyncio
+
+    # --- Validation ---
+    if query is not None and queries is not None:
+        return EnrichedSearchResponse(
+            error="Provide either 'query' (single string) or 'queries' (list), not both."
+        )
+    if query is None and queries is None:
+        return EnrichedSearchResponse(error="Either 'query' or 'queries' must be provided.")
+
+    # --- Multi-query path ---
+    if queries is not None:
+        clean_queries = [q.strip() for q in queries if q and q.strip()]
+        if len(clean_queries) < 2:
+            return MultiQuerySearchResponse(
+                error="'queries' must contain at least 2 non-empty search strings.",
+                queries=queries or [],
+            )
+        if result_layout not in ("merged", "by_query"):
+            return MultiQuerySearchResponse(
+                error="result_layout must be 'merged' or 'by_query'.",
+                queries=clean_queries,
+            )
+
+        # Handle limit/offset aliases
+        if n_results is not None and limit == DEFAULT_SEARCH_LIMIT:
+            limit = n_results
+        if skip is not None and offset == 0:
+            offset = skip
+
+        # Resolve country once, shared across all sub-queries
+        country_code: str | None = None
+        if required_country:
+            country_code = await _resolve_country_code(required_country)
+
+        # Fan out concurrent _search_raw calls, one per query
+        _select_fields = [
+            "idno", "name", "database_id", "definition_long",
+            "periodicity", "time_periods", "ref_country", "dimensions", "measurement_unit",
+        ]
+        raw_tasks = [
+            _search_raw(query=q, limit=limit, offset=offset, select_fields=_select_fields)
+            for q in clean_queries
+        ]
+        raw_results = await asyncio.gather(*raw_tasks, return_exceptions=True)
+
+        # Enrich results per group; apply cross-group dedup when requested
+        seen_ids: set[tuple[str, str]] = set()
+        groups: list[QueryGroupResult] = []
+        total_candidates = 0
+        deduplicated_count = 0
+
+        for q, raw_result in zip(clean_queries, raw_results):
+            if isinstance(raw_result, Exception):
+                groups.append(QueryGroupResult(query=q, error=str(raw_result)))
+                continue
+            if raw_result.error or not raw_result.items:
+                groups.append(QueryGroupResult(
+                    query=q,
+                    error=raw_result.error or f"No indicators found for: '{q}'",
+                ))
+                continue
+
+            enriched = _enrich_search_results(raw_result, country_code)
+            total_candidates += len(enriched)
+
+            if dedupe:
+                deduped: list[EnrichedIndicator] = []
+                for ind in enriched:
+                    key = (ind.database_id, ind.idno)
+                    if key not in seen_ids:
+                        seen_ids.add(key)
+                        deduped.append(ind)
+                    else:
+                        deduplicated_count += 1
+                enriched = deduped
+
+            groups.append(QueryGroupResult(query=q, indicators=enriched, count=len(enriched)))
+
+        if result_layout == "merged":
+            merged_indicators: list[EnrichedIndicator] = [
+                ind for g in groups for ind in g.indicators
+            ]
+            if country_code:
+                merged_indicators.sort(
+                    key=lambda x: (
+                        not (x.covers_country or False),
+                        -(int(x.latest_data or 0) if str(x.latest_data or "").isdigit() else 0),
+                    )
+                )
+            return MultiQuerySearchResponse(
+                indicators=merged_indicators,
+                result_layout="merged",
+                queries=clean_queries,
+                required_country=country_code,
+                total_candidates=total_candidates,
+                deduplicated_count=deduplicated_count if dedupe else None,
+            )
+        else:  # by_query
+            return MultiQuerySearchResponse(
+                results=groups,
+                result_layout="by_query",
+                queries=clean_queries,
+                required_country=country_code,
+                total_candidates=total_candidates,
+                deduplicated_count=deduplicated_count if dedupe else None,
+            )
+
+    # --- Single-query path (original behavior, fully preserved) ---
     # Handle common parameter aliases sent by LLM clients.
     # Aliases only apply when the primary parameter is at its default value;
     # an explicit limit/offset always takes precedence over n_results/skip.
@@ -535,7 +757,7 @@ async def search(
 
     # Fetch all needed metadata in ONE search call
     search_result = await _search_raw(
-        query=query,
+        query=query,  # type: ignore[arg-type]  # validated non-None above
         limit=limit,
         offset=offset,
         select_fields=[
@@ -557,73 +779,7 @@ async def search(
     if not search_result.items:
         return EnrichedSearchResponse(error=f"No indicators found for: '{query}'")
 
-    db_mapping = await get_database_mapping()
-
-    # Process each indicator
-    indicators: list[EnrichedIndicator] = []
-    for item in search_result.items:
-        raw = item.model_dump()
-
-        # Extract latest_data and time_period_range
-        time_periods = raw.get("time_periods", [])
-        latest_data = None
-        time_period_range = None
-        if time_periods and isinstance(time_periods, list):
-            tp = time_periods[0] if isinstance(time_periods[0], dict) else {}
-            latest_data = tp.get("LATEST_DATA_POINT") or tp.get("end")
-            start = tp.get("start")
-            end = tp.get("end")
-            if start and end:
-                time_period_range = f"{start}-{end}"
-
-        # Check covers_country from ref_country
-        covers_country = None
-        ref_country = raw.get("ref_country", [])
-        if country_code and ref_country and isinstance(ref_country, list):
-            country_codes = {
-                c.get("code") if isinstance(c, dict) else c for c in ref_country
-            }
-            # Check overlap if multiple countries requested
-            requested_codes = set([c.strip() for c in country_code.split(",")])
-            covers_country = bool(country_codes & requested_codes)
-        elif country_code:
-            covers_country = False
-
-        # Extract dimension names from series_description/dimensions
-        dimensions = raw.get("dimensions", [])
-        label_to_code = {
-            "sex": "SEX",
-            "age": "AGE",
-            "residential area": "URBANISATION",
-            "urbanisation": "URBANISATION",
-            "education": "EDUCATION",
-        }
-
-        useful_dims: list[str] = []
-        if dimensions and isinstance(dimensions, list):
-            for dim in dimensions:
-                if isinstance(dim, dict):
-                    label = (dim.get("label") or "").lower()
-                    if label in label_to_code:
-                        useful_dims.append(label_to_code[label])
-
-        # Build EnrichedIndicator
-        db_id = raw.get("database_id", "")
-        indicators.append(
-            EnrichedIndicator(
-                idno=raw.get("idno", ""),
-                database_id=db_id,
-                database_name=db_mapping.get(db_id),
-                name=raw.get("name", ""),
-                truncated_definition=(raw.get("definition_long") or "")[:100],
-                unit=raw.get("measurement_unit"),
-                periodicity=raw.get("periodicity"),
-                latest_data=latest_data,
-                time_period_range=time_period_range,
-                covers_country=covers_country,
-                dimensions=useful_dims if useful_dims else None,
-            )
-        )
+    indicators = _enrich_search_results(search_result, country_code)
 
     # Sort: covers_country=True first, then by latest_data descending
     if country_code:

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -655,11 +655,11 @@ async def search(  # noqa: PLR0911
         error: Error message string if the request failed; otherwise None.
     """
     # --- Validation ---
-    active_modes = sum([
+    active_modes = sum((
         query is not None,
         queries is not None,
         query_groups is not None,
-    ])
+    ))
     if active_modes > 1:
         return EnrichedSearchResponse(
             error="Provide exactly one of 'query', 'queries', or 'query_groups', not multiple."
@@ -788,7 +788,7 @@ async def search(  # noqa: PLR0911
                 )
 
         # Resolve unique country values concurrently to avoid redundant codelist lookups
-        unique_countries = {c for _, c in flat_pairs if c}
+        unique_countries = list({c for _, c in flat_pairs if c})
         resolved_map: dict[str, str | None] = {}
         if unique_countries:
             codes = await asyncio.gather(

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -1226,8 +1226,10 @@ async def get_data(
             offset, has_more, next_offset: Use next_offset for the next page when has_more is True.
             error: Error message if the request failed; otherwise None.
                 If error contains "No metadata found", the indicator_id is invalid or stale.
-                Do NOT retry with the same ID. Instead, call data360_search_indicators with
-                the original topic/query to find the correct, current indicator ID, then retry.
+                Do NOT retry with the same ID and do NOT call data360_search_indicators again.
+                Instead, look back at the other indicators already returned by the previous
+                data360_search_indicators call in this conversation and try the next best match.
+                Only call data360_search_indicators again if no prior search results exist in context.
                 If error is about a disaggregation or HTTP failure but data is still None,
                 the upstream API may be temporarily unavailable — retry once or report the error.
             failed_validation: Optional list of filter validation messages. Non-empty means
@@ -1509,7 +1511,9 @@ async def get_data_api_url(
         Full Data360 data API URL string (query parameters included).
         Raises ValueError if the indicator is not found in the specified database.
             If this happens, the indicator_id is invalid or stale. Do NOT retry with the same ID.
-            Call data360_search_indicators with the original topic to find the correct indicator ID.
+            Look back at the other indicators already returned by the previous
+            data360_search_indicators call in this conversation and try the next best match.
+            Only call data360_search_indicators again if no prior search results exist in context.
     """
     settings = get_data360_settings()
 

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -1225,6 +1225,11 @@ async def get_data(
             total_count: Total records available, or None.
             offset, has_more, next_offset: Use next_offset for the next page when has_more is True.
             error: Error message if the request failed; otherwise None.
+                If error contains "No metadata found", the indicator_id is invalid or stale.
+                Do NOT retry with the same ID. Instead, call data360_search_indicators with
+                the original topic/query to find the correct, current indicator ID, then retry.
+                If error is about a disaggregation or HTTP failure but data is still None,
+                the upstream API may be temporarily unavailable — retry once or report the error.
             failed_validation: Optional list of filter validation messages. Non-empty means
                 some filters were invalid; data may still be returned with valid filters applied.
     """
@@ -1503,6 +1508,8 @@ async def get_data_api_url(
     Returns:
         Full Data360 data API URL string (query parameters included).
         Raises ValueError if the indicator is not found in the specified database.
+            If this happens, the indicator_id is invalid or stale. Do NOT retry with the same ID.
+            Call data360_search_indicators with the original topic to find the correct indicator ID.
     """
     settings = get_data360_settings()
 

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import zlib
@@ -25,6 +26,7 @@ from .models import (
     MetadataRequest,
     MetadataResponse,
     MultiQuerySearchResponse,
+    QueryGroup,
     QueryGroupResult,
     SearchRequest,
     SearchResponse,
@@ -42,6 +44,20 @@ COUNTRY_CODE_LENGTH = 3
 SCORE_THRESHOLD = 70
 MAX_RETURN_STATEMENTS = 6
 DEFAULT_SEARCH_LIMIT = 5
+
+# Fields fetched by _search_raw for LLM-friendly enrichment.
+# Shared between single-query and multi-query paths to ensure consistency.
+_ENRICHMENT_SELECT_FIELDS = [
+    "idno",
+    "name",
+    "database_id",
+    "definition_long",
+    "periodicity",
+    "time_periods",
+    "ref_country",
+    "dimensions",
+    "measurement_unit",
+]
 
 # Prefiltering constants for get_data output.
 # Based on a 16-database survey (see payload_analysis.md for full documentation).
@@ -439,7 +455,7 @@ async def _search_raw(
 
 async def _resolve_country_code(country_query: str) -> str | None:
     """Resolve country name to code using cached REF_AREA codelist."""
-    from . import providers as data360_providers
+    from . import providers as data360_providers  # noqa: PLC0415
 
     if not country_query:
         return None
@@ -470,6 +486,7 @@ async def _resolve_country_code(country_query: str) -> str | None:
 def _enrich_search_results(
     search_result: "SearchResponse",
     country_code: str | None,
+    db_mapping: dict[str, str] | None = None,
 ) -> list[EnrichedIndicator]:
     """Convert raw SearchResponse items into a list of EnrichedIndicator objects.
 
@@ -479,12 +496,15 @@ def _enrich_search_results(
     Args:
         search_result: Raw response from _search_raw().
         country_code: Resolved country code (or None). Used to compute covers_country.
+        db_mapping: Optional dict mapping database_id -> human-readable name.
 
     Returns:
         List of EnrichedIndicator objects. Empty if search_result.items is falsy.
     """
     if not search_result.items:
         return []
+
+    _db = db_mapping or {}
 
     _label_to_code = {
         "sex": "SEX",
@@ -510,17 +530,18 @@ def _enrich_search_results(
             if start and end:
                 time_period_range = f"{start}-{end}"
 
-        # Check covers_country from ref_country
-        covers_country = None
+        # Check covers_country from ref_country — produce a per-country bool map
+        covers_country: dict[str, bool] | None = None
         ref_country = raw.get("ref_country", [])
         if country_code and ref_country and isinstance(ref_country, list):
             country_codes = {
                 c.get("code") if isinstance(c, dict) else c for c in ref_country
             }
-            requested_codes = {c.strip() for c in country_code.split(",")}
-            covers_country = bool(country_codes & requested_codes)
+            requested_codes = [c.strip() for c in country_code.split(";") if c.strip()]
+            covers_country = {code: code in country_codes for code in requested_codes}
         elif country_code:
-            covers_country = False
+            requested_codes = [c.strip() for c in country_code.split(";") if c.strip()]
+            covers_country = {code: False for code in requested_codes}
 
         # Extract dimension names
         dimensions = raw.get("dimensions", [])
@@ -532,12 +553,15 @@ def _enrich_search_results(
                     if label in _label_to_code:
                         useful_dims.append(_label_to_code[label])
 
+        db_id = raw.get("database_id", "")
         indicators.append(
             EnrichedIndicator(
                 idno=raw.get("idno", ""),
-                database_id=raw.get("database_id", ""),
+                database_id=db_id,
+                database_name=_db.get(db_id),
                 name=raw.get("name", ""),
                 truncated_definition=(raw.get("definition_long") or "")[:100],
+                unit=raw.get("measurement_unit"),
                 periodicity=raw.get("periodicity"),
                 latest_data=latest_data,
                 time_period_range=time_period_range,
@@ -546,16 +570,21 @@ def _enrich_search_results(
             )
         )
 
+    # Set requested_country on all indicators
+    for ind in indicators:
+        ind.requested_country = country_code
+
     return indicators
 
 
-async def search(
+async def search(  # noqa: PLR0911
     query: str | None = None,
     required_country: str | None = None,
     limit: int = DEFAULT_SEARCH_LIMIT,
     offset: int = 0,
-    # New multi-query parameters
+    # Multi-query parameters
     queries: list[str] | None = None,
+    query_groups: list[QueryGroup] | None = None,
     result_layout: str = "merged",
     dedupe: bool = True,
     # The following parameters are accepted for robustness; LLM clients sometimes
@@ -590,47 +619,68 @@ async def search(
 
     Args:
         query: Single search query (e.g., "unemployment rate", "poverty", "GDP per capita").
-            Mutually exclusive with queries.
+            Mutually exclusive with queries and query_groups.
         queries: List of search terms for multi-topic search in one call (e.g.
-            ["GDP growth", "inflation rate", "unemployment"]). Mutually exclusive with query.
-            Requires at least 2 non-empty strings.
+            ["GDP growth", "inflation rate", "unemployment"]). Mutually exclusive with query
+            and query_groups. Requires at least 2 non-empty strings.
+        query_groups: List of QueryGroup objects, each binding one or more search terms to
+            an optional country scope. Use when different queries target different countries.
+            Use this instead of queries when each query targets a different country.
+            JSON schema for each group: {"queries": ["<term1>", "<term2>"], "country": "<name or 3-letter code>"}
+            Example: [
+                {"queries": ["GDP per capita", "inflation"], "country": "Kenya"},
+                {"queries": ["Gini coefficient"], "country": "Morocco"}
+            ]
+            Mutually exclusive with query and queries. Requires at least 2 non-empty queries
+            total across all groups. required_country is ignored when query_groups is used.
         required_country: Optional country name or 3-letter code (e.g. "Kenya", "KEN").
             Use comma-separated names or codes to check multiple countries in one call (e.g. "China, USA").
-            Shared across all queries — this tool is for multiple topics in the same geographic scope.
-            For different countries per query, make separate search() calls.
-
-            Open question: Whether to support per-query country codes (e.g., "GDP for Kenya AND
-            inflation for Morocco") is an open design decision. The current recommendation is to
-            make separate search() calls for that case, as mixing country scopes in a single call
-            complicates result interpretation and the enrichment pipeline.
+            Shared across all queries — only when all topics share the same geographic scope.
+            Ignored when query_groups is used (each group has its own country).
         limit: Maximum number of indicators per query (default 5).
         offset: Number of results to skip per query for pagination (default 0).
-        result_layout: Only used with queries. "merged" (default) returns a flat deduped list.
-            "by_query" returns one group per input query. In both cases, dedupe=True performs
-            cross-group deduplication (first-seen wins).
-        dedupe: Only used with queries. When True (default), deduplicates by (database_id, idno)
-            across all query groups. First-seen order is preserved (queries processed in order).
+        result_layout: Only used with queries/query_groups.
+            Use "merged" (default) when you want a single flat list to pick from.
+            Use "by_query" when you need to know which indicators came from which query —
+            e.g. to attribute country coverage per query or display grouped results.
+        dedupe: Only used with queries/query_groups. When True (default), deduplicates by
+            (database_id, idno) across all query groups. First-seen order is preserved.
 
     Returns:
         With query: EnrichedSearchResponse with indicators, required_country, pagination fields.
-        With queries: MultiQuerySearchResponse with indicators (merged) or results (by_query),
-            total_candidates, deduplicated_count, and per-group errors.
+            Each indicator has covers_country (bool) and requested_country (resolved code).
+        With queries/query_groups: MultiQuerySearchResponse with indicators (merged) or
+            results (by_query), total_candidates, deduplicated_count, and per-group errors.
+            Each indicator has requested_country showing which group's country it was evaluated against.
         error: Error message string if the request failed; otherwise None.
     """
-    import asyncio
-
     # --- Validation ---
-    if query is not None and queries is not None:
+    active_modes = sum([
+        query is not None,
+        queries is not None,
+        query_groups is not None,
+    ])
+    if active_modes > 1:
         return EnrichedSearchResponse(
-            error="Provide either 'query' (single string) or 'queries' (list), not both."
+            error="Provide exactly one of 'query', 'queries', or 'query_groups', not multiple."
         )
-    if query is None and queries is None:
-        return EnrichedSearchResponse(error="Either 'query' or 'queries' must be provided.")
+    if active_modes == 0:
+        return EnrichedSearchResponse(
+            error="One of 'query', 'queries', or 'query_groups' must be provided."
+        )
 
-    # --- Multi-query path ---
+    # --- Multi-query path (queries= flat list) ---
     if queries is not None:
         clean_queries = [q.strip() for q in queries if q and q.strip()]
-        if len(clean_queries) < 2:
+        if len(clean_queries) < len(queries):
+            _logger.warning(
+                "Stripped %d empty/whitespace-only entries from queries "
+                "(original: %d, kept: %d)",
+                len(queries) - len(clean_queries),
+                len(queries),
+                len(clean_queries),
+            )
+        if len(clean_queries) < 2:  # noqa: PLR2004
             return MultiQuerySearchResponse(
                 error="'queries' must contain at least 2 non-empty search strings.",
                 queries=queries or [],
@@ -641,89 +691,133 @@ async def search(
                 queries=clean_queries,
             )
 
-        # Handle limit/offset aliases
-        if n_results is not None and limit == DEFAULT_SEARCH_LIMIT:
-            limit = n_results
-        if skip is not None and offset == 0:
-            offset = skip
+        # Handle limit/offset aliases (mirror single-query path warnings)
+        if n_results is not None:
+            if limit == DEFAULT_SEARCH_LIMIT:
+                limit = n_results
+            elif limit != n_results:
+                _logger.warning(
+                    "Both limit=%d and n_results=%d provided; using limit",
+                    limit,
+                    n_results,
+                )
+        if skip is not None:
+            if offset == 0:
+                offset = skip
+            elif offset != skip:
+                _logger.warning(
+                    "Both offset=%d and skip=%d provided; using offset",
+                    offset,
+                    skip,
+                )
 
-        # Resolve country once, shared across all sub-queries
+        # Resolve shared country once for all sub-queries
         country_code: str | None = None
         if required_country:
             country_code = await _resolve_country_code(required_country)
 
+        # Each query gets the same country code
+        per_query_codes: list[str | None] = [country_code] * len(clean_queries)
+
         # Fan out concurrent _search_raw calls, one per query
-        _select_fields = [
-            "idno", "name", "database_id", "definition_long",
-            "periodicity", "time_periods", "ref_country", "dimensions", "measurement_unit",
-        ]
         raw_tasks = [
-            _search_raw(query=q, limit=limit, offset=offset, select_fields=_select_fields)
+            _search_raw(query=q, limit=limit, offset=offset, select_fields=_ENRICHMENT_SELECT_FIELDS)
             for q in clean_queries
         ]
         raw_results = await asyncio.gather(*raw_tasks, return_exceptions=True)
 
-        # Enrich results per group; apply cross-group dedup when requested
-        seen_ids: set[tuple[str, str]] = set()
-        groups: list[QueryGroupResult] = []
-        total_candidates = 0
-        deduplicated_count = 0
+        db_mapping = await get_database_mapping()
+        return await _build_multi_query_response(
+            clean_queries=clean_queries,
+            raw_results=raw_results,
+            per_query_codes=per_query_codes,
+            result_layout=result_layout,
+            dedupe=dedupe,
+            db_mapping=db_mapping,
+        )
 
-        for q, raw_result in zip(clean_queries, raw_results):
-            if isinstance(raw_result, Exception):
-                groups.append(QueryGroupResult(query=q, error=str(raw_result)))
-                continue
-            if raw_result.error or not raw_result.items:
-                groups.append(QueryGroupResult(
-                    query=q,
-                    error=raw_result.error or f"No indicators found for: '{q}'",
-                ))
-                continue
+    # --- query_groups path ---
+    if query_groups is not None:
+        if required_country:
+            _logger.warning(
+                "required_country is ignored when query_groups is used; "
+                "set country per QueryGroup instead."
+            )
 
-            enriched = _enrich_search_results(raw_result, country_code)
-            total_candidates += len(enriched)
-
-            if dedupe:
-                deduped: list[EnrichedIndicator] = []
-                for ind in enriched:
-                    key = (ind.database_id, ind.idno)
-                    if key not in seen_ids:
-                        seen_ids.add(key)
-                        deduped.append(ind)
-                    else:
-                        deduplicated_count += 1
-                enriched = deduped
-
-            groups.append(QueryGroupResult(query=q, indicators=enriched, count=len(enriched)))
-
-        if result_layout == "merged":
-            merged_indicators: list[EnrichedIndicator] = [
-                ind for g in groups for ind in g.indicators
-            ]
-            if country_code:
-                merged_indicators.sort(
-                    key=lambda x: (
-                        not (x.covers_country or False),
-                        -(int(x.latest_data or 0) if str(x.latest_data or "").isdigit() else 0),
+        # Flatten groups into (query, raw_country) pairs, stripping empty entries
+        flat_pairs: list[tuple[str, str | None]] = []
+        for group in query_groups:
+            for q in group.queries:
+                stripped = q.strip() if q else ""
+                if stripped:
+                    flat_pairs.append((stripped, group.country))
+                else:
+                    _logger.warning(
+                        "Empty/whitespace-only query stripped from query_groups."
                     )
+
+        if len(flat_pairs) < 2:  # noqa: PLR2004
+            return MultiQuerySearchResponse(
+                error="query_groups must produce at least 2 non-empty queries total.",
+                queries=[fp[0] for fp in flat_pairs],
+            )
+        if result_layout not in ("merged", "by_query"):
+            return MultiQuerySearchResponse(
+                error="result_layout must be 'merged' or 'by_query'.",
+                queries=[fp[0] for fp in flat_pairs],
+            )
+
+        # Handle limit/offset aliases
+        if n_results is not None:
+            if limit == DEFAULT_SEARCH_LIMIT:
+                limit = n_results
+            elif limit != n_results:
+                _logger.warning(
+                    "Both limit=%d and n_results=%d provided; using limit",
+                    limit,
+                    n_results,
                 )
-            return MultiQuerySearchResponse(
-                indicators=merged_indicators,
-                result_layout="merged",
-                queries=clean_queries,
-                required_country=country_code,
-                total_candidates=total_candidates,
-                deduplicated_count=deduplicated_count if dedupe else None,
+        if skip is not None:
+            if offset == 0:
+                offset = skip
+            elif offset != skip:
+                _logger.warning(
+                    "Both offset=%d and skip=%d provided; using offset",
+                    offset,
+                    skip,
+                )
+
+        # Resolve unique country values concurrently to avoid redundant codelist lookups
+        unique_countries = {c for _, c in flat_pairs if c}
+        resolved_map: dict[str, str | None] = {}
+        if unique_countries:
+            codes = await asyncio.gather(
+                *[_resolve_country_code(c) for c in unique_countries]
             )
-        else:  # by_query
-            return MultiQuerySearchResponse(
-                results=groups,
-                result_layout="by_query",
-                queries=clean_queries,
-                required_country=country_code,
-                total_candidates=total_candidates,
-                deduplicated_count=deduplicated_count if dedupe else None,
-            )
+            resolved_map = dict(zip(unique_countries, codes))
+
+        clean_queries = [q for q, _ in flat_pairs]
+        per_query_codes = [
+            resolved_map.get(c) if c else None
+            for _, c in flat_pairs
+        ]
+
+        # Fan out concurrent _search_raw calls, one per flattened query
+        raw_tasks = [
+            _search_raw(query=q, limit=limit, offset=offset, select_fields=_ENRICHMENT_SELECT_FIELDS)
+            for q in clean_queries
+        ]
+        raw_results = await asyncio.gather(*raw_tasks, return_exceptions=True)
+
+        db_mapping = await get_database_mapping()
+        return await _build_multi_query_response(
+            clean_queries=clean_queries,
+            raw_results=raw_results,
+            per_query_codes=per_query_codes,
+            result_layout=result_layout,
+            dedupe=dedupe,
+            db_mapping=db_mapping,
+        )
 
     # --- Single-query path (original behavior, fully preserved) ---
     # Handle common parameter aliases sent by LLM clients.
@@ -760,17 +854,7 @@ async def search(
         query=query,  # type: ignore[arg-type]  # validated non-None above
         limit=limit,
         offset=offset,
-        select_fields=[
-            "idno",
-            "name",
-            "database_id",
-            "definition_long",
-            "periodicity",
-            "time_periods",
-            "ref_country",
-            "dimensions",
-            "measurement_unit",
-        ],
+        select_fields=_ENRICHMENT_SELECT_FIELDS,
     )
 
     if search_result.error:
@@ -779,7 +863,8 @@ async def search(
     if not search_result.items:
         return EnrichedSearchResponse(error=f"No indicators found for: '{query}'")
 
-    indicators = _enrich_search_results(search_result, country_code)
+    db_mapping = await get_database_mapping()
+    indicators = _enrich_search_results(search_result, country_code, db_mapping)
 
     # Sort: covers_country=True first, then by latest_data descending
     if country_code:
@@ -800,6 +885,97 @@ async def search(
         has_more=search_result.has_more,
         next_offset=search_result.next_offset,
     )
+
+
+async def _build_multi_query_response(
+    clean_queries: list[str],
+    raw_results: list[Any],
+    per_query_codes: list[str | None],
+    result_layout: str,
+    dedupe: bool,
+    db_mapping: dict[str, str] | None = None,
+) -> MultiQuerySearchResponse:
+    """Shared response builder for queries= and query_groups= paths.
+
+    Encapsulates enrichment, deduplication, and layout selection so both
+    paths stay in sync without code duplication.
+    """
+    seen_ids: set[tuple[str, str]] = set()
+    groups: list[QueryGroupResult] = []
+    total_candidates = 0
+    deduplicated_count = 0
+
+    for i, (q, raw_result) in enumerate(zip(clean_queries, raw_results)):
+        code_for_query = per_query_codes[i]
+        if isinstance(raw_result, Exception):
+            groups.append(QueryGroupResult(
+                query=q,
+                country_code=code_for_query,
+                error=str(raw_result),
+            ))
+            continue
+        if raw_result.error or not raw_result.items:
+            groups.append(QueryGroupResult(
+                query=q,
+                country_code=code_for_query,
+                error=raw_result.error or f"No indicators found for: '{q}'",
+            ))
+            continue
+
+        enriched = _enrich_search_results(raw_result, code_for_query, db_mapping)
+        total_candidates += len(enriched)
+
+        if dedupe:
+            deduped: list[EnrichedIndicator] = []
+            for ind in enriched:
+                key = (ind.database_id, ind.idno)
+                if key not in seen_ids:
+                    seen_ids.add(key)
+                    deduped.append(ind)
+                else:
+                    deduplicated_count += 1
+            enriched = deduped
+
+        groups.append(QueryGroupResult(
+            query=q,
+            country_code=code_for_query,
+            indicators=enriched,
+            count=len(enriched),
+        ))
+
+    # Compute response-level required_country: join all unique resolved codes
+    all_codes = sorted({c for c in per_query_codes if c})
+    response_country = ",".join(all_codes) if all_codes else None
+
+    if result_layout == "merged":
+        merged_indicators: list[EnrichedIndicator] = [
+            ind for g in groups for ind in g.indicators
+        ]
+        # Sort: covers_country=True first (per-indicator, already correct), then recency
+        if response_country:
+            merged_indicators.sort(
+                key=lambda x: (
+                    not (x.covers_country or False),
+                    -(int(x.latest_data or 0) if str(x.latest_data or "").isdigit() else 0),
+                )
+            )
+        return MultiQuerySearchResponse(
+            indicators=merged_indicators,
+            result_layout="merged",
+            queries=clean_queries,
+            required_country=response_country,
+            total_candidates=total_candidates,
+            deduplicated_count=deduplicated_count if dedupe else None,
+        )
+    else:  # by_query
+        return MultiQuerySearchResponse(
+            results=groups,
+            result_layout="by_query",
+            queries=clean_queries,
+            required_country=response_country,
+            total_candidates=total_candidates,
+            deduplicated_count=deduplicated_count if dedupe else None,
+        )
 
 
 # ruff: noqa: PLR0913, PLR0912, PLR0915
@@ -823,7 +999,7 @@ async def get_metadata(
         select_fields: Optional list of metadata fields to return. If None, returns all fields.
             Available fields: methodology, statistical_concept, definition_long, limitation,
             relevance, aggregation_method, periodicity, time_periods, ref_country, sources_note.
-        get_valid_disaggregations_func: Internal use; function to filter raw disaggregation response.
+        get_valid_disaggregations_func: Internal parameter — do not pass this; leave it as None.
         fetch_disaggregation: If True (default), also fetch disaggregation dimensions (field_name, field_value).
         required_country: Optional country name or 3-letter code (e.g. "Kenya", "KEN").
             Use comma-separated for multiple (e.g. "China, USA"). When provided,
@@ -964,6 +1140,10 @@ async def get_disaggregation(
     Typically call after data360_search_indicators when you need available years or breakdowns.
     Use the returned values in disaggregation_filters; do not use FREQ for filtering (it breaks queries).
 
+    After calling this tool, use the returned field_value codes directly as disaggregation_filters
+    in data360_get_data or data360_get_viz_spec. For example, if SEX returns ["M", "F", "_T"],
+    pass {"SEX": "F"} to filter to female-only data.
+
     Args:
         database_id: Database identifier (e.g., WB_GS, WB_SSGD).
         indicator_id: Indicator ID (e.g., WB_GS_NY_GDP_PCAP_KD).
@@ -1011,6 +1191,7 @@ async def get_disaggregation(
 async def get_data(
     database_id: str,
     indicator_id: str,
+    country_code: str | None = None,
     disaggregation_filters: dict[str, str | None] | None = None,
     start_year: int | None = None,
     end_year: int | None = None,
@@ -1026,10 +1207,12 @@ async def get_data(
     Args:
         database_id: Database identifier (e.g., "IPC_IPC", "WB_GS").
         indicator_id: Indicator ID (e.g., "IPC_IPC_PHASE", "WB_GS_NY_GDP_PCAP_KD").
+        country_code: Optional 3-letter code or comma-separated list (e.g. "KEN" or "KEN,MAR").
+            Applied as REF_AREA filter. Takes precedence over REF_AREA in disaggregation_filters.
         disaggregation_filters: Optional dict of dimension filters. Keys: REF_AREA, SEX, AGE,
             URBANISATION, UNIT_MEASURE, etc. REF_AREA supports comma-separated codes (e.g. "KEN,TZA").
             Use value None to request all values for a dimension (e.g. {"SEX": None}).
-        start_year: Optional start year (inclusive). Defaults to last 20 years if both start/end omitted.
+        start_year: Optional start year (inclusive). Defaults to last 5 years if both start/end omitted.
         end_year: Optional end year (inclusive). Defaults to current year if both start/end omitted.
         limit: Maximum records per page (default 50, max 100).
         offset: Number of records to skip for pagination (default 0).
@@ -1042,7 +1225,8 @@ async def get_data(
             total_count: Total records available, or None.
             offset, has_more, next_offset: Use next_offset for the next page when has_more is True.
             error: Error message if the request failed; otherwise None.
-            failed_validation: Optional list of filter validation messages.
+            failed_validation: Optional list of filter validation messages. Non-empty means
+                some filters were invalid; data may still be returned with valid filters applied.
     """
     data_url = data360_config.data_url or f"{data360_config.api_url}/data"
 
@@ -1051,7 +1235,7 @@ async def get_data(
 
     # Smart time defaults: if no time range specified, default to last 5 years
     if start_year is None and end_year is None:
-        from datetime import datetime
+        from datetime import datetime  # noqa: PLC0415
 
         current_year = datetime.now().year
         end_year = current_year
@@ -1085,6 +1269,11 @@ async def get_data(
         "top": limit + 1,
     }
 
+    # Apply country_code if provided (supports comma-separated, e.g. "KEN,MAR")
+    # Takes precedence over REF_AREA in disaggregation_filters
+    if country_code:
+        params["REF_AREA"] = country_code
+
     # Fetch metadata and disaggregations FIRST to inform parameter building
     # This ensures we don't apply invalid defaults (like AGE=_T) which cause empty results
     metadata_res = await get_metadata(
@@ -1099,13 +1288,25 @@ async def get_data(
             "definition_short",
         ],
         fetch_disaggregation=True,  # Crucial: fetch valid options
+        required_country=country_code,  # Pass for REF_AREA validation
     )
 
     if metadata_res.error:
+        if metadata_res.indicator_metadata is None:
+            # Fatal: indicator not found or completely unavailable.
+            _logger.warning(
+                "Aborting get_data for %s: indicator metadata missing. Error: %s",
+                indicator_id,
+                metadata_res.error,
+            )
+            return IndicatorDataResponse(error=metadata_res.error)
+        # Non-fatal: disaggregation lookup failed but indicator metadata is valid.
+        # Proceed without validated disaggregation defaults.
         _logger.warning(
-            f"Metadata fetch error for {indicator_id}: {metadata_res.error}"
+            "Non-fatal metadata error for %s (proceeding without disaggregation defaults): %s",
+            indicator_id,
+            metadata_res.error,
         )
-        return IndicatorDataResponse(error=metadata_res.error)
 
     api_metadata = metadata_res.indicator_metadata or {}
 
@@ -1130,7 +1331,7 @@ async def get_data(
     params.update(effective_disagg)
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
-            print(f"Fetching data from {data_url} with params: {params}")
+            _logger.debug("Fetching data from %s with params: %s", data_url, params)
             data_res = await client.get(data_url, params=params)
             data_res.raise_for_status()
 
@@ -1262,7 +1463,7 @@ async def discover_indicators(
             required_dimensions=["SEX", "AGE"]
         )
     """
-    import warnings
+    import warnings  # noqa: PLC0415
 
     warnings.warn(
         "discover_indicators is deprecated. Use search() + get_disaggregation() + get_metadata() instead.",
@@ -1301,6 +1502,7 @@ async def get_data_api_url(
 
     Returns:
         Full Data360 data API URL string (query parameters included).
+        Raises ValueError if the indicator is not found in the specified database.
     """
     settings = get_data360_settings()
 
@@ -1329,8 +1531,14 @@ async def get_data_api_url(
     )
 
     if metadata_res.error:
-        raise ValueError(
-            f"Indicator '{indicator_id}' not found or error fetching metadata: {metadata_res.error}"
+        if metadata_res.indicator_metadata is None:
+            raise ValueError(
+                f"Indicator '{indicator_id}' not found: {metadata_res.error}"
+            )
+        _logger.warning(
+            "Non-fatal metadata error for %s in get_data_api_url (proceeding): %s",
+            indicator_id,
+            metadata_res.error,
         )
 
     # Process valid disaggregations into {dim: [values]} format

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -186,7 +186,7 @@ async def _resolve_queried_countries(
     resolved = await _resolve_country_code(required_country)
     if not resolved:
         return None
-    return [c.strip() for c in resolved.split(",")]
+    return [c.strip() for c in resolved.split(";") if c.strip()]
 
 
 def _validate_user_filters(
@@ -460,16 +460,17 @@ async def _resolve_country_code(country_query: str) -> str | None:
     if not country_query:
         return None
 
-    # Handle multi-country
-    if "," in country_query:
-        parts = [p.strip() for p in country_query.split(",") if p.strip()]
+    # Handle multi-country: semicolons are the user-facing delimiter because
+    # some country names contain commas (e.g. "Korea, Republic of").
+    if ";" in country_query:
+        parts = [p.strip() for p in country_query.split(";") if p.strip()]
         resolved_codes = []
         for part in parts:
             code = await _resolve_country_code(part)
             if code:
                 resolved_codes.append(code)
 
-        return ",".join(resolved_codes) if resolved_codes else None
+        return ";".join(resolved_codes) if resolved_codes else None
 
     # Already a 3-letter code
     if len(country_query) == COUNTRY_CODE_LENGTH and country_query.isupper():
@@ -641,7 +642,9 @@ async def search(  # noqa: PLR0911
             Requires at least 2 non-empty queries total across all groups.
             If using this, do not pass query or queries. required_country is ignored.
         required_country: Optional country name or 3-letter code (e.g. "Kenya", "KEN").
-            Use comma-separated names or codes to check multiple countries in one call (e.g. "China, USA").
+            Use semicolon-separated names or codes to check multiple countries in one call
+            (e.g. "China; USA"). Semicolons are used because some country names contain
+            commas (e.g. "Korea, Republic of").
             Shared across all queries — only when all topics share the same geographic scope.
             Ignored when query_groups is used (each group has its own country).
         limit: Maximum number of indicators per query (default 5).
@@ -655,7 +658,8 @@ async def search(  # noqa: PLR0911
 
     Returns:
         With query: EnrichedSearchResponse with indicators, required_country, pagination fields.
-            Each indicator has covers_country (bool) and requested_country (resolved code).
+            Each indicator has covers_country (dict[str, bool], e.g. {\"KEN\": True}) and
+            requested_country (resolved semicolon-separated code string).
         With queries/query_groups: MultiQuerySearchResponse with indicators (merged) or
             results (by_query), total_candidates, deduplicated_count, and per-group errors.
             Each indicator has requested_country showing which group's country it was evaluated against.
@@ -889,7 +893,7 @@ async def search(  # noqa: PLR0911
     if country_code:
         indicators.sort(
             key=lambda x: (
-                not (x.covers_country or False),
+                not any((x.covers_country or {}).values()),
                 -(int(x.latest_data or 0) if str(x.latest_data or "").isdigit() else 0),
             )
         )
@@ -962,9 +966,9 @@ async def _build_multi_query_response(
             count=len(enriched),
         ))
 
-    # Compute response-level required_country: join all unique resolved codes
+    # Compute response-level required_country: join all unique resolved codes with ";"
     all_codes = sorted({c for c in per_query_codes if c})
-    response_country = ",".join(all_codes) if all_codes else None
+    response_country = ";".join(all_codes) if all_codes else None
 
     if result_layout == "merged":
         merged_indicators: list[EnrichedIndicator] = [
@@ -974,7 +978,7 @@ async def _build_multi_query_response(
         if response_country:
             merged_indicators.sort(
                 key=lambda x: (
-                    not (x.covers_country or False),
+                    not any((x.covers_country or {}).values()),
                     -(int(x.latest_data or 0) if str(x.latest_data or "").isdigit() else 0),
                 )
             )
@@ -1021,7 +1025,7 @@ async def get_metadata(
         get_valid_disaggregations_func: Internal parameter — do not pass this; leave it as None.
         fetch_disaggregation: If True (default), also fetch disaggregation dimensions (field_name, field_value).
         required_country: Optional country name or 3-letter code (e.g. "Kenya", "KEN").
-            Use comma-separated for multiple (e.g. "China, USA"). When provided,
+            Use semicolon-separated for multiple (e.g. "China; USA"). When provided,
             REF_AREA in disaggregation shows which queried countries have data.
 
     Returns:
@@ -1167,7 +1171,7 @@ async def get_disaggregation(
         database_id: Database identifier (e.g., WB_GS, WB_SSGD).
         indicator_id: Indicator ID (e.g., WB_GS_NY_GDP_PCAP_KD).
         required_country: Optional country name or 3-letter code (e.g. "Kenya", "KEN").
-            Use comma-separated names or codes to check multiple countries in one call (e.g. "China, USA").
+            Use semicolon-separated names or codes to check multiple countries in one call (e.g. "China; USA").
             When provided, REF_AREA shows which queried countries have data for this indicator.
 
     Returns:
@@ -1226,7 +1230,7 @@ async def get_data(
     Args:
         database_id: Database identifier (e.g., "IPC_IPC", "WB_GS").
         indicator_id: Indicator ID (e.g., "IPC_IPC_PHASE", "WB_GS_NY_GDP_PCAP_KD").
-        country_code: Optional 3-letter code or comma-separated list (e.g. "KEN" or "KEN,MAR").
+        country_code: Optional 3-letter code or semicolon-separated list (e.g. "KEN" or "KEN;MAR").
             Applied as REF_AREA filter. Takes precedence over REF_AREA in disaggregation_filters.
         disaggregation_filters: Optional dict of dimension filters. Keys: REF_AREA, SEX, AGE,
             URBANISATION, UNIT_MEASURE, etc. REF_AREA supports comma-separated codes (e.g. "KEN,TZA").
@@ -1295,10 +1299,10 @@ async def get_data(
         "top": limit + 1,
     }
 
-    # Apply country_code if provided (supports comma-separated, e.g. "KEN,MAR")
-    # Takes precedence over REF_AREA in disaggregation_filters
+    # Convert semicolon-separated list into comma-separated list for Data API
     if country_code:
-        params["REF_AREA"] = country_code
+        # Takes precedence over REF_AREA in disaggregation_filters
+        params["REF_AREA"] = country_code.replace(";", ",")
 
     # Fetch metadata and disaggregations FIRST to inform parameter building
     # This ensures we don't apply invalid defaults (like AGE=_T) which cause empty results
@@ -1520,7 +1524,7 @@ async def get_data_api_url(
     Args:
         database_id: Database identifier (e.g., WB_HNP, WB_WDI).
         indicator_id: Indicator ID (e.g., WB_HNP_SP_POP_TOTL).
-        country_code: Optional 3-letter code or comma-separated list (e.g. "KEN" or "CHN,USA").
+        country_code: Optional 3-letter code or semicolon-separated list (e.g. "KEN" or "CHN;USA").
         start_year: Optional start year (inclusive).
         end_year: Optional end year (inclusive).
         disaggregation_filters: Optional dict of dimension filters (e.g. {"SEX": "F"}).

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -926,7 +926,7 @@ async def _build_multi_query_response(
     Encapsulates enrichment, deduplication, and layout selection so both
     paths stay in sync without code duplication.
     """
-    seen_ids: set[tuple[str, str]] = set()
+    seen_dict: dict[tuple[str, str], EnrichedIndicator] = {}
     groups: list[QueryGroupResult] = []
     total_candidates = 0
     deduplicated_count = 0
@@ -951,22 +951,40 @@ async def _build_multi_query_response(
         enriched = _enrich_search_results(raw_result, code_for_query, db_mapping)
         total_candidates += len(enriched)
 
-        if dedupe:
-            deduped: list[EnrichedIndicator] = []
-            for ind in enriched:
-                key = (ind.database_id, ind.idno)
-                if key not in seen_ids:
-                    seen_ids.add(key)
-                    deduped.append(ind)
-                else:
+        group_indicators: list[EnrichedIndicator] = []
+        group_seen: set[tuple[str, str]] = set()
+
+        for ind in enriched:
+            key = (ind.database_id, ind.idno)
+
+            if key in seen_dict:
+                existing_ind = seen_dict[key]
+
+                # Merge covers_country data across queries/groups
+                if existing_ind.covers_country is not None and ind.covers_country is not None:
+                    existing_ind.covers_country.update(ind.covers_country)
+
+                if dedupe and result_layout == "merged":
+                    # Global deduplication: discard from subsequent groups in merged layout
                     deduplicated_count += 1
-            enriched = deduped
+                else:
+                    # In by_query layout, or if dedupe=False, we keep the indicator.
+                    # But if dedupe=True, we still deduplicate WITHIN the same group.
+                    if dedupe and key in group_seen:
+                        deduplicated_count += 1
+                    else:
+                        group_seen.add(key)
+                        group_indicators.append(existing_ind)
+            else:
+                seen_dict[key] = ind
+                group_seen.add(key)
+                group_indicators.append(ind)
 
         groups.append(QueryGroupResult(
             query=q,
             country_code=code_for_query,
-            indicators=enriched,
-            count=len(enriched),
+            indicators=group_indicators,
+            count=len(group_indicators),
         ))
 
     # Compute response-level required_country: join all unique resolved codes with ";"

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -655,6 +655,16 @@ async def search(  # noqa: PLR0911
         error: Error message string if the request failed; otherwise None.
     """
     # --- Validation ---
+    # Normalise LLM-hallucinated empty defaults before mode detection.
+    # When a client sends query="" or queries=[] alongside the real parameter
+    # (e.g. query_groups), treat these as "not provided" — identical to None.
+    if query is not None and not query.strip():
+        _logger.debug("query='%s' normalised to None (empty/whitespace-only)", query)
+        query = None
+    if queries is not None and not any(q and q.strip() for q in queries):
+        _logger.debug("queries=%r normalised to None (all entries empty)", queries)
+        queries = None
+
     active_modes = sum((
         query is not None,
         queries is not None,
@@ -668,6 +678,7 @@ async def search(  # noqa: PLR0911
         return EnrichedSearchResponse(
             error="One of 'query', 'queries', or 'query_groups' must be provided."
         )
+
 
     # --- Multi-query path (queries= flat list) ---
     if queries is not None:

--- a/src/data360/models.py
+++ b/src/data360/models.py
@@ -136,7 +136,9 @@ class EnrichedIndicator(BaseModel):
         None, description="Data availability range (e.g., '1990-2024')"
     )
     covers_country: dict[str, bool] | None = Field(
-        None, description="Per-country coverage map: True if indicator has data for the requested country code"
+        None,
+        description="Per-country coverage map (e.g. {'KEN': True, 'GHA': False}). "
+        "Populated when required_country is provided. None when no country was requested.",
     )
     requested_country: str | None = Field(
         None,
@@ -159,7 +161,9 @@ class EnrichedSearchResponse(MCPPagedResponse):
         default_factory=list, description="Enriched indicators sorted by relevance"
     )
     required_country: str | None = Field(
-        None, description="Resolved country code (e.g., KEN for Kenya)"
+        None,
+        description="Resolved country code(s). Semicolon-separated for multiple countries "
+        "(e.g. 'KEN' or 'KEN;GHA').",
     )
     error: str | None = Field(None, description="Error message if search failed")
 
@@ -234,7 +238,9 @@ class MultiQuerySearchResponse(BaseModel):
         default_factory=list, description="The input query strings"
     )
     required_country: str | None = Field(
-        None, description="Resolved country code(s) used for all sub-queries"
+        None,
+        description="Resolved country code(s) used for all sub-queries. "
+        "Semicolon-separated for multiple countries (e.g. 'KEN;GHA').",
     )
     total_candidates: int = Field(
         0,

--- a/src/data360/models.py
+++ b/src/data360/models.py
@@ -158,6 +158,60 @@ class EnrichedSearchResponse(MCPPagedResponse):
     error: str | None = Field(None, description="Error message if search failed")
 
 
+class QueryGroupResult(BaseModel):
+    """Result group for a single query within a multi-query search.
+
+    Only returned when result_layout='by_query'.
+    """
+
+    query: str = Field(..., description="The search query that produced these results")
+    indicators: list[EnrichedIndicator] = Field(
+        default_factory=list, description="Indicators found for this query"
+    )
+    count: int = Field(default=0, description="Number of indicators in this group")
+    error: str | None = Field(
+        None, description="Error message if this sub-query failed"
+    )
+
+
+class MultiQuerySearchResponse(BaseModel):
+    """Response for multi-query search (when queries parameter is used).
+
+    result_layout='merged': indicators contains a flat, deduped list.
+    result_layout='by_query': results contains one group per input query.
+    dedupe=True with by_query means cross-group dedup — first group to
+    claim an indicator keeps it; later groups skip it.
+    """
+
+    indicators: list[EnrichedIndicator] = Field(
+        default_factory=list,
+        description="Merged, deduplicated indicators (result_layout='merged')",
+    )
+    results: list[QueryGroupResult] | None = Field(
+        None,
+        description="Per-query result groups (result_layout='by_query')",
+    )
+    result_layout: str = Field(
+        "merged", description="Layout mode used: 'merged' or 'by_query'"
+    )
+    queries: list[str] = Field(
+        default_factory=list, description="The input query strings"
+    )
+    required_country: str | None = Field(
+        None, description="Resolved country code(s) used for all sub-queries"
+    )
+    total_candidates: int = Field(
+        0,
+        description="Total indicators found before dedup (merged) or across all groups (by_query)",
+    )
+    deduplicated_count: int | None = Field(
+        None, description="Number of duplicates removed (merged layout only)"
+    )
+    error: str | None = Field(
+        None, description="Top-level error if the entire multi-query operation failed"
+    )
+
+
 class MetadataRequest(BaseModel):
     """Request model for data 360 metadata retrieval."""
 

--- a/src/data360/models.py
+++ b/src/data360/models.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -135,8 +135,14 @@ class EnrichedIndicator(BaseModel):
     time_period_range: str | None = Field(
         None, description="Data availability range (e.g., '1990-2024')"
     )
-    covers_country: bool | None = Field(
-        None, description="True if indicator has data for the requested country"
+    covers_country: dict[str, bool] | None = Field(
+        None, description="Per-country coverage map: True if indicator has data for the requested country code"
+    )
+    requested_country: str | None = Field(
+        None,
+        description="Resolved country code this indicator was evaluated against "
+        "(set when per-group countries are used via query_groups; also set for "
+        "single-query path when required_country is provided).",
     )
     dimensions: list[str] | None = Field(
         None, description="Available disaggregations (SEX, AGE, URBANISATION)"
@@ -158,6 +164,30 @@ class EnrichedSearchResponse(MCPPagedResponse):
     error: str | None = Field(None, description="Error message if search failed")
 
 
+class QueryGroup(BaseModel):
+    """A group of search queries scoped to an optional country.
+
+    Allows binding multiple search terms to a specific geographic scope
+    in a single search() call. Used with the query_groups parameter.
+
+    Example::
+
+        QueryGroup(queries=["GDP per capita", "inflation rate"], country="Kenya")
+    """
+
+    queries: list[str] = Field(
+        ...,
+        description="Search terms for this group (e.g., ['GDP per capita', 'inflation rate']). "
+        "At least one non-empty string required.",
+        min_length=1,
+    )
+    country: str | None = Field(
+        None,
+        description="Country name or 3-letter code for this group (e.g., 'Kenya' or 'KEN'). "
+        "If None, no country filtering is applied to indicators in this group.",
+    )
+
+
 class QueryGroupResult(BaseModel):
     """Result group for a single query within a multi-query search.
 
@@ -165,6 +195,11 @@ class QueryGroupResult(BaseModel):
     """
 
     query: str = Field(..., description="The search query that produced these results")
+    country_code: str | None = Field(
+        None,
+        description="Resolved country code for this query group (e.g., 'KEN'). "
+        "Set when query_groups is used and a country was specified for this group.",
+    )
     indicators: list[EnrichedIndicator] = Field(
         default_factory=list, description="Indicators found for this query"
     )
@@ -185,13 +220,14 @@ class MultiQuerySearchResponse(BaseModel):
 
     indicators: list[EnrichedIndicator] = Field(
         default_factory=list,
-        description="Merged, deduplicated indicators (result_layout='merged')",
+        description="Flat indicator list. Populated when result_layout='merged'; "
+        "empty when 'by_query' (see results field instead).",
     )
     results: list[QueryGroupResult] | None = Field(
         None,
         description="Per-query result groups (result_layout='by_query')",
     )
-    result_layout: str = Field(
+    result_layout: Literal["merged", "by_query"] = Field(
         "merged", description="Layout mode used: 'merged' or 'by_query'"
     )
     queries: list[str] = Field(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -916,7 +916,7 @@ class TestGetDataResilience:
 
         httpx_mock.add_callback(data_callback)
 
-        result = await get_data("WB_WDI", "WB_WDI_SP_POP_TOTL", country_code="KEN,MAR")
+        result = await get_data("WB_WDI", "WB_WDI_SP_POP_TOTL", country_code="KEN;MAR")
 
         assert len(captured_urls) == 1
         assert "REF_AREA=KEN%2CMAR" in captured_urls[0] or "REF_AREA=KEN,MAR" in captured_urls[0]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -816,6 +816,113 @@ class TestGetData:
 # New tests for ReferenceAreaManager should be added in test_providers.py
 
 
+# ---------------------------------------------------------------------------
+# B1 — get_data() graceful degradation on disaggregation-only errors (Issue #59)
+# ---------------------------------------------------------------------------
+
+
+class TestGetDataResilience:
+    """Tests for Issue #59: get_data should not abort when only disaggregation fails."""
+
+    @pytest.mark.asyncio
+    async def test_get_data_proceeds_when_disaggregation_fails_but_metadata_valid(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
+        """When indicator metadata is found but disaggregation errors, data fetch still proceeds."""
+        # Metadata succeeds
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.test.example.com/metadata",
+            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL", "name": "Pop"}}]},
+        )
+        # Disaggregation fails with 500
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(r".*/disaggregation.*"),
+            status_code=500,
+            text="Internal Server Error",
+        )
+        # Data fetch succeeds
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(r".*/data\?.*"),
+            json={"value": [{"REF_AREA": "KEN", "TIME_PERIOD": "2020", "OBS_VALUE": 5000}]},
+        )
+
+        result = await get_data("WB_WDI", "WB_WDI_SP_POP_TOTL")
+
+        # Should have data despite disaggregation error
+        assert result.data is not None
+        assert len(result.data) >= 1
+        assert result.error is None
+
+    @pytest.mark.asyncio
+    async def test_get_data_aborts_when_indicator_metadata_missing(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
+        """When indicator metadata is missing (indicator not found), abort with error."""
+        # Metadata returns empty (indicator not found)
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.test.example.com/metadata",
+            json={"value": []},
+        )
+        # Disaggregation returns 200 empty (doesn't matter)
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(r".*/disaggregation.*"),
+            json=[],
+        )
+
+        result = await get_data("WB_WDI", "NONEXISTENT_INDICATOR")
+
+        # Should abort — indicator not found
+        assert result.data is None or result.data == []
+        assert result.error is not None
+
+    # ---------------------------------------------------------------------------
+    # C1 — country_code parameter on get_data()
+    # ---------------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_get_data_country_code_param_sets_ref_area(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
+        """country_code parameter should be passed as REF_AREA in the data request URL."""
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.test.example.com/metadata",
+            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL", "name": "Pop"}}]},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(r".*/disaggregation.*"),
+            json=[],
+        )
+
+        captured_urls: list[str] = []
+
+        def data_callback(request: httpx.Request) -> httpx.Response | None:
+            if request.method == "GET" and request.url.path == "/data":
+                captured_urls.append(str(request.url))
+                return httpx.Response(
+                    200,
+                    json={"value": [
+                        {"REF_AREA": "KEN", "TIME_PERIOD": "2020", "OBS_VALUE": 100},
+                        {"REF_AREA": "MAR", "TIME_PERIOD": "2020", "OBS_VALUE": 200},
+                    ]},
+                )
+            return None
+
+        httpx_mock.add_callback(data_callback)
+
+        result = await get_data("WB_WDI", "WB_WDI_SP_POP_TOTL", country_code="KEN,MAR")
+
+        assert len(captured_urls) == 1
+        assert "REF_AREA=KEN%2CMAR" in captured_urls[0] or "REF_AREA=KEN,MAR" in captured_urls[0]
+        assert result.data is not None
+
+
 class TestDatabaseNameInSearch:
     """Tests that search results carry the correct database_name for each indicator."""
 
@@ -922,6 +1029,116 @@ class TestDatabaseNameInSearch:
                 f"Expected database_name for id '{ind.database_id}', got None"
             )
             assert ind.database_name == mapping[ind.database_id]
+
+
+class TestDatabaseNameInMetadata:
+    """Tests that get_metadata injects database_name into indicator_metadata."""
+
+    @pytest.mark.asyncio
+    async def test_get_metadata_injects_database_name(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
+        """indicator_metadata must contain database_name resolved from database_id."""
+        metadata_response = {
+            "value": [
+                {
+                    "series_description": {
+                        "idno": "WB_GS_INDICATOR",
+                        "name": "Some indicator",
+                        "database_id": "WB_GS",
+                        "definition_long": "Full definition",
+                    }
+                }
+            ]
+        }
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.test.example.com/metadata",
+            json=metadata_response,
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(r".*/disaggregation.*"),
+            json=[],
+        )
+
+        captured_urls: list[str] = []
+
+        def data_callback(request: httpx.Request) -> httpx.Response | None:
+            if request.method == "GET" and request.url.path == "/data":
+                captured_urls.append(str(request.url))
+                return httpx.Response(
+                    200,
+                    json={"value": [
+                        {"REF_AREA": "KEN", "TIME_PERIOD": "2020", "OBS_VALUE": 100},
+                        {"REF_AREA": "MAR", "TIME_PERIOD": "2020", "OBS_VALUE": 200},
+                    ]},
+                )
+            return None
+
+        httpx_mock.add_callback(data_callback)
+
+        result = await get_data("WB_WDI", "WB_WDI_SP_POP_TOTL", country_code="KEN,MAR")
+
+        assert len(captured_urls) == 1
+        assert "REF_AREA=KEN%2CMAR" in captured_urls[0] or "REF_AREA=KEN,MAR" in captured_urls[0]
+        assert result.data is not None
+
+
+# ---------------------------------------------------------------------------
+# D1 — get_data_api_url() parity fix (same Issue #59 resilience)
+# ---------------------------------------------------------------------------
+
+
+class TestGetDataApiUrlResilience:
+    @pytest.mark.asyncio
+    async def test_get_data_api_url_proceeds_on_nonfatal_metadata_error(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
+        """get_data_api_url should not raise when indicator metadata exists but disaggregation fails."""
+        from data360.api import get_data_api_url
+
+        # Metadata succeeds
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.test.example.com/metadata",
+            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL", "name": "Pop"}}]},
+        )
+        # Disaggregation fails
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(r".*/disaggregation.*"),
+            status_code=500,
+            text="Internal Server Error",
+        )
+
+        # Should not raise — returns a URL string
+        url = await get_data_api_url("WB_WDI", "WB_WDI_SP_POP_TOTL")
+        assert isinstance(url, str)
+        assert "WB_WDI" in url
+        assert "WB_WDI_SP_POP_TOTL" in url
+
+    @pytest.mark.asyncio
+    async def test_get_data_api_url_raises_when_indicator_not_found(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
+        """get_data_api_url should raise ValueError when indicator metadata is missing."""
+        from data360.api import get_data_api_url
+
+        # Metadata returns empty
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.test.example.com/metadata",
+            json={"value": []},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(r".*/disaggregation.*"),
+            json=[],
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            await get_data_api_url("WB_WDI", "NONEXISTENT_INDICATOR")
 
 
 class TestDatabaseNameInMetadata:

--- a/tests/test_multi_query_search.py
+++ b/tests/test_multi_query_search.py
@@ -717,3 +717,272 @@ class TestQueryGroups:
         assert isinstance(result, MultiQuerySearchResponse)
         # Only 2 unique countries resolved despite 3 queries
         assert set(resolve_calls) == {"Kenya", "Morocco"}
+
+
+# ---------------------------------------------------------------------------
+# Semicolon delimiter + covers_country dict
+# ---------------------------------------------------------------------------
+
+
+def _make_series_with_countries(
+    idno: str,
+    name: str,
+    ref_country_codes: list[str],
+) -> SeriesDescription:
+    """Helper that builds a SeriesDescription with an explicit ref_country list."""
+    return SeriesDescription(
+        idno=idno,
+        name=name,
+        database_id="WB_WDI",
+        definition_long="Test indicator.",
+        periodicity="Annual",
+        time_periods=[{"start": "2000", "end": "2023", "LATEST_DATA_POINT": "2023"}],
+        ref_country=[{"code": c} for c in ref_country_codes],
+        dimensions=[],
+    )
+
+
+def _make_search_response_with_countries(
+    idno: str,
+    name: str,
+    ref_country_codes: list[str],
+) -> SearchResponse:
+    return SearchResponse(
+        items=[_make_series_with_countries(idno, name, ref_country_codes)],
+        count=1,
+        total_count=1,
+        offset=0,
+        has_more=False,
+        next_offset=None,
+    )
+
+
+class TestSemicolonDelimiterAndCoversCountry:
+    """Tests for the semicolon country delimiter and per-country covers_country dict."""
+
+    # -- covers_country shape --------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_single_country_covers_country_is_dict(self):
+        """With one country, covers_country must be a dict keyed by that country's code."""
+        resp = _make_search_response_with_countries("IND_1", "GDP", ["KEN"])
+        with (
+            patch("data360.api._search_raw", new=AsyncMock(return_value=resp)),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value="KEN")),
+        ):
+            result = await search(query="GDP", required_country="Kenya")
+
+        assert isinstance(result, EnrichedSearchResponse)
+        ind = result.indicators[0]
+        assert isinstance(ind.covers_country, dict)
+        assert ind.covers_country == {"KEN": True}
+
+    @pytest.mark.asyncio
+    async def test_single_country_not_covered_is_false_in_dict(self):
+        """When the indicator does not list the requested country, covers_country[code] is False."""
+        resp = _make_search_response_with_countries("IND_1", "GDP", ["USA"])
+        with (
+            patch("data360.api._search_raw", new=AsyncMock(return_value=resp)),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value="KEN")),
+        ):
+            result = await search(query="GDP", required_country="Kenya")
+
+        assert isinstance(result, EnrichedSearchResponse)
+        ind = result.indicators[0]
+        assert isinstance(ind.covers_country, dict)
+        assert ind.covers_country == {"KEN": False}
+
+    @pytest.mark.asyncio
+    async def test_no_country_covers_country_is_none(self):
+        """When no country is requested, covers_country must be None."""
+        resp = _make_search_response_with_countries("IND_1", "GDP", ["KEN"])
+        with (
+            patch("data360.api._search_raw", new=AsyncMock(return_value=resp)),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value=None)),
+        ):
+            result = await search(query="GDP")
+
+        assert isinstance(result, EnrichedSearchResponse)
+        assert result.indicators[0].covers_country is None
+
+    @pytest.mark.asyncio
+    async def test_empty_ref_country_with_requested_country_is_all_false(self):
+        """If ref_country list is empty but a country was requested, all codes map to False."""
+        resp = _make_search_response_with_countries("IND_1", "GDP", [])
+        with (
+            patch("data360.api._search_raw", new=AsyncMock(return_value=resp)),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value="KEN")),
+        ):
+            result = await search(query="GDP", required_country="Kenya")
+
+        ind = result.indicators[0]
+        # ref_country is [] — falls into the elif country_code branch
+        assert isinstance(ind.covers_country, dict)
+        assert ind.covers_country == {"KEN": False}
+
+    # -- semicolon multi-country -----------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_multi_country_semicolon_resolves_both(self):
+        """Semicolon-separated required_country correctly splits and resolves each part.
+
+        We test this by calling _resolve_country_code directly (no mock on the
+        function itself) and mocking only the underlying codelist provider so the
+        recursive path executes.
+        """
+        from data360.api import _resolve_country_code
+
+        call_args: list[str] = []
+
+        async def _fake_find(codelist_type: str, query: str, limit: int = 1) -> list[dict]:
+            call_args.append(query)
+            mapping = {"Kenya": "KEN", "Ghana": "GHA"}
+            code = mapping.get(query)
+            return [{"id": code, "score": 90}] if code else []
+
+        with patch("data360.providers.find_codelist_value", new=AsyncMock(side_effect=_fake_find)):
+            result = await _resolve_country_code("Kenya; Ghana")
+
+        # Both parts should have been looked up
+        assert "Kenya" in call_args
+        assert "Ghana" in call_args
+        # Result is semicolon-joined resolved codes
+        assert result == "KEN;GHA"
+
+    @pytest.mark.asyncio
+    async def test_multi_country_covers_country_has_entry_per_code(self):
+        """covers_country dict has one key per requested country code."""
+        resp = _make_search_response_with_countries("IND_1", "GDP", ["KEN"])
+
+        async def _resolve(country: str) -> str | None:
+            mapping = {"KEN;GHA": None, "KEN": "KEN", "GHA": "GHA", "Kenya": "KEN", "Ghana": "GHA"}
+            return mapping.get(country)
+
+        with (
+            patch("data360.api._search_raw", new=AsyncMock(return_value=resp)),
+            patch(
+                "data360.api._resolve_country_code",
+                new=AsyncMock(side_effect=_resolve),
+            ),
+        ):
+            # Directly test _enrich_search_results with a pre-resolved multi-country code
+            from data360.api import _enrich_search_results
+
+            search_resp = _make_search_response_with_countries("IND_1", "GDP", ["KEN"])
+            indicators = _enrich_search_results(search_resp, "KEN;GHA")
+
+        ind = indicators[0]
+        assert isinstance(ind.covers_country, dict)
+        assert set(ind.covers_country.keys()) == {"KEN", "GHA"}
+        assert ind.covers_country["KEN"] is True
+        assert ind.covers_country["GHA"] is False
+
+    @pytest.mark.asyncio
+    async def test_multi_country_all_covered(self):
+        """When all requested countries are in ref_country, all values are True."""
+        from data360.api import _enrich_search_results
+
+        search_resp = _make_search_response_with_countries("IND_1", "GDP", ["KEN", "GHA"])
+        indicators = _enrich_search_results(search_resp, "KEN;GHA")
+
+        ind = indicators[0]
+        assert ind.covers_country == {"KEN": True, "GHA": True}
+
+    @pytest.mark.asyncio
+    async def test_multi_country_none_covered(self):
+        """When no requested country is in ref_country, all values are False."""
+        from data360.api import _enrich_search_results
+
+        search_resp = _make_search_response_with_countries("IND_1", "GDP", ["USA", "FRA"])
+        indicators = _enrich_search_results(search_resp, "KEN;GHA")
+
+        ind = indicators[0]
+        assert ind.covers_country == {"KEN": False, "GHA": False}
+
+    # -- comma-in-name safety --------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_comma_in_country_name_not_split(self):
+        """A country name containing a comma must NOT be split on that comma.
+
+        'Korea, Republic of' should be resolved as a single lookup, not two.
+        """
+        resolve_calls: list[str] = []
+
+        async def _track(country: str) -> str | None:
+            resolve_calls.append(country)
+            # Simulate no semicolon → falls through to codelist lookup returning KOR
+            return "KOR"
+
+        with (
+            patch("data360.api._search_raw", new=AsyncMock(return_value=_make_search_response())),
+            patch("data360.api._resolve_country_code", new=AsyncMock(side_effect=_track)),
+        ):
+            await search(query="GDP", required_country="Korea, Republic of")
+
+        # The country string should reach _resolve_country_code as-is (no splitting on comma)
+        assert "Korea, Republic of" in resolve_calls
+
+    # -- response-level required_country format --------------------------------
+
+    @pytest.mark.asyncio
+    async def test_required_country_in_response_uses_semicolon(self):
+        """EnrichedSearchResponse.required_country must use semicolons when multiple codes."""
+        resp1 = _make_search_response_with_countries("IND_1", "GDP", ["KEN"])
+        resp2 = _make_search_response_with_countries("IND_2", "Gini", ["GHA"])
+
+        async def _resolve(country: str) -> str | None:
+            return {"Kenya": "KEN", "Ghana": "GHA"}.get(country)
+
+        with (
+            patch("data360.api._search_raw", new=AsyncMock(side_effect=[resp1, resp2])),
+            patch("data360.api._resolve_country_code", new=AsyncMock(side_effect=_resolve)),
+        ):
+            result = await search(
+                query_groups=[
+                    QueryGroup(queries=["GDP"], country="Kenya"),
+                    QueryGroup(queries=["Gini"], country="Ghana"),
+                ],
+            )
+
+        assert isinstance(result, MultiQuerySearchResponse)
+        # Codes are sorted and joined with ";"
+        assert result.required_country == "GHA;KEN"
+        assert "," not in (result.required_country or "")
+
+    # -- sort ordering ---------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_covered_indicator_sorts_before_uncovered(self):
+        """Indicator with covers_country having any True value sorts before all-False indicator."""
+        from data360.api import _enrich_search_results
+
+        # older indicator but covered
+        covered_resp = _make_search_response_with_countries("IND_COVERED", "GDP", ["KEN"])
+        covered_resp.items[0].time_periods = [{"start": "2000", "end": "2010", "LATEST_DATA_POINT": "2010"}]
+
+        # newer indicator but not covered
+        uncovered_resp = _make_search_response_with_countries("IND_UNCOVERED", "Inflation", ["USA"])
+        uncovered_resp.items[0].time_periods = [{"start": "2000", "end": "2023", "LATEST_DATA_POINT": "2023"}]
+
+        from data360.models import SearchResponse as SR
+
+        combined = SR(
+            items=[covered_resp.items[0], uncovered_resp.items[0]],
+            count=2,
+            total_count=2,
+            offset=0,
+            has_more=False,
+            next_offset=None,
+        )
+        indicators = _enrich_search_results(combined, "KEN")
+
+        indicators.sort(
+            key=lambda x: (
+                not any((x.covers_country or {}).values()),
+                -(int(x.latest_data or 0) if str(x.latest_data or "").isdigit() else 0),
+            )
+        )
+
+        assert indicators[0].idno == "IND_COVERED"
+        assert indicators[1].idno == "IND_UNCOVERED"

--- a/tests/test_multi_query_search.py
+++ b/tests/test_multi_query_search.py
@@ -1,0 +1,326 @@
+"""Tests for multi-query search (queries parameter) in data360_search_indicators."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from data360.api import search
+from data360.models import (
+    EnrichedSearchResponse,
+    MultiQuerySearchResponse,
+    QueryGroupResult,
+    SearchResponse,
+    SeriesDescription,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_series(idno: str = "WB_WDI_GDP", name: str = "GDP") -> SeriesDescription:
+    return SeriesDescription(
+        idno=idno,
+        name=name,
+        database_id="WB_WDI",
+        definition_long="A test indicator.",
+        periodicity="Annual",
+        time_periods=[{"start": "2000", "end": "2023", "LATEST_DATA_POINT": "2023"}],
+        ref_country=[{"code": "KEN"}],
+        dimensions=[],
+    )
+
+
+def _make_search_response(
+    idno: str = "WB_WDI_GDP",
+    name: str = "GDP",
+    count: int = 1,
+) -> SearchResponse:
+    return SearchResponse(
+        items=[_make_series(idno, name)],
+        count=count,
+        total_count=count,
+        offset=0,
+        has_more=False,
+        next_offset=None,
+    )
+
+
+def _empty_search_response() -> SearchResponse:
+    return SearchResponse(items=None, error="No indicators found for: 'xyz'")
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatibility tests (single query path)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchSingleQueryBackwardCompat:
+    @pytest.mark.asyncio
+    async def test_single_query_returns_enriched_response(self):
+        with (
+            patch(
+                "data360.api._search_raw",
+                new=AsyncMock(return_value=_make_search_response()),
+            ),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value=None)),
+        ):
+            result = await search(query="GDP per capita")
+
+        assert isinstance(result, EnrichedSearchResponse)
+        assert len(result.indicators) == 1
+        assert result.error is None
+
+    @pytest.mark.asyncio
+    async def test_single_query_with_country(self):
+        with (
+            patch(
+                "data360.api._search_raw",
+                new=AsyncMock(return_value=_make_search_response()),
+            ),
+            patch(
+                "data360.api._resolve_country_code",
+                new=AsyncMock(return_value="KEN"),
+            ),
+        ):
+            result = await search(query="GDP", required_country="Kenya")
+
+        assert isinstance(result, EnrichedSearchResponse)
+        assert result.required_country == "KEN"
+
+    @pytest.mark.asyncio
+    async def test_single_query_no_results_returns_error(self):
+        with (
+            patch(
+                "data360.api._search_raw",
+                new=AsyncMock(return_value=_empty_search_response()),
+            ),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value=None)),
+        ):
+            result = await search(query="xyz-does-not-exist")
+
+        assert isinstance(result, EnrichedSearchResponse)
+        assert result.error is not None
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestSearchValidation:
+    @pytest.mark.asyncio
+    async def test_both_query_and_queries_returns_error(self):
+        result = await search(query="GDP", queries=["GDP", "inflation"])
+        assert isinstance(result, EnrichedSearchResponse)
+        assert result.error is not None
+        assert "both" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_neither_query_nor_queries_returns_error(self):
+        result = await search()
+        assert isinstance(result, EnrichedSearchResponse)
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_queries_with_one_entry_returns_error(self):
+        result = await search(queries=["GDP"])
+        assert isinstance(result, MultiQuerySearchResponse)
+        assert result.error is not None
+        assert "at least 2" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_queries_with_empty_strings_filtered_to_under_two_errors(self):
+        result = await search(queries=["GDP", "  ", ""])
+        assert isinstance(result, MultiQuerySearchResponse)
+        assert result.error is not None
+        assert "at least 2" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_invalid_result_layout_returns_error(self):
+        result = await search(queries=["GDP", "inflation"], result_layout="invalid")
+        assert isinstance(result, MultiQuerySearchResponse)
+        assert result.error is not None
+        assert "result_layout" in result.error.lower()
+
+
+# ---------------------------------------------------------------------------
+# Multi-query merged layout tests
+# ---------------------------------------------------------------------------
+
+
+class TestSearchMultiQueryMerged:
+    @pytest.mark.asyncio
+    async def test_two_queries_merged_returns_multi_response(self):
+        gdp_resp = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        inf_resp = _make_search_response(idno="WB_WDI_INF", name="Inflation")
+
+        mock_raw = AsyncMock(side_effect=[gdp_resp, inf_resp])
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value=None)),
+        ):
+            result = await search(queries=["GDP", "inflation"])
+
+        assert isinstance(result, MultiQuerySearchResponse)
+        assert result.result_layout == "merged"
+        assert len(result.indicators) == 2
+        assert result.total_candidates == 2
+
+    @pytest.mark.asyncio
+    async def test_merged_deduplication_removes_duplicates(self):
+        # Both queries return the same indicator
+        same_resp_1 = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        same_resp_2 = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+
+        mock_raw = AsyncMock(side_effect=[same_resp_1, same_resp_2])
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value=None)),
+        ):
+            result = await search(queries=["GDP growth", "GDP"], dedupe=True)
+
+        assert isinstance(result, MultiQuerySearchResponse)
+        assert len(result.indicators) == 1
+        assert result.deduplicated_count == 1
+
+    @pytest.mark.asyncio
+    async def test_merged_dedupe_false_preserves_duplicates(self):
+        same_resp_1 = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        same_resp_2 = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+
+        mock_raw = AsyncMock(side_effect=[same_resp_1, same_resp_2])
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value=None)),
+        ):
+            result = await search(queries=["GDP growth", "GDP"], dedupe=False)
+
+        assert isinstance(result, MultiQuerySearchResponse)
+        assert len(result.indicators) == 2
+        assert result.deduplicated_count is None
+
+    @pytest.mark.asyncio
+    async def test_country_resolved_once(self):
+        gdp_resp = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        inf_resp = _make_search_response(idno="WB_WDI_INF", name="Inflation")
+
+        mock_raw = AsyncMock(side_effect=[gdp_resp, inf_resp])
+        mock_resolve = AsyncMock(return_value="KEN")
+
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=mock_resolve),
+        ):
+            result = await search(
+                queries=["GDP", "inflation"], required_country="Kenya"
+            )
+
+        # resolve called once regardless of query count
+        mock_resolve.assert_awaited_once_with("Kenya")
+        assert result.required_country == "KEN"
+
+    @pytest.mark.asyncio
+    async def test_one_failing_sub_query_does_not_crash(self):
+        good_resp = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        bad_resp = _empty_search_response()
+
+        mock_raw = AsyncMock(side_effect=[good_resp, bad_resp])
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value=None)),
+        ):
+            result = await search(queries=["GDP", "xyz-missing"])
+
+        assert isinstance(result, MultiQuerySearchResponse)
+        # Good sub-query still returns its indicator
+        assert len(result.indicators) == 1
+
+
+# ---------------------------------------------------------------------------
+# Multi-query by_query layout tests
+# ---------------------------------------------------------------------------
+
+
+class TestSearchMultiQueryByQuery:
+    @pytest.mark.asyncio
+    async def test_by_query_returns_groups(self):
+        gdp_resp = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        inf_resp = _make_search_response(idno="WB_WDI_INF", name="Inflation")
+
+        mock_raw = AsyncMock(side_effect=[gdp_resp, inf_resp])
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value=None)),
+        ):
+            result = await search(
+                queries=["GDP", "inflation"], result_layout="by_query"
+            )
+
+        assert isinstance(result, MultiQuerySearchResponse)
+        assert result.result_layout == "by_query"
+        assert result.results is not None
+        assert len(result.results) == 2
+        assert result.results[0].query == "GDP"
+        assert result.results[1].query == "inflation"
+
+    @pytest.mark.asyncio
+    async def test_by_query_cross_group_dedup(self):
+        """Same indicator in both groups: second group should not include it."""
+        same_resp_1 = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        same_resp_2 = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+
+        mock_raw = AsyncMock(side_effect=[same_resp_1, same_resp_2])
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value=None)),
+        ):
+            result = await search(
+                queries=["GDP growth", "GDP per capita"],
+                result_layout="by_query",
+                dedupe=True,
+            )
+
+        assert result.results is not None
+        assert result.results[0].count == 1  # first group keeps it
+        assert result.results[1].count == 0  # second group loses it to dedup
+        assert result.deduplicated_count == 1
+
+    @pytest.mark.asyncio
+    async def test_by_query_failed_group_has_error_field(self):
+        good_resp = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        bad_resp = _empty_search_response()
+
+        mock_raw = AsyncMock(side_effect=[good_resp, bad_resp])
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value=None)),
+        ):
+            result = await search(
+                queries=["GDP", "xyz-missing"], result_layout="by_query"
+            )
+
+        assert result.results is not None
+        assert result.results[0].error is None
+        assert result.results[1].error is not None
+
+    @pytest.mark.asyncio
+    async def test_by_query_exception_in_sub_query(self):
+        """_search_raw raises an exception for one sub-query."""
+
+        async def _raise_on_second(*, query, **kwargs):
+            if query == "crash":
+                raise RuntimeError("Network timeout")
+            return _make_search_response()
+
+        with (
+            patch("data360.api._search_raw", new=AsyncMock(side_effect=_raise_on_second)),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value=None)),
+        ):
+            result = await search(queries=["GDP", "crash"], result_layout="by_query")
+
+        assert result.results is not None
+        crash_group = next(g for g in result.results if g.query == "crash")
+        assert crash_group.error is not None
+        assert "Network timeout" in crash_group.error

--- a/tests/test_multi_query_search.py
+++ b/tests/test_multi_query_search.py
@@ -144,6 +144,74 @@ class TestSearchValidation:
         assert result.error is not None
         assert "result_layout" in result.error.lower()
 
+    @pytest.mark.asyncio
+    async def test_empty_string_query_with_query_groups_does_not_error(self):
+        """LLM clients sometimes send query="" alongside query_groups.
+        Empty string should be normalised to None and not trigger the mutual
+        exclusion error — the query_groups path should be taken instead."""
+        gdp_resp = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        inf_resp = _make_search_response(idno="WB_WDI_INF", name="Inflation")
+
+        mock_raw = AsyncMock(side_effect=[gdp_resp, inf_resp])
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value="KEN")),
+        ):
+            result = await search(
+                query="",  # LLM-hallucinated empty default
+                query_groups=[
+                    QueryGroup(queries=["GDP per capita"], country="Kenya"),
+                    QueryGroup(queries=["inflation rate"], country="Kenya"),
+                ],
+            )
+
+        assert result.error is None or "exactly one" not in (result.error or "")
+        assert isinstance(result, MultiQuerySearchResponse)
+
+    @pytest.mark.asyncio
+    async def test_whitespace_query_with_query_groups_does_not_error(self):
+        """query='   ' (whitespace-only) should also be treated as absent."""
+        gdp_resp = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        inf_resp = _make_search_response(idno="WB_WDI_INF", name="Inflation")
+
+        mock_raw = AsyncMock(side_effect=[gdp_resp, inf_resp])
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value="KEN")),
+        ):
+            result = await search(
+                query="   ",
+                query_groups=[
+                    QueryGroup(queries=["GDP per capita"], country="Kenya"),
+                    QueryGroup(queries=["inflation rate"], country="Kenya"),
+                ],
+            )
+
+        assert result.error is None or "exactly one" not in (result.error or "")
+        assert isinstance(result, MultiQuerySearchResponse)
+
+    @pytest.mark.asyncio
+    async def test_empty_queries_list_with_query_groups_does_not_error(self):
+        """queries=[] sent alongside query_groups should be normalised to None."""
+        gdp_resp = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        inf_resp = _make_search_response(idno="WB_WDI_INF", name="Inflation")
+
+        mock_raw = AsyncMock(side_effect=[gdp_resp, inf_resp])
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value="KEN")),
+        ):
+            result = await search(
+                queries=[],  # LLM-hallucinated empty default
+                query_groups=[
+                    QueryGroup(queries=["GDP per capita"], country="Kenya"),
+                    QueryGroup(queries=["inflation rate"], country="Kenya"),
+                ],
+            )
+
+        assert result.error is None or "exactly one" not in (result.error or "")
+        assert isinstance(result, MultiQuerySearchResponse)
+
 
 # ---------------------------------------------------------------------------
 # Multi-query merged layout tests

--- a/tests/test_multi_query_search.py
+++ b/tests/test_multi_query_search.py
@@ -334,8 +334,8 @@ class TestSearchMultiQueryByQuery:
         assert result.results[1].query == "inflation"
 
     @pytest.mark.asyncio
-    async def test_by_query_cross_group_dedup(self):
-        """Same indicator in both groups: second group should not include it."""
+    async def test_by_query_cross_group_dedup_disabled(self):
+        """Same indicator in both groups: by_query layout should retain it in both groups."""
         same_resp_1 = _make_search_response(idno="WB_WDI_GDP", name="GDP")
         same_resp_2 = _make_search_response(idno="WB_WDI_GDP", name="GDP")
 
@@ -352,7 +352,39 @@ class TestSearchMultiQueryByQuery:
 
         assert result.results is not None
         assert result.results[0].count == 1  # first group keeps it
-        assert result.results[1].count == 0  # second group loses it to dedup
+        assert result.results[1].count == 1  # second group also keeps it
+        assert result.deduplicated_count == 0
+
+    @pytest.mark.asyncio
+    async def test_merged_layout_merges_covers_country(self):
+        """When an indicator is in two groups, covers_country is merged and deduplicated."""
+        resp_1 = _make_search_response_with_countries("WB_WDI_GDP", "GDP", ["KEN"])
+        resp_2 = _make_search_response_with_countries("WB_WDI_GDP", "GDP", ["KEN"])
+
+        mock_raw = AsyncMock(side_effect=[resp_1, resp_2])
+
+        async def _resolve(c):
+            if c == "Kenya": return "KEN"
+            if c == "Morocco": return "MAR"
+            return None
+
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(side_effect=_resolve)),
+        ):
+            result = await search(
+                query_groups=[
+                    QueryGroup(queries=["GDP"], country="Kenya"),
+                    QueryGroup(queries=["GDP"], country="Morocco"),
+                ],
+                result_layout="merged",
+                dedupe=True,
+            )
+
+        assert isinstance(result, MultiQuerySearchResponse)
+        assert len(result.indicators) == 1
+        ind = result.indicators[0]
+        assert ind.covers_country == {"KEN": True, "MAR": False}
         assert result.deduplicated_count == 1
 
     @pytest.mark.asyncio

--- a/tests/test_multi_query_search.py
+++ b/tests/test_multi_query_search.py
@@ -1,13 +1,13 @@
-"""Tests for multi-query search (queries parameter) in data360_search_indicators."""
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from data360.api import search
 from data360.models import (
     EnrichedSearchResponse,
     MultiQuerySearchResponse,
+    QueryGroup,
     QueryGroupResult,
     SearchResponse,
     SeriesDescription,
@@ -115,7 +115,7 @@ class TestSearchValidation:
         result = await search(query="GDP", queries=["GDP", "inflation"])
         assert isinstance(result, EnrichedSearchResponse)
         assert result.error is not None
-        assert "both" in result.error.lower()
+        assert "exactly one" in result.error.lower()
 
     @pytest.mark.asyncio
     async def test_neither_query_nor_queries_returns_error(self):
@@ -324,3 +324,328 @@ class TestSearchMultiQueryByQuery:
         crash_group = next(g for g in result.results if g.query == "crash")
         assert crash_group.error is not None
         assert "Network timeout" in crash_group.error
+
+
+# ---------------------------------------------------------------------------
+# A2 — _ENRICHMENT_SELECT_FIELDS constant used in both paths
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichmentSelectFields:
+    def test_constant_exists_and_is_non_empty(self):
+        from data360.api import _ENRICHMENT_SELECT_FIELDS
+        assert isinstance(_ENRICHMENT_SELECT_FIELDS, list)
+        assert len(_ENRICHMENT_SELECT_FIELDS) > 0
+        assert "idno" in _ENRICHMENT_SELECT_FIELDS
+        assert "database_id" in _ENRICHMENT_SELECT_FIELDS
+
+    @pytest.mark.asyncio
+    async def test_single_query_path_uses_constant(self):
+        """_search_raw should receive the _ENRICHMENT_SELECT_FIELDS list."""
+        from data360.api import _ENRICHMENT_SELECT_FIELDS
+
+        mock_raw = AsyncMock(return_value=_make_search_response())
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value=None)),
+        ):
+            await search(query="GDP")
+
+        mock_raw.assert_awaited_once()
+        _, kwargs = mock_raw.call_args
+        assert kwargs.get("select_fields") == _ENRICHMENT_SELECT_FIELDS
+
+    @pytest.mark.asyncio
+    async def test_multi_query_path_uses_constant(self):
+        """Each _search_raw call in multi-query path should receive _ENRICHMENT_SELECT_FIELDS."""
+        from data360.api import _ENRICHMENT_SELECT_FIELDS
+
+        gdp_resp = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        inf_resp = _make_search_response(idno="WB_WDI_INF", name="Inflation")
+        mock_raw = AsyncMock(side_effect=[gdp_resp, inf_resp])
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value=None)),
+        ):
+            await search(queries=["GDP", "inflation"])
+
+        for call in mock_raw.call_args_list:
+            _, kwargs = call
+            assert kwargs.get("select_fields") == _ENRICHMENT_SELECT_FIELDS
+
+
+# ---------------------------------------------------------------------------
+# A3 — Alias conflict warnings in multi-query path
+# ---------------------------------------------------------------------------
+
+
+class TestAliasConflictWarnings:
+    @pytest.mark.asyncio
+    async def test_n_results_and_limit_conflict_logs_warning(self, caplog):
+        gdp_resp = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        inf_resp = _make_search_response(idno="WB_WDI_INF", name="Inflation")
+        mock_raw = AsyncMock(side_effect=[gdp_resp, inf_resp])
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value=None)),
+        ):
+            import logging
+            with caplog.at_level(logging.WARNING, logger="data360.api"):
+                await search(queries=["GDP", "inflation"], limit=10, n_results=3)
+
+        assert any("limit" in rec.message.lower() and "n_results" in rec.message.lower()
+                   for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_skip_and_offset_conflict_logs_warning(self, caplog):
+        gdp_resp = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        inf_resp = _make_search_response(idno="WB_WDI_INF", name="Inflation")
+        mock_raw = AsyncMock(side_effect=[gdp_resp, inf_resp])
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value=None)),
+        ):
+            import logging
+            with caplog.at_level(logging.WARNING, logger="data360.api"):
+                await search(queries=["GDP", "inflation"], offset=5, skip=10)
+
+        assert any("offset" in rec.message.lower() and "skip" in rec.message.lower()
+                   for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# A4 — Literal typing for result_layout
+# ---------------------------------------------------------------------------
+
+
+class TestLiteralResultLayout:
+    def test_invalid_result_layout_raises_validation_error(self):
+        with pytest.raises(ValidationError):
+            MultiQuerySearchResponse(
+                result_layout="flat",
+                queries=["a", "b"],
+            )
+
+    def test_valid_merged_layout_accepted(self):
+        resp = MultiQuerySearchResponse(result_layout="merged", queries=["a", "b"])
+        assert resp.result_layout == "merged"
+
+    def test_valid_by_query_layout_accepted(self):
+        resp = MultiQuerySearchResponse(result_layout="by_query", queries=["a", "b"])
+        assert resp.result_layout == "by_query"
+
+
+# ---------------------------------------------------------------------------
+# A5 — Log stripped empty queries
+# ---------------------------------------------------------------------------
+
+
+class TestStrippedQueryLogging:
+    @pytest.mark.asyncio
+    async def test_empty_entries_warning_logged(self, caplog):
+        result = await search(queries=["GDP", "  ", ""])
+        assert isinstance(result, MultiQuerySearchResponse)
+        # Should have logged warning (empty entries stripped leaving < 2)
+        # error returned because < 2 valid queries remain
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_partial_strip_still_logs_warning(self, caplog):
+        """3 queries, 1 empty — remaining 2 are valid, warning still emitted."""
+        gdp_resp = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        inf_resp = _make_search_response(idno="WB_WDI_INF", name="Inflation")
+        mock_raw = AsyncMock(side_effect=[gdp_resp, inf_resp])
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value=None)),
+        ):
+            import logging
+            with caplog.at_level(logging.WARNING, logger="data360.api"):
+                result = await search(queries=["GDP", "inflation", ""])
+
+        assert isinstance(result, MultiQuerySearchResponse)
+        assert result.error is None
+        assert any("stripped" in rec.message.lower() for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# E1/E2 — QueryGroup per-group country
+# ---------------------------------------------------------------------------
+
+
+class TestQueryGroups:
+    @pytest.mark.asyncio
+    async def test_query_groups_by_query_layout(self):
+        """Each group should carry correct country_code; indicators have correct requested_country."""
+        gdp_resp = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        gini_resp = _make_search_response(idno="WB_WDI_GINI", name="Gini")
+        mock_raw = AsyncMock(side_effect=[gdp_resp, gini_resp])
+
+        async def _resolve(country):
+            return {"Kenya": "KEN", "Morocco": "MAR"}.get(country, None)
+
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(side_effect=_resolve)),
+        ):
+            result = await search(
+                query_groups=[
+                    QueryGroup(queries=["GDP per capita"], country="Kenya"),
+                    QueryGroup(queries=["Gini coefficient"], country="Morocco"),
+                ],
+                result_layout="by_query",
+            )
+
+        assert isinstance(result, MultiQuerySearchResponse)
+        assert result.result_layout == "by_query"
+        assert result.results is not None
+        assert len(result.results) == 2
+
+        gdp_group = result.results[0]
+        gini_group = result.results[1]
+
+        assert gdp_group.country_code == "KEN"
+        assert gini_group.country_code == "MAR"
+
+        # Each indicator should carry its per-group country
+        assert gdp_group.indicators[0].requested_country == "KEN"
+        assert gini_group.indicators[0].requested_country == "MAR"
+
+    @pytest.mark.asyncio
+    async def test_query_groups_merged_layout_carries_requested_country(self):
+        """Merged indicators must carry requested_country for LLM attribution."""
+        gdp_resp = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        gini_resp = _make_search_response(idno="WB_WDI_GINI", name="Gini")
+        mock_raw = AsyncMock(side_effect=[gdp_resp, gini_resp])
+
+        async def _resolve(country):
+            return {"Kenya": "KEN", "Morocco": "MAR"}.get(country, None)
+
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(side_effect=_resolve)),
+        ):
+            result = await search(
+                query_groups=[
+                    QueryGroup(queries=["GDP per capita"], country="Kenya"),
+                    QueryGroup(queries=["Gini coefficient"], country="Morocco"),
+                ],
+                result_layout="merged",
+            )
+
+        assert isinstance(result, MultiQuerySearchResponse)
+        assert len(result.indicators) == 2
+
+        by_id = {ind.idno: ind for ind in result.indicators}
+        assert by_id["WB_WDI_GDP"].requested_country == "KEN"
+        assert by_id["WB_WDI_GINI"].requested_country == "MAR"
+
+    @pytest.mark.asyncio
+    async def test_query_groups_mutually_exclusive_with_queries(self):
+        result = await search(
+            queries=["GDP", "inflation"],
+            query_groups=[QueryGroup(queries=["GDP"], country="Kenya")],
+        )
+        assert isinstance(result, EnrichedSearchResponse)
+        assert result.error is not None
+        assert "exactly one" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_query_groups_mutually_exclusive_with_query(self):
+        result = await search(
+            query="GDP",
+            query_groups=[QueryGroup(queries=["GDP", "inflation"], country="Kenya")],
+        )
+        assert isinstance(result, EnrichedSearchResponse)
+        assert result.error is not None
+        assert "exactly one" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_query_groups_minimum_two_queries_total(self):
+        """Single query across all groups triggers minimum-2 error."""
+        result = await search(
+            query_groups=[QueryGroup(queries=["GDP"], country="Kenya")],
+        )
+        assert isinstance(result, MultiQuerySearchResponse)
+        assert result.error is not None
+        assert "at least 2" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_query_groups_with_none_country(self):
+        """Groups without country still work; indicators have requested_country=None."""
+        gdp_resp = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        inf_resp = _make_search_response(idno="WB_WDI_INF", name="Inflation")
+        mock_raw = AsyncMock(side_effect=[gdp_resp, inf_resp])
+
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value=None)),
+        ):
+            result = await search(
+                query_groups=[
+                    QueryGroup(queries=["GDP"], country=None),
+                    QueryGroup(queries=["inflation"], country=None),
+                ],
+                result_layout="by_query",
+            )
+
+        assert isinstance(result, MultiQuerySearchResponse)
+        assert result.results is not None
+        for group in result.results:
+            assert group.country_code is None
+            for ind in group.indicators:
+                assert ind.requested_country is None
+
+    @pytest.mark.asyncio
+    async def test_query_groups_required_country_ignored_warning(self, caplog):
+        """required_country is ignored when query_groups is used; warning logged."""
+        gdp_resp = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        inf_resp = _make_search_response(idno="WB_WDI_INF", name="Inflation")
+        mock_raw = AsyncMock(side_effect=[gdp_resp, inf_resp])
+
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(return_value="KEN")),
+        ):
+            import logging
+            with caplog.at_level(logging.WARNING, logger="data360.api"):
+                result = await search(
+                    query_groups=[
+                        QueryGroup(queries=["GDP"], country="Kenya"),
+                        QueryGroup(queries=["inflation"], country=None),
+                    ],
+                    required_country="Morocco",  # should be ignored
+                )
+
+        assert isinstance(result, MultiQuerySearchResponse)
+        assert any("ignored" in rec.message.lower() for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_query_groups_concurrent_country_resolution(self):
+        """Unique countries are resolved concurrently; each resolved code is distinct."""
+        gdp_resp = _make_search_response(idno="WB_WDI_GDP", name="GDP")
+        inf_resp = _make_search_response(idno="WB_WDI_INF", name="Inflation")
+        gini_resp = _make_search_response(idno="WB_WDI_GINI", name="Gini")
+        mock_raw = AsyncMock(side_effect=[gdp_resp, inf_resp, gini_resp])
+
+        resolve_calls: list[str] = []
+
+        async def _track_resolve(country):
+            resolve_calls.append(country)
+            return {"Kenya": "KEN", "Morocco": "MAR"}.get(country)
+
+        with (
+            patch("data360.api._search_raw", new=mock_raw),
+            patch("data360.api._resolve_country_code", new=AsyncMock(side_effect=_track_resolve)),
+        ):
+            result = await search(
+                query_groups=[
+                    QueryGroup(queries=["GDP", "inflation"], country="Kenya"),
+                    QueryGroup(queries=["Gini"], country="Morocco"),
+                ],
+                result_layout="by_query",
+            )
+
+        assert isinstance(result, MultiQuerySearchResponse)
+        # Only 2 unique countries resolved despite 3 queries
+        assert set(resolve_calls) == {"Kenya", "Morocco"}


### PR DESCRIPTION
## Multi-query Search — Backend Implementation

Implements the three call patterns for `data360_search_indicators`:

- **Single query** (`query=`): existing behaviour, unchanged.
- **Multi-topic, shared country** (`queries=`, `required_country=`): returns a merged flat list of deduped indicators.
- **Cross-country groups** (`query_groups=`, `result_layout="by_query"`): returns one result group per query, each scoped to its own country.

### Key additions

- `query_groups` parameter: list of `{queries, country}` objects enabling asymmetric country assignment per topic.
- `result_layout` field in the response: `"merged"` (flat list) or `"by_query"` (grouped per query).
- `required_country` resolved and returned in all response shapes.
- `covers_country` populated per indicator when a country scope is present.

### Dependency

> **Depends on worldbank/data360-mcp#62 (`components/search-v0`) being merged first.**
> PR #62 adds `@data360/tool-types` with the `search-contract` types (`QueryGroupResult`,
> `Data360MultiQuerySearchToolResult`, `result_layout`) that this PR's response shape must satisfy.

### No UI changes required

The chatbot UI integration is handled separately in worldbank/data-ai-chatbot#109.
This PR contains only server-side changes.