### PR TITLE
feat(analyze): LLM sampling decomposition, multi-country query_groups routing, and viz gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ cp .env.example .env
 | `MCP_PORT` | Port for the MCP server | `8000` |
 | `MCP_TRANSPORT` | Transport protocol (`http` or `sse`) | `http` |
 | `MCP_CHARTS_API_URL` | Optional URL for an external chart rendering API | _(none)_ |
+| `OPENAI_API_KEY` | Optional API key for LLM sampling fallback (used by `data360_analyze_development_topic` if client lacks sampling support) | _(none)_ |
 
 ### Run the Server
 
@@ -90,6 +91,7 @@ DEBUG=true uv run scripts/llm_mcp_demo.py
 
 | Tool | Description |
 |---|---|
+| `data360_analyze_development_topic` | End-to-end multi-search and prefetching tool for analyzing vague/abstract topics (e.g. "What makes a country great?"). Decomposes the question using MCP sampling (with OpenAI fallback), evaluates candidates, and ranks indicators. |
 | `data360_search_indicators` | Search indicators with enriched metadata. Pass `required_country` for server-side coverage check. Returns `covers_country`, `latest_data`, `dimensions`. |
 | `data360_get_data` | Fetch data points with filters (country, time period, SEX, AGE, etc.). |
 | `data360_get_metadata` | Get indicator metadata. Use `select_fields` for specific fields. |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -40,6 +40,7 @@ The server starts at `http://localhost:8000/mcp`.
 
 | Tool | What it does |
 |---|---|
+| `data360_analyze_development_topic` | Analyze vague topics using LLM query decomposition |
 | `data360_search_indicators` | Search indicators with country coverage check |
 | `data360_get_data` | Fetch time-series data with filters |
 | `data360_get_metadata` | Get indicator methodology and definitions |

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -1404,8 +1404,9 @@ async def analyze_development_topic(
             sub_queries: The decomposed search terms (from LLM or rule-based).
             decomposition_method: "sampling" or "rule_based".
             selected_indicators: List of ranked indicator dicts, each with:
-                rank, indicator_id, database_id, name, definition, reason,
-                data_snapshot (list of recent data points), data_error (if fetch failed).
+                rank, indicator_id, database_id, name, definition,
+                matched_sub_queries (dict with original_query and decomposed_sub_query),
+                score, data_snapshot (list of recent data points), data_error (if fetch failed).
             coverage_note: Summary of how many indicators were found.
             error: Top-level error message if the entire operation failed.
     """
@@ -1479,34 +1480,34 @@ async def analyze_development_topic(
         len(sub_queries), decomposition_method, sub_queries,
     )
 
-    # --- Step 3: Multi-search across sub-queries ---
-    search_tasks = [
-        search(
-            query=sq,
-            required_country=country_code or country,
-            limit=max_indicators,
-        )
-        for sq in sub_queries
-    ]
-    search_results = await asyncio.gather(*search_tasks, return_exceptions=True)
+    # --- Step 3: Multi-search via the new queries parameter ---
+    # Delegates fan-out, enrichment, and cross-query dedup to search().
+    # result_layout="by_query" preserves which sub-query each indicator came
+    # from — needed to populate matched_sub_queries in the response.
+    multi_result = await search(
+        queries=sub_queries,
+        required_country=country_code or country,
+        limit=max_indicators,
+        result_layout="by_query",
+        dedupe=True,
+    )
 
-    # Pool and deduplicate indicators by indicator ID
-    seen_ids: set[str] = set()
-    all_indicators: list[tuple[EnrichedIndicator, str]] = []  # (indicator, source_query)
+    # Build (indicator, source_query) tuples from grouped results
+    all_indicators: list[tuple[EnrichedIndicator, str]] = []
     total_candidates = 0
 
-    for sq, result in zip(sub_queries, search_results):
-        if isinstance(result, Exception):
-            _logger.warning("Search failed for sub-query '%s': %s", sq, result)
-            continue
-        if result.error:
-            _logger.warning("Search error for sub-query '%s': %s", sq, result.error)
-            continue
-        for ind in result.indicators:
-            total_candidates += 1
-            if ind.idno not in seen_ids:
-                seen_ids.add(ind.idno)
-                all_indicators.append((ind, sq))
+    if isinstance(multi_result, MultiQuerySearchResponse) and multi_result.results:
+        for group in multi_result.results:
+            if group.error:
+                _logger.warning(
+                    "Search error for sub-query '%s': %s", group.query, group.error
+                )
+                continue
+            for ind in group.indicators:
+                total_candidates += 1
+                all_indicators.append((ind, group.query))
+    elif multi_result.error:
+        _logger.warning("Multi-query search failed: %s", multi_result.error)
 
     if not all_indicators:
         return {
@@ -1587,7 +1588,10 @@ async def analyze_development_topic(
             "database_id": ind.database_id,
             "name": ind.name,
             "definition": ind.truncated_definition,
-            "matched_sub_query": source_sq,
+            "matched_sub_queries": {
+                "original_query": query,
+                "decomposed_sub_query": source_sq,
+            },
             "score": round(score, 2),
             "data_snapshot": data_snapshot,
             "data_error": data_error,

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -1496,9 +1496,15 @@ _SAMPLING_SYSTEM_PROMPT = (
     "You are a development economist. Given the user's question about "
     "development data or indicators, generate 3-5 specific, measurable "
     "topics that can be searched in a statistical database (e.g. World "
-    "Bank indicators). Return ONLY a JSON array of short search strings. "
-    'Example: ["GDP per capita", "life expectancy at birth", "school enrollment rate"]\n'
-    "Do not include any other text."
+    "Bank indicators).\n\n"
+    "If the question mentions MULTIPLE countries with DIFFERENT topics per country, "
+    "return a JSON array of objects, each with 'queries' (list of search strings) "
+    "and 'country' (country name):\n"
+    '[{"queries": ["unemployment rate", "labor participation"], "country": "Morocco"}, '
+    '{"queries": ["manufacturing output"], "country": "Ethiopia"}]\n\n'
+    "Otherwise, return a flat JSON array of short search strings:\n"
+    '["GDP per capita", "life expectancy at birth", "school enrollment rate"]\n\n'
+    "Return ONLY the JSON. Do not include any other text."
 )
 
 
@@ -1605,6 +1611,7 @@ async def analyze_development_topic(
     Args:
         query: The user's development-related question (can be vague/broad).
         country: Optional country name or 3-letter code (e.g. "Ghana", "GHA").
+            Can also be comma-separated for multi-country comparisons (e.g. "Morocco, Ethiopia").
         max_indicators: Maximum number of indicators to return (default 4, max 6).
         start_year: Optional start year for data snapshots. Defaults to last 5 years.
         end_year: Optional end year for data snapshots. Defaults to current year.
@@ -1613,7 +1620,7 @@ async def analyze_development_topic(
     Returns:
         Dict with:
             query: The original question.
-            country / country_code: Resolved country info (if provided).
+            country / country_code: Resolved country info (if provided). May be comma-separated.
             sub_queries: The decomposed search terms (from LLM or rule-based).
             decomposition_method: "sampling" or "rule_based".
             selected_indicators: List of ranked indicator dicts, each with:
@@ -1640,6 +1647,7 @@ async def analyze_development_topic(
 
     # --- Step 2: Decompose query into sub-queries ---
     sub_queries: list[str] = []
+    query_groups_from_sampling: list[QueryGroup] | None = None
     decomposition_method = "rule_based"
     sampling_error = None
 
@@ -1664,12 +1672,34 @@ async def analyze_development_topic(
                 # Remove first and last lines (fences)
                 cleaned = "\n".join(lines[1:-1]).strip()
             parsed = json.loads(cleaned)
-            if isinstance(parsed, list) and all(isinstance(s, str) for s in parsed):
-                sub_queries = [s.strip() for s in parsed if s.strip()][:5]
-                decomposition_method = "sampling"
-                _logger.info(
-                    "Sampling decomposition succeeded: %s", sub_queries
-                )
+
+            if isinstance(parsed, list) and len(parsed) > 0:
+                # Case A: grouped format [{"queries": [...], "country": "..."}, ...]
+                if isinstance(parsed[0], dict) and "queries" in parsed[0]:
+                    query_groups_from_sampling = [
+                        QueryGroup(
+                            queries=[q.strip() for q in g["queries"] if q and q.strip()][:5],
+                            country=g.get("country"),
+                        )
+                        for g in parsed
+                        if isinstance(g, dict) and g.get("queries")
+                    ]
+                    if query_groups_from_sampling:
+                        decomposition_method = "sampling"
+                        # sub_queries for display/logging
+                        sub_queries = [q for g in query_groups_from_sampling for q in g.queries]
+                        _logger.info(
+                            "Sampling decomposition succeeded (grouped): %s", query_groups_from_sampling
+                        )
+
+                # Case B: flat format ["GDP per capita", "life expectancy", ...]
+                elif isinstance(parsed[0], str):
+                    sub_queries = [s.strip() for s in parsed if isinstance(s, str) and s.strip()][:5]
+                    if sub_queries:
+                        decomposition_method = "sampling"
+                        _logger.info(
+                            "Sampling decomposition succeeded (flat): %s", sub_queries
+                        )
         except (ValueError, json.JSONDecodeError) as e:
             sampling_error = f"{type(e).__name__}: {e}"
             _logger.warning(
@@ -1697,13 +1727,34 @@ async def analyze_development_topic(
     # Delegates fan-out, enrichment, and cross-query dedup to search().
     # result_layout="by_query" preserves which sub-query each indicator came
     # from — needed to populate matched_sub_queries in the response.
-    multi_result = await search(
-        queries=sub_queries,
-        required_country=country_code or country,
-        limit=max_indicators,
-        result_layout="by_query",
-        dedupe=True,
-    )
+    if query_groups_from_sampling:
+        multi_result = await search(
+            query_groups=query_groups_from_sampling,
+            limit=max_indicators,
+            result_layout="by_query",
+            dedupe=True,
+        )
+    elif country_code and "," in country_code:
+        # Cross-product fallback
+        codes = [c.strip() for c in country_code.split(",")]
+        groups = [
+            QueryGroup(queries=sub_queries, country=code)
+            for code in codes
+        ]
+        multi_result = await search(
+            query_groups=groups,
+            limit=max_indicators,
+            result_layout="by_query",
+            dedupe=True,
+        )
+    else:
+        multi_result = await search(
+            queries=sub_queries,
+            required_country=country_code or country,
+            limit=max_indicators,
+            result_layout="by_query",
+            dedupe=True,
+        )
 
     # Build (indicator, source_query) tuples from grouped results
     all_indicators: list[tuple[EnrichedIndicator, str]] = []

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -1,8 +1,11 @@
 import json
 import logging
+import re
 import zlib
 from typing import Any
 from urllib.parse import urlencode
+
+from fastmcp.server.context import Context
 
 import dotenv
 import httpx
@@ -1262,6 +1265,349 @@ async def discover_indicators(
     )
 
     # ... existing implementation ...
+
+
+# --- Topic Analysis Helpers ---
+
+# Conjunctions and stopwords used for rule-based query decomposition
+_SPLIT_CONJUNCTIONS = re.compile(r"\band\b|\bor\b|\b&\b|,|;", re.IGNORECASE)
+_STOPWORDS = frozenset({
+    "what", "are", "the", "main", "is", "a", "an", "of", "for", "in",
+    "to", "how", "does", "do", "its", "their", "has", "been", "being",
+    "with", "on", "at", "by", "from", "about", "between", "which",
+    "facing", "challenges", "issues", "problems", "region", "country",
+    "makes", "great", "key", "major", "most", "important",
+})
+_DEFAULT_SUMMARY_YEARS = 5
+_SAMPLING_SYSTEM_PROMPT = (
+    "You are a development economist. Given the user's question about "
+    "development data or indicators, generate 3-5 specific, measurable "
+    "topics that can be searched in a statistical database (e.g. World "
+    "Bank indicators). Return ONLY a JSON array of short search strings. "
+    'Example: ["GDP per capita", "life expectancy at birth", "school enrollment rate"]\n'
+    "Do not include any other text."
+)
+
+
+def _decompose_query(query: str) -> list[str]:
+    """Split a vague query into searchable sub-queries using rule-based heuristics.
+
+    Splits on conjunctions (and, or, &, commas, semicolons), removes stopwords,
+    and returns non-empty fragments. Falls back to the original query if
+    decomposition produces nothing useful.
+    """
+    # Split on conjunctions
+    fragments = _SPLIT_CONJUNCTIONS.split(query)
+    sub_queries: list[str] = []
+    for frag in fragments:
+        # Remove stopwords and clean up
+        words = [
+            w for w in frag.strip().split()
+            if w.lower() not in _STOPWORDS and len(w) > 1
+        ]
+        cleaned = " ".join(words).strip()
+        if cleaned and len(cleaned) > 2:
+            sub_queries.append(cleaned)
+
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    unique: list[str] = []
+    for sq in sub_queries:
+        key = sq.lower()
+        if key not in seen:
+            seen.add(key)
+            unique.append(sq)
+
+    # If decomposition produced nothing useful, use the original query
+    if not unique:
+        return [query.strip()]
+
+    # Cap at 5 sub-queries to bound search cost
+    return unique[:5]
+
+
+def _score_indicator(
+    indicator: "EnrichedIndicator",
+    query_tokens: set[str],
+) -> float:
+    """Score an indicator for relevance to the original query.
+
+    Scoring factors:
+    - Country coverage: +2 if covers_country is True
+    - Data recency: +1 if latest_data is within the last 3 years
+    - Token overlap: proportion of query tokens found in indicator name + definition
+    """
+    score = 0.0
+
+    # Country coverage
+    if indicator.covers_country:
+        score += 2.0
+
+    # Data recency
+    try:
+        from datetime import datetime
+        latest = int(indicator.latest_data or "0")
+        current_year = datetime.now().year
+        if latest >= current_year - 3:
+            score += 1.0
+        elif latest >= current_year - 10:
+            score += 0.5
+    except (ValueError, TypeError):
+        pass
+
+    # Token overlap between query and indicator name + definition
+    indicator_text = f"{indicator.name} {indicator.truncated_definition}".lower()
+    indicator_tokens = set(indicator_text.split())
+    if query_tokens:
+        overlap = len(query_tokens & indicator_tokens)
+        score += overlap / max(len(query_tokens), 1)
+
+    return score
+
+
+async def analyze_development_topic(
+    query: str,
+    country: str | None = None,
+    max_indicators: int = 4,
+    start_year: int | None = None,
+    end_year: int | None = None,
+    ctx: Context | None = None,
+) -> dict[str, Any]:
+    """Analyze a development topic by finding and fetching relevant indicators.
+
+    Use this tool when the user asks a broad or vague question about development
+    data that does not name a specific indicator — for example:
+    "What makes a country great?", "What are Ghana's economic challenges?",
+    "How is education performing in Sub-Saharan Africa?"
+
+    The tool decomposes the question into specific searchable topics (using the
+    connected LLM when sampling is available, or rule-based heuristics as
+    fallback), searches the Data360 catalog for each topic, scores and ranks
+    the results, and prefetches recent data for the top indicators.
+
+    Do NOT use this tool when the user already names a specific indicator or
+    metric (e.g. "GDP per capita for Kenya") — use data360_search_indicators
+    and data360_get_data directly instead.
+
+    Args:
+        query: The user's development-related question (can be vague/broad).
+        country: Optional country name or 3-letter code (e.g. "Ghana", "GHA").
+        max_indicators: Maximum number of indicators to return (default 4, max 6).
+        start_year: Optional start year for data snapshots. Defaults to last 5 years.
+        end_year: Optional end year for data snapshots. Defaults to current year.
+        ctx: MCP Context object (injected by FastMCP). Used for sampling when available.
+
+    Returns:
+        Dict with:
+            query: The original question.
+            country / country_code: Resolved country info (if provided).
+            sub_queries: The decomposed search terms (from LLM or rule-based).
+            decomposition_method: "sampling" or "rule_based".
+            selected_indicators: List of ranked indicator dicts, each with:
+                rank, indicator_id, database_id, name, definition, reason,
+                data_snapshot (list of recent data points), data_error (if fetch failed).
+            coverage_note: Summary of how many indicators were found.
+            error: Top-level error message if the entire operation failed.
+    """
+    import asyncio
+    from datetime import datetime
+
+    max_indicators = min(max_indicators, 6)
+    current_year = datetime.now().year
+    if end_year is None:
+        end_year = current_year
+    if start_year is None:
+        start_year = current_year - _DEFAULT_SUMMARY_YEARS + 1
+
+    # --- Step 1: Resolve country code ---
+    country_code = None
+    if country:
+        country_code = await _resolve_country_code(country)
+
+    # --- Step 2: Decompose query into sub-queries ---
+    sub_queries: list[str] = []
+    decomposition_method = "rule_based"
+    sampling_error = None
+
+    # Try sampling first (LLM-powered decomposition)
+    _logger.info(
+        "analyze_development_topic: ctx=%s, type=%s",
+        ctx is not None, type(ctx).__name__ if ctx is not None else "None",
+    )
+    if ctx is not None:
+        try:
+            sampling_result = await ctx.sample(
+                f"User question: {query}",
+                system_prompt=_SAMPLING_SYSTEM_PROMPT,
+                max_tokens=256,
+            )
+            # Parse the LLM response as a JSON array
+            raw_text = sampling_result.text or ""
+            # Strip markdown code fences if present
+            cleaned = raw_text.strip()
+            if cleaned.startswith("```"):
+                lines = cleaned.split("\n")
+                # Remove first and last lines (fences)
+                cleaned = "\n".join(lines[1:-1]).strip()
+            parsed = json.loads(cleaned)
+            if isinstance(parsed, list) and all(isinstance(s, str) for s in parsed):
+                sub_queries = [s.strip() for s in parsed if s.strip()][:5]
+                decomposition_method = "sampling"
+                _logger.info(
+                    "Sampling decomposition succeeded: %s", sub_queries
+                )
+        except (ValueError, json.JSONDecodeError) as e:
+            sampling_error = f"{type(e).__name__}: {e}"
+            _logger.warning(
+                "Sampling returned non-JSON response, falling back to rule-based: %s", e
+            )
+        except Exception as e:
+            sampling_error = f"{type(e).__name__}: {e}"
+            _logger.info(
+                "Sampling unavailable (client may not support it), "
+                "falling back to rule-based decomposition: %s (%s)",
+                type(e).__name__, e,
+            )
+
+    # Fall back to rule-based decomposition
+    if not sub_queries:
+        sub_queries = _decompose_query(query)
+        decomposition_method = "rule_based"
+
+    _logger.info(
+        "Analyzing topic with %d sub-queries (%s): %s",
+        len(sub_queries), decomposition_method, sub_queries,
+    )
+
+    # --- Step 3: Multi-search across sub-queries ---
+    search_tasks = [
+        search(
+            query=sq,
+            required_country=country_code or country,
+            limit=max_indicators,
+        )
+        for sq in sub_queries
+    ]
+    search_results = await asyncio.gather(*search_tasks, return_exceptions=True)
+
+    # Pool and deduplicate indicators by indicator ID
+    seen_ids: set[str] = set()
+    all_indicators: list[tuple[EnrichedIndicator, str]] = []  # (indicator, source_query)
+    total_candidates = 0
+
+    for sq, result in zip(sub_queries, search_results):
+        if isinstance(result, Exception):
+            _logger.warning("Search failed for sub-query '%s': %s", sq, result)
+            continue
+        if result.error:
+            _logger.warning("Search error for sub-query '%s': %s", sq, result.error)
+            continue
+        for ind in result.indicators:
+            total_candidates += 1
+            if ind.idno not in seen_ids:
+                seen_ids.add(ind.idno)
+                all_indicators.append((ind, sq))
+
+    if not all_indicators:
+        return {
+            "query": query,
+            "country": country,
+            "country_code": country_code,
+            "sub_queries": sub_queries,
+            "decomposition_method": decomposition_method,
+            "selected_indicators": [],
+            "coverage_note": f"No indicators found across {len(sub_queries)} sub-queries.",
+            "error": "No matching indicators found for this topic.",
+        }
+
+    # --- Step 4: Score and rank ---
+    query_tokens = {
+        w.lower() for w in query.split()
+        if w.lower() not in _STOPWORDS and len(w) > 1
+    }
+
+    scored: list[tuple[float, EnrichedIndicator, str]] = []
+    for ind, source_sq in all_indicators:
+        score = _score_indicator(ind, query_tokens)
+        scored.append((score, ind, source_sq))
+
+    # Sort descending by score
+    scored.sort(key=lambda x: x[0], reverse=True)
+    top = scored[:max_indicators]
+
+    # --- Step 5: Prefetch data for top indicators ---
+    async def _fetch_data_for_indicator(
+        ind: EnrichedIndicator,
+    ) -> dict[str, Any] | None:
+        """Fetch a small data snapshot for one indicator."""
+        try:
+            filters: dict[str, str | None] = {}
+            if country_code:
+                filters["REF_AREA"] = country_code
+
+            data_result = await get_data(
+                database_id=ind.database_id,
+                indicator_id=ind.idno,
+                disaggregation_filters=filters if filters else None,
+                start_year=start_year,
+                end_year=end_year,
+                limit=20,
+            )
+            if data_result.error:
+                return {"error": data_result.error}
+            return {
+                "data": data_result.data,
+                "metadata": data_result.metadata,
+                "count": data_result.count,
+            }
+        except Exception as e:
+            return {"error": str(e)}
+
+    data_tasks = [_fetch_data_for_indicator(ind) for _, ind, _ in top]
+    data_results = await asyncio.gather(*data_tasks, return_exceptions=True)
+
+    # --- Step 6: Build response ---
+    selected_indicators = []
+    for rank, ((score, ind, source_sq), data_res) in enumerate(
+        zip(top, data_results), start=1
+    ):
+        data_snapshot = None
+        data_error = None
+
+        if isinstance(data_res, Exception):
+            data_error = str(data_res)
+        elif data_res is not None and "error" in data_res:
+            data_error = data_res["error"]
+        elif data_res is not None:
+            data_snapshot = data_res
+
+        selected_indicators.append({
+            "rank": rank,
+            "indicator_id": ind.idno,
+            "database_id": ind.database_id,
+            "name": ind.name,
+            "definition": ind.truncated_definition,
+            "matched_sub_query": source_sq,
+            "score": round(score, 2),
+            "data_snapshot": data_snapshot,
+            "data_error": data_error,
+        })
+
+    result = {
+        "query": query,
+        "country": country,
+        "country_code": country_code,
+        "sub_queries": sub_queries,
+        "decomposition_method": decomposition_method,
+        "selected_indicators": selected_indicators,
+        "coverage_note": (
+            f"{len(selected_indicators)} indicators selected from "
+            f"{len(sub_queries)} sub-queries ({total_candidates} candidates)"
+        ),
+    }
+    if sampling_error:
+        result["sampling_error"] = sampling_error
+    return result
 
 
 # --- Visualization Workflow Tools ---

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -1494,7 +1494,6 @@ async def analyze_development_topic(
 
     # Build (indicator, source_query) tuples from grouped results
     all_indicators: list[tuple[EnrichedIndicator, str]] = []
-    total_candidates = 0
 
     if isinstance(multi_result, MultiQuerySearchResponse) and multi_result.results:
         for group in multi_result.results:
@@ -1504,10 +1503,14 @@ async def analyze_development_topic(
                 )
                 continue
             for ind in group.indicators:
-                total_candidates += 1
                 all_indicators.append((ind, group.query))
     elif multi_result.error:
         _logger.warning("Multi-query search failed: %s", multi_result.error)
+
+    # Use the authoritative raw candidate count from the search response
+    # (multi_result.total_candidates reflects pre-dedup numbers, which is
+    # a more honest figure for the coverage_note than counting deduplicated results).
+    total_candidates = getattr(multi_result, "total_candidates", len(all_indicators))
 
     if not all_indicators:
         return {

--- a/src/data360/mcp_server/_server_definition.py
+++ b/src/data360/mcp_server/_server_definition.py
@@ -1,4 +1,23 @@
+import os
+import dotenv
 from fastmcp import FastMCP
+from fastmcp.client.sampling.handlers.openai import OpenAISamplingHandler
+
+# Load .env so OPENAI_API_KEY is available
+dotenv.load_dotenv()
+
+# Only instantiate the OpenAI handler if an API key actually exists.
+# Otherwise, AsyncOpenAI() will immediately crash the server on startup.
+sampling_handler = None
+if os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY_MCP"):
+    try:
+        sampling_handler = OpenAISamplingHandler(default_model="gpt-4o-mini")
+    except Exception:
+        pass
 
 # NOTE: base definition to allow for mounting of resources, prompts, tools, independently
-mcp = FastMCP("Data360 MCP Server")
+mcp = FastMCP(
+    "Data360 MCP Server",
+    sampling_handler=sampling_handler,
+    sampling_handler_behavior="fallback",
+)

--- a/src/data360/mcp_server/tools.py
+++ b/src/data360/mcp_server/tools.py
@@ -77,14 +77,8 @@ analyze_development_topic = mcp.tool(
     description=data360_api.analyze_development_topic.__doc__,
 )
 
-# data360_generate_viz_gallery is gated behind an environment variable.
-# Set DATA360_ENABLE_GALLERY=true to register the tool (e.g. during local testing).
-# Do not set this flag in production deployments until the tool is production-ready.
-import os as _os  # noqa: E402
-
-if _os.environ.get("DATA360_ENABLE_GALLERY", "").lower() == "true":
-    generate_viz_gallery = mcp.tool(
-        data360_viz.generate_viz_gallery,
-        name="data360_generate_viz_gallery",
-        description=data360_viz.generate_viz_gallery.__doc__,
-    )
+generate_viz_gallery = mcp.tool(
+    data360_viz.generate_viz_gallery,
+    name="data360_generate_viz_gallery",
+    description=data360_viz.generate_viz_gallery.__doc__,
+)

--- a/src/data360/mcp_server/tools.py
+++ b/src/data360/mcp_server/tools.py
@@ -70,3 +70,9 @@ get_supported_chart_types = mcp.tool(
     name="data360_get_supported_chart_types",
     description=data360_viz.get_supported_chart_types.__doc__,
 )
+
+analyze_development_topic = mcp.tool(
+    data360_api.analyze_development_topic,
+    name="data360_analyze_development_topic",
+    description=data360_api.analyze_development_topic.__doc__,
+)

--- a/src/data360/mcp_server/tools.py
+++ b/src/data360/mcp_server/tools.py
@@ -76,3 +76,10 @@ analyze_development_topic = mcp.tool(
     name="data360_analyze_development_topic",
     description=data360_api.analyze_development_topic.__doc__,
 )
+
+# NOTE: Enabled for testing. Comment out before production deployment.
+generate_viz_gallery = mcp.tool(
+    data360_viz.generate_viz_gallery,
+    name="data360_generate_viz_gallery",
+    description=data360_viz.generate_viz_gallery.__doc__,
+)

--- a/src/data360/mcp_server/tools.py
+++ b/src/data360/mcp_server/tools.py
@@ -77,9 +77,14 @@ analyze_development_topic = mcp.tool(
     description=data360_api.analyze_development_topic.__doc__,
 )
 
-# NOTE: Enabled for testing. Comment out before production deployment.
-generate_viz_gallery = mcp.tool(
-    data360_viz.generate_viz_gallery,
-    name="data360_generate_viz_gallery",
-    description=data360_viz.generate_viz_gallery.__doc__,
-)
+# data360_generate_viz_gallery is gated behind an environment variable.
+# Set DATA360_ENABLE_GALLERY=true to register the tool (e.g. during local testing).
+# Do not set this flag in production deployments until the tool is production-ready.
+import os as _os  # noqa: E402
+
+if _os.environ.get("DATA360_ENABLE_GALLERY", "").lower() == "true":
+    generate_viz_gallery = mcp.tool(
+        data360_viz.generate_viz_gallery,
+        name="data360_generate_viz_gallery",
+        description=data360_viz.generate_viz_gallery.__doc__,
+    )

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -21,6 +21,7 @@ break JSON encoding.
 from __future__ import annotations
 
 import asyncio
+import itertools
 import json
 import logging
 import math
@@ -46,6 +47,10 @@ _FALLBACK_WARNING = (
     "Draco could not determine an optimal encoding; "
     "a default chart was generated as fallback."
 )
+
+# Maximum concurrent chart-generation calls inside generate_viz_gallery.
+# 6 indicators produce up to 21 chart tasks; this bounds API pressure.
+_MAX_CONCURRENT_GALLERY_CALLS = 5
 
 VizResult = dict[str, str | None]
 
@@ -970,8 +975,6 @@ async def generate_viz_gallery(
             failed_charts: Number of charts that failed.
             country_code: The country code used (if any).
     """
-    import asyncio
-    import itertools
 
     if not indicators:
         return {
@@ -991,7 +994,7 @@ async def generate_viz_gallery(
 
     # --- Single-indicator charts ---
     for ind in capped:
-        db_id = ind.get("database_id") or ind.get("database_id", "")
+        db_id = ind.get("database_id", "")
         ind_id = ind.get("indicator_id") or ind.get("idno", "")
         ind_name = ind.get("name", ind_id)
 
@@ -1033,7 +1036,7 @@ async def generate_viz_gallery(
         })
 
     total_charts = len(tasks_meta)
-    semaphore = asyncio.Semaphore(5)
+    semaphore = asyncio.Semaphore(_MAX_CONCURRENT_GALLERY_CALLS)
 
     async def _generate_one(meta: dict) -> dict:
         async with semaphore:
@@ -1047,9 +1050,9 @@ async def generate_viz_gallery(
                         end_year=end_year,
                         chart_type=meta.get("chart_type_hint"),
                     )
-                    chart_type_used = result.get("strategy") or (
-                        chart_types[0] if chart_types else "line"
-                    )
+                    # Use the strategy returned by the viz tool. Fall back to hint
+                    # or "line" only when strategy is absent (not merely empty).
+                    chart_type_used = result.get("strategy") or meta.get("chart_type_hint") or "line"
                 else:
                     result = await get_multi_indicator_viz_spec(
                         indicator_ids=meta["indicator_ids"],

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -931,3 +931,191 @@ async def get_multi_indicator_viz_spec(
     result["strategy"] = strategy_result.strategy.value
     result["reason"] = strategy_result.reason
     return result
+
+
+async def generate_viz_gallery(
+    indicators: list[dict],
+    country_code: str | None = None,
+    start_year: int | None = None,
+    end_year: int | None = None,
+    chart_types: list[str] | None = None,
+) -> dict:
+    """Generate a gallery of charts for a set of indicators — singles and all pairwise combos.
+
+    Use this tool after data360_analyze_development_topic to batch-generate all useful
+    chart combinations from its selected_indicators output. The LLM then filters this
+    gallery and narrates the most relevant charts for the user's question.
+
+    Do NOT use this tool to generate a chart for a single known indicator — use
+    data360_get_viz_spec for that. This tool is specifically for exploring relationships
+    across a set of thematically related indicators.
+
+    Args:
+        indicators: List of indicator dicts, each with at minimum "database_id" and
+            "indicator_id". Typically pass the selected_indicators list from
+            data360_analyze_development_topic directly. Min 1, max 6.
+        country_code: Optional 3-letter code or comma-separated codes (e.g. "GHA" or "GHA,NGA").
+        start_year: Optional start year (inclusive). Defaults to last 5 years.
+        end_year: Optional end year (inclusive). Defaults to current year.
+        chart_types: Optional list to restrict chart types generated
+            (e.g. ["line", "scatter"]). If None, all applicable types are generated.
+
+    Returns:
+        Dict with:
+            gallery: List of chart dicts, each with chart_url, chart_type, indicators
+                (list of indicator names), indicator_ids (list of dicts with database_id
+                and indicator_id), description, and optionally error.
+            total_charts: Total number of chart slots attempted.
+            successful_charts: Number of charts successfully generated.
+            failed_charts: Number of charts that failed.
+            country_code: The country code used (if any).
+    """
+    import asyncio
+    import itertools
+
+    if not indicators:
+        return {
+            "gallery": [],
+            "total_charts": 0,
+            "successful_charts": 0,
+            "failed_charts": 0,
+            "country_code": country_code,
+            "error": "No indicators provided.",
+        }
+
+    # Cap at 6 to keep combinations manageable (6 singles + 15 pairs = 21 max)
+    capped = indicators[:6]
+
+    # Build chart tasks: (label, coroutine_factory)
+    tasks_meta: list[dict] = []
+
+    # --- Single-indicator charts ---
+    for ind in capped:
+        db_id = ind.get("database_id") or ind.get("database_id", "")
+        ind_id = ind.get("indicator_id") or ind.get("idno", "")
+        ind_name = ind.get("name", ind_id)
+
+        if not db_id or not ind_id:
+            continue
+
+        chart_type_hint = (chart_types[0] if chart_types and len(chart_types) == 1 else None)
+
+        tasks_meta.append({
+            "kind": "single",
+            "indicator_ids": [{"database_id": db_id, "indicator_id": ind_id}],
+            "indicator_names": [ind_name],
+            "db_id": db_id,
+            "ind_id": ind_id,
+            "chart_type_hint": chart_type_hint,
+        })
+
+    # --- Pairwise multi-indicator charts ---
+    for ind_a, ind_b in itertools.combinations(capped, 2):
+        db_a = ind_a.get("database_id", "")
+        id_a = ind_a.get("indicator_id") or ind_a.get("idno", "")
+        name_a = ind_a.get("name", id_a)
+
+        db_b = ind_b.get("database_id", "")
+        id_b = ind_b.get("indicator_id") or ind_b.get("idno", "")
+        name_b = ind_b.get("name", id_b)
+
+        if not (db_a and id_a and db_b and id_b):
+            continue
+
+        tasks_meta.append({
+            "kind": "pair",
+            "indicator_ids": [
+                {"database_id": db_a, "indicator_id": id_a},
+                {"database_id": db_b, "indicator_id": id_b},
+            ],
+            "indicator_names": [name_a, name_b],
+            "chart_type_hint": None,
+        })
+
+    total_charts = len(tasks_meta)
+    semaphore = asyncio.Semaphore(5)
+
+    async def _generate_one(meta: dict) -> dict:
+        async with semaphore:
+            try:
+                if meta["kind"] == "single":
+                    result = await get_viz_spec(
+                        database_id=meta["db_id"],
+                        indicator_id=meta["ind_id"],
+                        country_code=country_code,
+                        start_year=start_year,
+                        end_year=end_year,
+                        chart_type=meta.get("chart_type_hint"),
+                    )
+                    chart_type_used = result.get("strategy") or (
+                        chart_types[0] if chart_types else "line"
+                    )
+                else:
+                    result = await get_multi_indicator_viz_spec(
+                        indicator_ids=meta["indicator_ids"],
+                        country_code=country_code,
+                        start_year=start_year,
+                        end_year=end_year,
+                        chart_type=meta.get("chart_type_hint"),
+                    )
+                    chart_type_used = result.get("strategy", "scatter")
+
+                if result.get("error"):
+                    return {
+                        "chart_url": None,
+                        "chart_type": None,
+                        "indicators": meta["indicator_names"],
+                        "indicator_ids": meta["indicator_ids"],
+                        "description": _gallery_description(
+                            meta["indicator_names"], country_code, chart_type_used
+                        ),
+                        "error": result["error"],
+                    }
+
+                return {
+                    "chart_url": result.get("url"),
+                    "chart_type": chart_type_used,
+                    "indicators": meta["indicator_names"],
+                    "indicator_ids": meta["indicator_ids"],
+                    "description": _gallery_description(
+                        meta["indicator_names"], country_code, chart_type_used
+                    ),
+                }
+
+            except Exception as e:
+                return {
+                    "chart_url": None,
+                    "chart_type": None,
+                    "indicators": meta["indicator_names"],
+                    "indicator_ids": meta["indicator_ids"],
+                    "description": _gallery_description(
+                        meta["indicator_names"], country_code, None
+                    ),
+                    "error": str(e),
+                }
+
+    chart_results = await asyncio.gather(*[_generate_one(m) for m in tasks_meta])
+
+    successful = sum(1 for c in chart_results if c.get("chart_url") and not c.get("error"))
+    failed = total_charts - successful
+
+    return {
+        "gallery": list(chart_results),
+        "total_charts": total_charts,
+        "successful_charts": successful,
+        "failed_charts": failed,
+        "country_code": country_code,
+    }
+
+
+def _gallery_description(
+    indicator_names: list[str],
+    country_code: str | None,
+    chart_type: str | None,
+) -> str:
+    """Build a human-readable description for a gallery chart entry."""
+    country_str = f" for {country_code}" if country_code else ""
+    chart_str = f" ({chart_type})" if chart_type else ""
+    if len(indicator_names) == 1:
+        return f"{indicator_names[0]}{country_str}{chart_str}"
+    return f"{' vs '.join(indicator_names)}{country_str}{chart_str}"

--- a/tests/test_analyze_topic.py
+++ b/tests/test_analyze_topic.py
@@ -1,0 +1,359 @@
+"""Tests for analyze_development_topic tool."""
+
+import json
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from data360.api import (
+    _decompose_query,
+    _score_indicator,
+    analyze_development_topic,
+)
+from data360.models import EnrichedIndicator, EnrichedSearchResponse
+
+
+# --- Helpers ---
+
+
+def _make_indicator(
+    idno: str = "WB_WDI_NY_GDP_PCAP_KD",
+    name: str = "GDP per capita (constant 2015 US$)",
+    database_id: str = "WB_WDI",
+    definition: str = "GDP per capita is gross domestic product divided by mid-year population",
+    covers_country: bool = True,
+    latest_data: str = "2023",
+) -> EnrichedIndicator:
+    return EnrichedIndicator(
+        idno=idno,
+        database_id=database_id,
+        name=name,
+        truncated_definition=definition[:100],
+        covers_country=covers_country,
+        latest_data=latest_data,
+    )
+
+
+def _make_search_response(
+    indicators: list[EnrichedIndicator] | None = None,
+    error: str | None = None,
+) -> EnrichedSearchResponse:
+    return EnrichedSearchResponse(
+        indicators=indicators or [],
+        error=error,
+        count=len(indicators or []),
+    )
+
+
+@dataclass
+class FakeSamplingResult:
+    text: str | None
+    model: str = "fake-model"
+
+
+class FakeContext:
+    """Fake MCP Context that simulates sampling."""
+
+    def __init__(self, response_text: str | None = None, should_raise: bool = False):
+        self._response_text = response_text
+        self._should_raise = should_raise
+
+    async def sample(self, messages, **kwargs) -> FakeSamplingResult:
+        if self._should_raise:
+            raise ValueError("Client does not support sampling")
+        return FakeSamplingResult(text=self._response_text)
+
+
+# --- Unit tests for _decompose_query ---
+
+
+class TestDecomposeQuery:
+    """Tests for rule-based query decomposition."""
+
+    def test_splits_on_and(self):
+        result = _decompose_query("economic growth and public spending")
+        assert len(result) == 2
+        assert any("economic" in sq.lower() or "growth" in sq.lower() for sq in result)
+        assert any("public" in sq.lower() or "spending" in sq.lower() for sq in result)
+
+    def test_splits_on_comma(self):
+        result = _decompose_query("GDP, poverty, education")
+        assert len(result) == 3
+
+    def test_splits_on_semicolon(self):
+        result = _decompose_query("health outcomes; education access")
+        assert len(result) == 2
+
+    def test_removes_stopwords(self):
+        result = _decompose_query("What are the main challenges facing economic growth")
+        # Should have cleaned fragments, not contain stopwords as standalone terms
+        for sq in result:
+            words = sq.lower().split()
+            # At least the meaningful words should remain
+            assert not all(w in {"what", "are", "the", "main"} for w in words)
+
+    def test_falls_back_to_original_on_single_topic(self):
+        result = _decompose_query("GDP per capita")
+        assert len(result) == 1
+        assert "GDP" in result[0]
+
+    def test_handles_empty_fragments(self):
+        result = _decompose_query("and or and")
+        # All fragments are stopwords, should fall back to original
+        assert len(result) >= 1
+
+    def test_deduplicates(self):
+        result = _decompose_query("growth and growth and growth")
+        # All fragments are the same word, should deduplicate to 1
+        assert len(result) == 1
+
+    def test_caps_at_five(self):
+        result = _decompose_query("a, b, c, d, e, f, g, h")
+        assert len(result) <= 5
+
+
+# --- Unit tests for _score_indicator ---
+
+
+class TestScoreIndicator:
+    """Tests for indicator scoring function."""
+
+    def test_country_coverage_bonus(self):
+        ind_covered = _make_indicator(covers_country=True)
+        ind_not_covered = _make_indicator(covers_country=False)
+        tokens = {"gdp", "growth"}
+
+        score_covered = _score_indicator(ind_covered, tokens)
+        score_not = _score_indicator(ind_not_covered, tokens)
+
+        assert score_covered > score_not
+
+    def test_recency_bonus(self):
+        ind_recent = _make_indicator(latest_data="2025")
+        ind_old = _make_indicator(latest_data="2005")
+        tokens = {"gdp"}
+
+        score_recent = _score_indicator(ind_recent, tokens)
+        score_old = _score_indicator(ind_old, tokens)
+
+        assert score_recent > score_old
+
+    def test_token_overlap(self):
+        ind = _make_indicator(
+            name="GDP per capita growth",
+            definition="Economic growth rate",
+        )
+        high_overlap_tokens = {"gdp", "growth", "economic"}
+        no_overlap_tokens = {"education", "literacy", "enrollment"}
+
+        score_high = _score_indicator(ind, high_overlap_tokens)
+        score_none = _score_indicator(ind, no_overlap_tokens)
+
+        assert score_high > score_none
+
+
+# --- Integration tests for analyze_development_topic ---
+
+
+class TestAnalyzeDevelopmentTopic:
+    """Tests for the main analyze_development_topic function."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_with_sampling(self):
+        """Sampling succeeds and returns LLM-generated sub-queries."""
+        indicators = [
+            _make_indicator(
+                idno="WB_WDI_NY_GDP_PCAP_KD",
+                name="GDP per capita",
+            ),
+            _make_indicator(
+                idno="WB_WDI_SP_DYN_LE00_IN",
+                name="Life expectancy at birth",
+            ),
+        ]
+        mock_search_response = _make_search_response(indicators)
+
+        ctx = FakeContext(
+            response_text=json.dumps(["GDP per capita", "life expectancy"])
+        )
+
+        mock_data_response = AsyncMock()
+        mock_data_response.return_value.data = [
+            {"OBS_VALUE": 1500, "TIME_PERIOD": "2023", "REF_AREA": "GHA"}
+        ]
+        mock_data_response.return_value.error = None
+        mock_data_response.return_value.metadata = {"name": "GDP per capita"}
+        mock_data_response.return_value.count = 1
+
+        with (
+            patch("data360.api.search", return_value=mock_search_response) as mock_search,
+            patch("data360.api.get_data", mock_data_response),
+            patch("data360.api._resolve_country_code", return_value="GHA"),
+        ):
+            result = await analyze_development_topic(
+                query="What makes a country great?",
+                country="Ghana",
+                ctx=ctx,
+            )
+
+        assert result["decomposition_method"] == "sampling"
+        assert len(result["sub_queries"]) == 2
+        assert result["country_code"] == "GHA"
+        assert len(result["selected_indicators"]) > 0
+        assert "error" not in result or result.get("error") is None
+
+    @pytest.mark.asyncio
+    async def test_sampling_fallback(self):
+        """When sampling raises, falls back to rule-based decomposition."""
+        indicators = [
+            _make_indicator(
+                idno="WB_WDI_NY_GDP_PCAP_KD",
+                name="GDP per capita",
+            ),
+        ]
+        mock_search_response = _make_search_response(indicators)
+
+        ctx = FakeContext(should_raise=True)
+
+        mock_data_response = AsyncMock()
+        mock_data_response.return_value.data = []
+        mock_data_response.return_value.error = None
+        mock_data_response.return_value.metadata = {}
+        mock_data_response.return_value.count = 0
+
+        with (
+            patch("data360.api.search", return_value=mock_search_response),
+            patch("data360.api.get_data", mock_data_response),
+        ):
+            result = await analyze_development_topic(
+                query="economic growth and public spending",
+                ctx=ctx,
+            )
+
+        assert result["decomposition_method"] == "rule_based"
+        assert len(result["sub_queries"]) >= 2
+        # Should not crash — graceful fallback
+        assert "error" not in result or result.get("error") is None
+
+    @pytest.mark.asyncio
+    async def test_no_ctx_uses_rule_based(self):
+        """When ctx is None (no MCP context), uses rule-based decomposition."""
+        indicators = [
+            _make_indicator(idno="WB_WDI_NY_GDP_PCAP_KD", name="GDP per capita"),
+        ]
+        mock_search_response = _make_search_response(indicators)
+
+        mock_data_response = AsyncMock()
+        mock_data_response.return_value.data = []
+        mock_data_response.return_value.error = None
+        mock_data_response.return_value.metadata = {}
+        mock_data_response.return_value.count = 0
+
+        with (
+            patch("data360.api.search", return_value=mock_search_response),
+            patch("data360.api.get_data", mock_data_response),
+        ):
+            result = await analyze_development_topic(
+                query="economic growth and education",
+                ctx=None,
+            )
+
+        assert result["decomposition_method"] == "rule_based"
+        assert len(result["sub_queries"]) >= 2
+
+    @pytest.mark.asyncio
+    async def test_empty_search_results(self):
+        """When all searches return no indicators, returns error."""
+        empty_response = _make_search_response(indicators=[])
+
+        with patch("data360.api.search", return_value=empty_response):
+            result = await analyze_development_topic(
+                query="nonexistent topic xyzzy",
+            )
+
+        assert result["selected_indicators"] == []
+        assert result["error"] is not None
+        assert "No matching" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_data_fetch_failure(self):
+        """Data fetch failures are reported per-indicator, do not crash the tool."""
+        indicators = [
+            _make_indicator(idno="WB_WDI_NY_GDP_PCAP_KD", name="GDP per capita"),
+        ]
+        mock_search_response = _make_search_response(indicators)
+
+        mock_data_response = AsyncMock()
+        mock_data_response.return_value.data = None
+        mock_data_response.return_value.error = "HTTP error 500: Internal Server Error"
+        mock_data_response.return_value.metadata = None
+        mock_data_response.return_value.count = 0
+
+        with (
+            patch("data360.api.search", return_value=mock_search_response),
+            patch("data360.api.get_data", mock_data_response),
+        ):
+            result = await analyze_development_topic(
+                query="GDP growth",
+            )
+
+        # Should have an indicator entry but with data_error set
+        assert len(result["selected_indicators"]) == 1
+        assert result["selected_indicators"][0]["data_error"] is not None
+        assert result["selected_indicators"][0]["data_snapshot"] is None
+
+    @pytest.mark.asyncio
+    async def test_max_indicators_capped(self):
+        """max_indicators is respected and capped at 6."""
+        indicators = [
+            _make_indicator(idno=f"WB_WDI_IND_{i}", name=f"Indicator {i}")
+            for i in range(10)
+        ]
+        mock_search_response = _make_search_response(indicators)
+
+        mock_data_response = AsyncMock()
+        mock_data_response.return_value.data = []
+        mock_data_response.return_value.error = None
+        mock_data_response.return_value.metadata = {}
+        mock_data_response.return_value.count = 0
+
+        with (
+            patch("data360.api.search", return_value=mock_search_response),
+            patch("data360.api.get_data", mock_data_response),
+        ):
+            result = await analyze_development_topic(
+                query="everything about development",
+                max_indicators=2,
+            )
+
+        assert len(result["selected_indicators"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_sampling_returns_invalid_json(self):
+        """When sampling returns non-JSON, gracefully falls back to rule-based."""
+        indicators = [
+            _make_indicator(idno="WB_WDI_NY_GDP_PCAP_KD", name="GDP per capita"),
+        ]
+        mock_search_response = _make_search_response(indicators)
+
+        ctx = FakeContext(response_text="This is not JSON at all")
+
+        mock_data_response = AsyncMock()
+        mock_data_response.return_value.data = []
+        mock_data_response.return_value.error = None
+        mock_data_response.return_value.metadata = {}
+        mock_data_response.return_value.count = 0
+
+        with (
+            patch("data360.api.search", return_value=mock_search_response),
+            patch("data360.api.get_data", mock_data_response),
+        ):
+            result = await analyze_development_topic(
+                query="economic growth and trade",
+                ctx=ctx,
+            )
+
+        assert result["decomposition_method"] == "rule_based"
+        assert len(result["sub_queries"]) >= 2

--- a/tests/test_analyze_topic.py
+++ b/tests/test_analyze_topic.py
@@ -12,7 +12,11 @@ from data360.api import (
     _score_indicator,
     analyze_development_topic,
 )
-from data360.models import EnrichedIndicator, EnrichedSearchResponse
+from data360.models import (
+    EnrichedIndicator,
+    MultiQuerySearchResponse,
+    QueryGroupResult,
+)
 
 
 # --- Helpers ---
@@ -39,11 +43,17 @@ def _make_indicator(
 def _make_search_response(
     indicators: list[EnrichedIndicator] | None = None,
     error: str | None = None,
-) -> EnrichedSearchResponse:
-    return EnrichedSearchResponse(
-        indicators=indicators or [],
-        error=error,
-        count=len(indicators or []),
+    query: str = "test query",
+) -> MultiQuerySearchResponse:
+    """Build a MultiQuerySearchResponse with by_query layout for mocking search()."""
+    inds = indicators or []
+    group = QueryGroupResult(query=query, indicators=inds, count=len(inds), error=error)
+    return MultiQuerySearchResponse(
+        results=[group],
+        result_layout="by_query",
+        queries=[query],
+        total_candidates=len(inds),
+        error=None if inds else error,
     )
 
 
@@ -188,7 +198,7 @@ class TestAnalyzeDevelopmentTopic:
         mock_data_response.return_value.count = 1
 
         with (
-            patch("data360.api.search", return_value=mock_search_response) as mock_search,
+            patch("data360.api.search", new=AsyncMock(return_value=mock_search_response)) as mock_search,
             patch("data360.api.get_data", mock_data_response),
             patch("data360.api._resolve_country_code", return_value="GHA"),
         ):
@@ -224,7 +234,7 @@ class TestAnalyzeDevelopmentTopic:
         mock_data_response.return_value.count = 0
 
         with (
-            patch("data360.api.search", return_value=mock_search_response),
+            patch("data360.api.search", new=AsyncMock(return_value=mock_search_response)),
             patch("data360.api.get_data", mock_data_response),
         ):
             result = await analyze_development_topic(
@@ -252,7 +262,7 @@ class TestAnalyzeDevelopmentTopic:
         mock_data_response.return_value.count = 0
 
         with (
-            patch("data360.api.search", return_value=mock_search_response),
+            patch("data360.api.search", new=AsyncMock(return_value=mock_search_response)),
             patch("data360.api.get_data", mock_data_response),
         ):
             result = await analyze_development_topic(
@@ -268,7 +278,7 @@ class TestAnalyzeDevelopmentTopic:
         """When all searches return no indicators, returns error."""
         empty_response = _make_search_response(indicators=[])
 
-        with patch("data360.api.search", return_value=empty_response):
+        with patch("data360.api.search", new=AsyncMock(return_value=empty_response)):
             result = await analyze_development_topic(
                 query="nonexistent topic xyzzy",
             )
@@ -292,7 +302,7 @@ class TestAnalyzeDevelopmentTopic:
         mock_data_response.return_value.count = 0
 
         with (
-            patch("data360.api.search", return_value=mock_search_response),
+            patch("data360.api.search", new=AsyncMock(return_value=mock_search_response)),
             patch("data360.api.get_data", mock_data_response),
         ):
             result = await analyze_development_topic(
@@ -320,7 +330,7 @@ class TestAnalyzeDevelopmentTopic:
         mock_data_response.return_value.count = 0
 
         with (
-            patch("data360.api.search", return_value=mock_search_response),
+            patch("data360.api.search", new=AsyncMock(return_value=mock_search_response)),
             patch("data360.api.get_data", mock_data_response),
         ):
             result = await analyze_development_topic(
@@ -347,7 +357,7 @@ class TestAnalyzeDevelopmentTopic:
         mock_data_response.return_value.count = 0
 
         with (
-            patch("data360.api.search", return_value=mock_search_response),
+            patch("data360.api.search", new=AsyncMock(return_value=mock_search_response)),
             patch("data360.api.get_data", mock_data_response),
         ):
             result = await analyze_development_topic(

--- a/tests/test_analyze_topic.py
+++ b/tests/test_analyze_topic.py
@@ -367,3 +367,126 @@ class TestAnalyzeDevelopmentTopic:
 
         assert result["decomposition_method"] == "rule_based"
         assert len(result["sub_queries"]) >= 2
+
+    @pytest.mark.asyncio
+    async def test_multi_country_sampling_returns_grouped(self):
+        """Sampling returns grouped structure for multi-country question."""
+        indicators = [
+            _make_indicator(idno="WB_WDI_1", name="Indicator 1")
+        ]
+        mock_search_response = _make_search_response(indicators)
+
+        ctx = FakeContext(
+            response_text=json.dumps([
+                {"queries": ["unemployment"], "country": "Morocco"},
+                {"queries": ["manufacturing"], "country": "Ethiopia"}
+            ])
+        )
+        mock_data_response = AsyncMock()
+        mock_data_response.return_value.data = []
+        mock_data_response.return_value.error = None
+        mock_data_response.return_value.count = 0
+
+        with (
+            patch("data360.api.search", new=AsyncMock(return_value=mock_search_response)) as mock_search,
+            patch("data360.api._resolve_country_code", return_value="MAR,ETH"),
+            patch("data360.api.get_data", mock_data_response),
+        ):
+            result = await analyze_development_topic(
+                query="Labor market Morocco vs manufacturing Ethiopia",
+                country="Morocco, Ethiopia",
+                ctx=ctx,
+            )
+
+        assert result["decomposition_method"] == "sampling"
+        assert result["country_code"] == "MAR,ETH"
+
+        # Verify search was called with query_groups properly scoped per country
+        mock_search.assert_called_once()
+        call_kwargs = mock_search.call_args.kwargs
+        assert "query_groups" in call_kwargs
+
+        groups = call_kwargs["query_groups"]
+        assert len(groups) == 2
+        assert groups[0].country == "Morocco"
+        assert groups[0].queries == ["unemployment"]
+        assert groups[1].country == "Ethiopia"
+        assert groups[1].queries == ["manufacturing"]
+
+    @pytest.mark.asyncio
+    async def test_multi_country_fallback_uses_cross_product(self):
+        """No sampling or invalid sampling with multi-country falls back to cross-product search."""
+        indicators = [
+            _make_indicator(idno="WB_WDI_1", name="Indicator 1")
+        ]
+        mock_search_response = _make_search_response(indicators)
+
+        mock_data_response = AsyncMock()
+        mock_data_response.return_value.data = []
+        mock_data_response.return_value.error = None
+        mock_data_response.return_value.count = 0
+
+        with (
+            patch("data360.api.search", new=AsyncMock(return_value=mock_search_response)) as mock_search,
+            patch("data360.api._resolve_country_code", return_value="MAR,ETH"),
+            patch("data360.api.get_data", mock_data_response),
+        ):
+            result = await analyze_development_topic(
+                # Use query that rule_based will split cleanly
+                query="labor market and manufacturing",
+                country="Morocco, Ethiopia",
+            )
+
+        assert result["decomposition_method"] == "rule_based"
+        assert result["country_code"] == "MAR,ETH"
+
+        # Verify search was called with query_groups configured for cross product
+        mock_search.assert_called_once()
+        call_kwargs = mock_search.call_args.kwargs
+        assert "query_groups" in call_kwargs
+
+        groups = call_kwargs["query_groups"]
+        assert len(groups) == 2
+        # MAR and ETH each get the SAME sub_queries (cross product)
+        assert groups[0].country == "MAR"
+        assert len(groups[0].queries) >= 2
+        assert groups[1].country == "ETH"
+        assert len(groups[1].queries) >= 2
+        assert groups[0].queries == groups[1].queries
+
+    @pytest.mark.asyncio
+    async def test_single_country_preserves_existing_behavior(self):
+        """Single country should still use `queries` param instead of `query_groups`."""
+        indicators = [
+            _make_indicator(idno="WB_WDI_1", name="Indicator 1")
+        ]
+        mock_search_response = _make_search_response(indicators)
+
+        ctx = FakeContext(
+            response_text=json.dumps(["GDP per capita", "inflation"])
+        )
+
+        mock_data_response = AsyncMock()
+        mock_data_response.return_value.data = []
+        mock_data_response.return_value.error = None
+        mock_data_response.return_value.count = 0
+
+        with (
+            patch("data360.api.search", new=AsyncMock(return_value=mock_search_response)) as mock_search,
+            patch("data360.api._resolve_country_code", return_value="GHA"),
+            patch("data360.api.get_data", mock_data_response),
+        ):
+            result = await analyze_development_topic(
+                query="Ghana economic status",
+                country="Ghana",
+                ctx=ctx,
+            )
+
+        assert result["decomposition_method"] == "sampling"
+
+        # Verify search was called with queries and required_country
+        mock_search.assert_called_once()
+        call_kwargs = mock_search.call_args.kwargs
+        assert "queries" in call_kwargs
+        assert call_kwargs["required_country"] == "GHA"
+        assert "query_groups" not in call_kwargs

--- a/tests/test_viz_gallery.py
+++ b/tests/test_viz_gallery.py
@@ -1,0 +1,244 @@
+"""Tests for generate_viz_gallery and matched_sub_queries enrichment."""
+
+from itertools import combinations
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from data360.visualization import generate_viz_gallery
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_indicator(
+    indicator_id: str = "WB_WDI_NY_GDP_PCAP_KD",
+    database_id: str = "WB_WDI",
+    name: str = "GDP per capita",
+) -> dict:
+    return {
+        "indicator_id": indicator_id,
+        "database_id": database_id,
+        "name": name,
+    }
+
+
+def _ok_result(url: str = "http://localhost/chart.json", strategy: str = "line") -> dict:
+    return {"url": url, "error": None, "strategy": strategy}
+
+
+def _err_result(msg: str = "No data") -> dict:
+    return {"url": None, "error": msg}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateVizGallery:
+    @pytest.mark.asyncio
+    async def test_empty_indicators_returns_error(self):
+        result = await generate_viz_gallery(indicators=[])
+        assert result["total_charts"] == 0
+        assert result["error"] is not None
+
+    @pytest.mark.asyncio
+    async def test_single_indicator_generates_one_chart(self):
+        inds = [_make_indicator()]
+        with (
+            patch(
+                "data360.visualization.get_viz_spec",
+                new=AsyncMock(return_value=_ok_result()),
+            ),
+            patch(
+                "data360.visualization.get_multi_indicator_viz_spec",
+                new=AsyncMock(return_value=_ok_result()),
+            ),
+        ):
+            result = await generate_viz_gallery(indicators=inds)
+
+        # 1 single, 0 pairs
+        assert result["total_charts"] == 1
+        assert result["successful_charts"] == 1
+        assert result["failed_charts"] == 0
+        assert len(result["gallery"]) == 1
+        assert result["gallery"][0]["chart_url"] is not None
+
+    @pytest.mark.asyncio
+    async def test_two_indicators_generates_three_charts(self):
+        inds = [_make_indicator("IND_A", name="Indicator A"), _make_indicator("IND_B", name="Indicator B")]
+        with (
+            patch(
+                "data360.visualization.get_viz_spec",
+                new=AsyncMock(return_value=_ok_result()),
+            ),
+            patch(
+                "data360.visualization.get_multi_indicator_viz_spec",
+                new=AsyncMock(return_value=_ok_result(strategy="scatter")),
+            ),
+        ):
+            result = await generate_viz_gallery(indicators=inds)
+
+        # 2 singles + 1 pair = 3
+        assert result["total_charts"] == 3
+        assert result["successful_charts"] == 3
+        pair_entries = [c for c in result["gallery"] if len(c["indicators"]) == 2]
+        assert len(pair_entries) == 1
+        assert pair_entries[0]["chart_type"] == "scatter"
+
+    @pytest.mark.asyncio
+    async def test_four_indicators_generates_ten_charts(self):
+        n = 4
+        inds = [_make_indicator(f"IND_{i}", name=f"Indicator {i}") for i in range(n)]
+
+        with (
+            patch(
+                "data360.visualization.get_viz_spec",
+                new=AsyncMock(return_value=_ok_result()),
+            ),
+            patch(
+                "data360.visualization.get_multi_indicator_viz_spec",
+                new=AsyncMock(return_value=_ok_result(strategy="layered_lines")),
+            ),
+        ):
+            result = await generate_viz_gallery(indicators=inds)
+
+        # n singles + C(n,2) pairs = 4 + 6 = 10
+        expected = n + len(list(combinations(range(n), 2)))
+        assert result["total_charts"] == expected
+        assert len(result["gallery"]) == expected
+
+    @pytest.mark.asyncio
+    async def test_six_indicators_generates_twenty_one_charts(self):
+        n = 6
+        inds = [_make_indicator(f"IND_{i}", name=f"Indicator {i}") for i in range(n)]
+
+        with (
+            patch(
+                "data360.visualization.get_viz_spec",
+                new=AsyncMock(return_value=_ok_result()),
+            ),
+            patch(
+                "data360.visualization.get_multi_indicator_viz_spec",
+                new=AsyncMock(return_value=_ok_result(strategy="scatter")),
+            ),
+        ):
+            result = await generate_viz_gallery(indicators=inds)
+
+        # 6 singles + C(6,2)=15 pairs = 21
+        assert result["total_charts"] == 21
+
+    @pytest.mark.asyncio
+    async def test_indicators_capped_at_six(self):
+        inds = [_make_indicator(f"IND_{i}", name=f"Indicator {i}") for i in range(9)]
+
+        with (
+            patch(
+                "data360.visualization.get_viz_spec",
+                new=AsyncMock(return_value=_ok_result()),
+            ),
+            patch(
+                "data360.visualization.get_multi_indicator_viz_spec",
+                new=AsyncMock(return_value=_ok_result()),
+            ),
+        ):
+            result = await generate_viz_gallery(indicators=inds)
+
+        # Capped to 6: 6 + 15 = 21
+        assert result["total_charts"] == 21
+
+    @pytest.mark.asyncio
+    async def test_failed_single_does_not_crash_gallery(self):
+        inds = [
+            _make_indicator("IND_A", name="Indicator A"),
+            _make_indicator("IND_B", name="Indicator B"),
+        ]
+
+        async def _side_effect_single(*, indicator_id, **kwargs):
+            if indicator_id == "IND_A":
+                return _err_result("API error for IND_A")
+            return _ok_result()
+
+        with (
+            patch(
+                "data360.visualization.get_viz_spec",
+                new=AsyncMock(side_effect=_side_effect_single),
+            ),
+            patch(
+                "data360.visualization.get_multi_indicator_viz_spec",
+                new=AsyncMock(return_value=_ok_result()),
+            ),
+        ):
+            result = await generate_viz_gallery(indicators=inds)
+
+        # 2 singles + 1 pair = 3; IND_A single fails, others succeed
+        assert result["total_charts"] == 3
+        assert result["failed_charts"] == 1
+        assert result["successful_charts"] == 2
+        failed_entries = [c for c in result["gallery"] if c.get("error")]
+        assert len(failed_entries) == 1
+        assert "IND_A" in failed_entries[0]["error"] or "Indicator A" in failed_entries[0]["indicators"]
+
+    @pytest.mark.asyncio
+    async def test_failed_pair_does_not_crash_gallery(self):
+        inds = [
+            _make_indicator("IND_A", name="A"),
+            _make_indicator("IND_B", name="B"),
+        ]
+
+        with (
+            patch(
+                "data360.visualization.get_viz_spec",
+                new=AsyncMock(return_value=_ok_result()),
+            ),
+            patch(
+                "data360.visualization.get_multi_indicator_viz_spec",
+                new=AsyncMock(return_value=_err_result("No overlapping data")),
+            ),
+        ):
+            result = await generate_viz_gallery(indicators=inds)
+
+        # pair fails (error in result), singles succeed
+        assert result["total_charts"] == 3
+        pair_entries = [c for c in result["gallery"] if len(c["indicators"]) == 2]
+        assert pair_entries[0].get("error") == "No overlapping data"
+
+    @pytest.mark.asyncio
+    async def test_country_code_passed_to_charts(self):
+        inds = [_make_indicator()]
+        mock_single = AsyncMock(return_value=_ok_result())
+
+        with patch("data360.visualization.get_viz_spec", new=mock_single):
+            await generate_viz_gallery(indicators=inds, country_code="GHA")
+
+        mock_single.assert_awaited_once()
+        call_kwargs = mock_single.call_args.kwargs
+        assert call_kwargs.get("country_code") == "GHA"
+
+    @pytest.mark.asyncio
+    async def test_description_includes_country(self):
+        inds = [_make_indicator(name="GDP per capita")]
+
+        with patch(
+            "data360.visualization.get_viz_spec",
+            new=AsyncMock(return_value=_ok_result()),
+        ):
+            result = await generate_viz_gallery(indicators=inds, country_code="GHA")
+
+        desc = result["gallery"][0]["description"]
+        assert "GHA" in desc
+        assert "GDP per capita" in desc
+
+    @pytest.mark.asyncio
+    async def test_chart_types_filter_passed_to_single(self):
+        inds = [_make_indicator()]
+        mock_single = AsyncMock(return_value=_ok_result())
+
+        with patch("data360.visualization.get_viz_spec", new=mock_single):
+            await generate_viz_gallery(indicators=inds, chart_types=["bar"])
+
+        call_kwargs = mock_single.call_args.kwargs
+        assert call_kwargs.get("chart_type") == "bar"


### PR DESCRIPTION
## Summary

Implements the "Question-to-Gallery" pipeline on top of PR #57 (`feat/multi-query-search`), with full multi-country comparative analysis support via LLM sampling and `query_groups`. The key idea: after `data360_analyze_development_topic` decomposes a vague question and selects indicators, the agent can call `data360_generate_viz_gallery` to batch-generate all single-indicator charts and pairwise combinations in one shot, then filter and narrate the most relevant charts.

Depends on: #57

## Changes

### `src/data360/api.py` — Multi-Country Topic Analysis

**Step 3 fan-out refactored**: the previous implementation maintained its own `asyncio.gather` loop plus a manual dedup set that duplicated logic now living in `search()`. Replaced with a three-path routing system:

**Path A — LLM-scoped groups:** When the sampling prompt detects a multi-country question with different topics per country (e.g. "labor market challenges in Morocco vs manufacturing growth in Ethiopia"), it returns a structured JSON array:
```json
[
  {"queries": ["unemployment rate", "labor participation"], "country": "Morocco"},
  {"queries": ["manufacturing output"], "country": "Ethiopia"}
]
```
These are mapped directly to `QueryGroup` objects and passed to `search(query_groups=...)`.

**Path B — Cross-product fallback:** When multiple countries are detected but the decomposition is flat (rule-based fallback or flat sampling), all sub-queries are paired with all countries via cross-product:
```python
groups = [QueryGroup(queries=sub_queries, country=code) for code in codes]
```

**Path C — Single country (unchanged):** Standard `search(queries=..., required_country=...)` path.

**Sampling prompt upgraded:** `_SAMPLING_SYSTEM_PROMPT` now instructs the LLM to return country-scoped groups when it detects different topics for different countries, while preserving the flat array format for single-country and topic-uniform questions.

**JSON parser upgraded:** The sampling response parser now handles both formats:
- Grouped: `[{"queries": [...], "country": "..."}]` → `QueryGroup` objects
- Flat: `["GDP per capita", "inflation"]` → flat sub-queries (existing behavior)

**`matched_sub_query` → `matched_sub_queries`**: upgraded from a bare string to a dict:
```python
"matched_sub_queries": {
    "original_query": query,
    "decomposed_sub_query": sq,
}
```

**`country` parameter:** Now accepts comma-separated values (e.g. `"Morocco, Ethiopia"`) for multi-country comparisons. `_resolve_country_code` already handles this, returning e.g. `"MAR,ETH"`.

### Interaction Matrix

| Scenario | Sampling available | Sampling unavailable |
|---|---|---|
| **No country** | Flat sub-queries → `queries=` | Flat sub-queries → `queries=` |
| **Single country** | Flat sub-queries → `queries=` + `required_country=` | Flat sub-queries → `queries=` + `required_country=` |
| **Multi-country, same topics** | Flat sub-queries → cross-product `query_groups` | Flat sub-queries → cross-product `query_groups` |
| **Multi-country, different topics** | Grouped sub-queries → scoped `query_groups` | Flat sub-queries → cross-product `query_groups` (best effort) |

### `src/data360/visualization.py` — `generate_viz_gallery()`

New async function. Input: list of indicator dicts (from `selected_indicators`). Output:

```
gallery: [
  { chart_url, chart_type, indicators, indicator_ids, description },
  ...
]
total_charts, successful_charts, failed_charts, country_code
```

- Caps at 6 indicators → max 21 charts (6 singles + 15 pairs)
- Concurrency bounded by `_MAX_CONCURRENT_GALLERY_CALLS` (default 5) module constant
- Singles via `get_viz_spec()`; pairs via `get_multi_indicator_viz_spec()`
- Failures per-chart are isolated — one bad chart does not crash the gallery
- Optional `chart_types` hint restricts chart type selection

### `src/data360/mcp_server/tools.py`

Registers both `data360_analyze_development_topic` and `data360_generate_viz_gallery` unconditionally. The previous `DATA360_ENABLE_GALLERY=true` environment variable gate has been removed — the gallery is now a standard production tool.

### `tests/test_analyze_topic.py`

Updated mocks to use `AsyncMock` + `MultiQuerySearchResponse` (with `by_query` layout) to match the refactored `search()` call contract. Added 3 new multi-country tests:

- `test_multi_country_sampling_returns_grouped`: Verifies LLM-scoped groups are passed as `query_groups` with per-country scoping
- `test_multi_country_fallback_uses_cross_product`: Verifies cross-product routing when sampling is unavailable and multiple countries are provided
- `test_single_country_preserves_existing_behavior`: Confirms single-country path still uses `queries=` with `required_country=`

### `tests/test_viz_gallery.py`

11 tests: empty input, single indicator, 2/4/6 indicator chart counts, 6-cap enforcement, failure isolation per single/pair, country code propagation, `chart_types` filter passthrough.

## Design Decisions

### GLiNER considered and rejected for rule-based fallback

We evaluated [GLiNER](https://github.com/urchade/GLiNER) (`gliner_multi-v2.1`) as a potential replacement for the regex-based `_decompose_query` fallback. **Decision: not adopted.** Two reasons:

1. **Extraction vs. generation mismatch.** GLiNER is a zero-shot NER model — it can only extract entity spans that are *already present* in the input text. The primary use case for `analyze_development_topic` is vague, conceptual questions like `"Is Canada a great country?"` or `"What makes a country successful?"`. These queries contain zero indicator-related terms to extract. The LLM sampling path is the only approach that can *infer* concepts like `"GDP per capita"`, `"HDI"`, `"life expectancy"` from questions that never mention them.

2. **Heavyweight dependency.** GLiNER requires `torch` (~500MB) + `gliner` (~210MB model weights). The MCP server currently has no PyTorch dependency. Adding ~700MB for a middle-tier fallback that fails on the exact use case this tool targets does not justify itself.

### Gallery env var gate removed

The `DATA360_ENABLE_GALLERY=true` feature flag was originally added as a safety gate during development. The gallery implementation is now stable (11 tests, failure isolation, concurrency bounds), so the gate has been removed. The tool is registered unconditionally alongside all other tools.

## Post-Review Fixes

- **Falsy strategy bug**: `chart_type_used` now falls back to `meta.get("chart_type_hint")` instead of unconditionally reading `chart_types[0]` when `get_viz_spec` returns an empty `strategy` string.
- **Redundant double-get**: `ind.get("database_id") or ind.get("database_id", "")` replaced with `ind.get("database_id", "")`.
- **`total_candidates` accuracy**: now uses `multi_result.total_candidates` (the pre-dedup raw count) instead of manually counting deduplicated items.
- **Module-level imports**: moved `asyncio` and `itertools` imports out of function bodies to module top level.
- **Base branch sync**: merged latest `feat/multi-query-search` changes (input normalisation, LLM docstring clarity, query_groups finalization).

## Checklist

- [x] Tests pass (`uv run pytest tests/test_multi_query_search.py tests/test_analyze_topic.py tests/test_viz_gallery.py` — 67/67)
- [x] Multi-country query_groups routing implemented and tested (3 new tests)
- [x] Sampling prompt supports country-scoped group output
- [x] Backward compatible — single-country and no-country paths unchanged
- [x] Gallery env var gate removed — tool is production-ready
- [x] Gallery failures are isolated per chart
- [x] `total_candidates` uses authoritative pre-dedup count
- [x] Synced with latest base branch (`feat/multi-query-search`)

## Related

- Depends on #57 (`feat/multi-query-search`) — must be merged first
