### PR TITLE
feat(viz): shared chart normalization, tool-aware UI wrappers, and MCP display fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2262,6 +2262,10 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@data360/chart-payload-normalize": {
+      "resolved": "packages/chart-payload-normalize",
+      "link": true
+    },
     "node_modules/@data360/mcp-ui": {
       "resolved": "packages/mcp-ui",
       "link": true
@@ -17009,11 +17013,21 @@
       "integrity": "sha512-YGAhaO7J5ywOXW6InXNlLmfU194F8lVgu7bRntUF3TiG8Y3nBK0x1UJJuHUP/e8IyihkjCYqhCScpSwnlaSRkQ==",
       "license": "MIT"
     },
+    "packages/chart-payload-normalize": {
+      "name": "@data360/chart-payload-normalize",
+      "version": "0.0.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.5.0"
+      }
+    },
     "packages/mcp-ui": {
       "name": "@data360/mcp-ui",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
+        "@data360/chart-payload-normalize": "0.0.1",
         "@data360/mcp-viz-core": "0.0.1",
         "html-to-image": "^1.11.13"
       },
@@ -17046,7 +17060,9 @@
         "@angular/compiler": "^18.2.13",
         "@angular/compiler-cli": "^18.2.13",
         "@angular/core": "^18.2.13",
+        "@data360/chart-payload-normalize": "0.0.1",
         "@data360/mcp-viz-core": "0.0.1",
+        "@data360/tool-types": "0.0.4",
         "ng-packagr": "^18.2.1",
         "rxjs": "^7.8.1",
         "typescript": "~5.5.4",
@@ -17057,7 +17073,9 @@
       "peerDependencies": {
         "@angular/common": ">=18.0.0 <21.0.0",
         "@angular/core": ">=18.0.0 <21.0.0",
+        "@data360/chart-payload-normalize": ">=0.0.1",
         "@data360/mcp-viz-core": "0.0.1",
+        "@data360/tool-types": ">=0.0.1",
         "rxjs": "^7.5.0",
         "vega": ">=5.0.0",
         "vega-embed": ">=6.0.0",
@@ -19298,7 +19316,9 @@
       "peerDependencies": {
         "@angular/common": ">=18.0.0 <21.0.0",
         "@angular/core": ">=18.0.0 <21.0.0",
+        "@data360/chart-payload-normalize": ">=0.0.1",
         "@data360/mcp-viz-core": "0.0.1",
+        "@data360/tool-types": ">=0.0.1",
         "rxjs": "^7.5.0",
         "vega": ">=5.0.0",
         "vega-embed": ">=6.0.0",
@@ -20551,7 +20571,7 @@
     },
     "packages/tool-types": {
       "name": "@data360/tool-types",
-      "version": "0.0.1",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.23.8"

--- a/packages/chart-payload-normalize/package.json
+++ b/packages/chart-payload-normalize/package.json
@@ -1,13 +1,12 @@
 {
-  "name": "@data360/tool-types",
-  "version": "0.0.4",
-  "description": "TypeScript types and runtime guards for Data360 MCP tool JSON payloads.",
+  "name": "@data360/chart-payload-normalize",
+  "version": "0.0.1",
+  "description": "Normalize Charts API envelopes and raw Vega-Lite JSON into spec + title for Data360 charts.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist",
-    "schemas"
+    "dist"
   ],
   "exports": {
     ".": {
@@ -16,20 +15,15 @@
     }
   },
   "scripts": {
-    "build": "tsc",
-    "test": "vitest run"
-  },
-  "dependencies": {
-    "zod": "^3.23.8"
+    "build": "tsc"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "typescript": "^5.5.0",
-    "vitest": "^2.1.0"
+    "typescript": "^5.5.0"
   },
   "keywords": [
     "data360",
-    "mcp",
+    "vega-lite",
     "world-bank"
   ],
   "license": "MIT",

--- a/packages/chart-payload-normalize/src/index.ts
+++ b/packages/chart-payload-normalize/src/index.ts
@@ -1,0 +1,135 @@
+/**
+ * Chart URLs may return either a Charts API envelope `{ spec, title, ... }`
+ * or a raw Vega-Lite spec object (e.g. Data360 MCP static JSON).
+ */
+
+export type NormalizedChartPayload = {
+  spec: Record<string, unknown>;
+  /** Main headline (matches Vega-Lite `title` string or `title.text`). */
+  title: string;
+  /**
+   * Vega-Lite compound title subtitle (geography · years · unit), when present.
+   * Prefer this for UI over tool `strategy`/`reason` metadata.
+   */
+  subtitle?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function looksLikeVegaLiteSpec(obj: Record<string, unknown>): boolean {
+  if (typeof obj.$schema === "string" && /\bvega\b/i.test(obj.$schema)) {
+    return true;
+  }
+  if ("mark" in obj) {
+    return true;
+  }
+  if ("encoding" in obj && isRecord(obj.encoding as unknown)) {
+    return true;
+  }
+  // Composite / faceted specs (no top-level mark)
+  if ("layer" in obj) {
+    return true;
+  }
+  if ("concat" in obj || "hconcat" in obj || "vconcat" in obj) {
+    return true;
+  }
+  if ("facet" in obj || "repeat" in obj) {
+    return true;
+  }
+  // Note: do not treat bare `{ spec: ... }` as VL — that pattern is also Charts API envelopes.
+  return false;
+}
+
+function titleFromSpec(spec: Record<string, unknown>): string {
+  const raw = spec.title;
+  if (typeof raw === "string") {
+    return raw;
+  }
+  if (isRecord(raw) && typeof raw.text === "string") {
+    return raw.text;
+  }
+  return "Chart";
+}
+
+/** Vega-Lite `{ title: { text, subtitle } }` → second line for chart cards. */
+export function subtitleFromSpec(spec: Record<string, unknown>): string | undefined {
+  const raw = spec.title;
+  if (!isRecord(raw)) {
+    return undefined;
+  }
+  const sub = raw.subtitle;
+  if (typeof sub === "string" && sub.trim()) {
+    return sub.trim();
+  }
+  return undefined;
+}
+
+function isLikelyChartsApiEnvelope(data: Record<string, unknown>): boolean {
+  return typeof data.id === "string" || typeof data.createdAt === "string";
+}
+
+/**
+ * @throws Error if the JSON is not a supported chart payload
+ */
+export function normalizeChartPayloadFromJson(
+  data: unknown,
+): NormalizedChartPayload {
+  if (!isRecord(data)) {
+    throw new Error("Chart JSON must be an object");
+  }
+
+  const nested = data.spec;
+
+  // Charts API: explicit metadata — unwrap nested `spec` only.
+  if (isRecord(nested) && isLikelyChartsApiEnvelope(data)) {
+    const title =
+      typeof data.title === "string" && data.title.trim()
+        ? data.title
+        : titleFromSpec(nested);
+    return {
+      spec: nested,
+      title,
+      subtitle: subtitleFromSpec(nested),
+    };
+  }
+
+  // Raw Vega-Lite document at root (MCP static JSON, facet, layer, concat, …).
+  if (looksLikeVegaLiteSpec(data)) {
+    return {
+      spec: data,
+      title: titleFromSpec(data),
+      subtitle: subtitleFromSpec(data),
+    };
+  }
+
+  // Charts-style `{ title, spec }` without id/createdAt (unwrap nested VL only).
+  if (
+    isRecord(nested) &&
+    typeof data.title === "string" &&
+    data.title.trim() &&
+    looksLikeVegaLiteSpec(nested)
+  ) {
+    return {
+      spec: nested,
+      title: data.title.trim(),
+      subtitle: subtitleFromSpec(nested),
+    };
+  }
+
+  // Nested `spec` that is clearly VL (legacy / loose envelopes).
+  if (isRecord(nested) && looksLikeVegaLiteSpec(nested)) {
+    const title =
+      typeof data.title === "string" && data.title.trim()
+        ? data.title.trim()
+        : titleFromSpec(nested);
+    return {
+      spec: nested,
+      title,
+      subtitle: subtitleFromSpec(nested),
+    };
+  }
+
+  throw new Error("Chart JSON did not contain a Vega-Lite spec");
+}

--- a/packages/chart-payload-normalize/tsconfig.json
+++ b/packages/chart-payload-normalize/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/mcp-ui-angular/README.md
+++ b/packages/mcp-ui-angular/README.md
@@ -92,7 +92,7 @@ Output is written to `dist/` (FESM bundles and typings for publishing).
 
 ### Live demo app
 
-A runnable sample app lives in [`packages/mcp-ui-angular-demo`](../mcp-ui-angular-demo). From that folder: `npm run build:libs`, then `npm install`, then `npm start` (see its README).
+A runnable sample app lives in **`packages/mcp-ui-angular-demo`** in this repo ([browse on GitHub](https://github.com/worldbank/data360-mcp/tree/main/packages/mcp-ui-angular-demo)). Clone the monorepo, then from `packages/mcp-ui-angular-demo`: `npm run build:libs`, then `npm install`, then `npm start` (see [that folder’s README](https://github.com/worldbank/data360-mcp/blob/main/packages/mcp-ui-angular-demo/README.md)).
 
 ## Version coupling
 

--- a/packages/mcp-ui-angular/ng-package.json
+++ b/packages/mcp-ui-angular/ng-package.json
@@ -1,7 +1,11 @@
 {
   "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
   "dest": "./dist",
-  "allowedNonPeerDependencies": ["html-to-image"],
+  "allowedNonPeerDependencies": [
+    "html-to-image",
+    "@data360/chart-payload-normalize",
+    "@data360/tool-types"
+  ],
   "lib": {
     "entryFile": "src/public-api.ts"
   }

--- a/packages/mcp-ui-angular/package.json
+++ b/packages/mcp-ui-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data360/mcp-ui-angular",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Angular components for presenting Data360 MCP tool output (Vega-Lite chart card).",
   "type": "module",
   "files": [
@@ -15,14 +15,18 @@
   "peerDependencies": {
     "@angular/common": ">=18.0.0 <21.0.0",
     "@angular/core": ">=18.0.0 <21.0.0",
-    "@data360/mcp-viz-core": "0.0.1",
+    "@data360/chart-payload-normalize": "0.0.1",
+    "@data360/mcp-viz-core": "0.0.2",
+    "@data360/tool-types": "0.0.4",
     "rxjs": "^7.5.0",
     "vega": ">=5.0.0",
     "vega-embed": ">=6.0.0",
     "vega-lite": ">=5.0.0"
   },
   "devDependencies": {
-    "@data360/mcp-viz-core": "0.0.1",
+    "@data360/chart-payload-normalize": "0.0.1",
+    "@data360/mcp-viz-core": "0.0.2",
+    "@data360/tool-types": "0.0.4",
     "@angular/common": "^18.2.13",
     "@angular/compiler": "^18.2.13",
     "@angular/compiler-cli": "^18.2.13",

--- a/packages/mcp-ui-angular/src/lib/data360-viz-tool-chart-card.component.ts
+++ b/packages/mcp-ui-angular/src/lib/data360-viz-tool-chart-card.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   Input,
   OnChanges,
+  OnDestroy,
   SimpleChanges,
   TemplateRef,
 } from "@angular/core";
@@ -58,7 +59,9 @@ import { Data360VegaChartCardComponent } from "./data360-vega-chart-card.compone
     `,
   ],
 })
-export class Data360VizToolChartCardComponent implements OnChanges {
+export class Data360VizToolChartCardComponent
+  implements OnChanges, OnDestroy
+{
   /**
    * Parsed viz tool payload from {@link parseData360VizToolResult}
    * (must include `url` when successful).
@@ -78,6 +81,8 @@ export class Data360VizToolChartCardComponent implements OnChanges {
   source = "";
   loadError: string | null = null;
   isLoading = false;
+  private loadRequestId = 0;
+  private loadAbortController: AbortController | null = null;
 
   constructor(private readonly cdr: ChangeDetectorRef) {}
 
@@ -87,6 +92,11 @@ export class Data360VizToolChartCardComponent implements OnChanges {
     }
   }
 
+  ngOnDestroy(): void {
+    this.loadAbortController?.abort();
+    this.loadAbortController = null;
+  }
+
   /** Same semantics as {@link isData360VizToolSuccess} without a narrowing type that breaks ng-packagr. */
   hasChartUrl(): boolean {
     const tr = this.toolResult;
@@ -94,6 +104,11 @@ export class Data360VizToolChartCardComponent implements OnChanges {
   }
 
   private async load(): Promise<void> {
+    const requestId = ++this.loadRequestId;
+    this.loadAbortController?.abort();
+    const abortController = new AbortController();
+    this.loadAbortController = abortController;
+
     this.loadError = null;
     this.spec = null;
     this.isLoading = false;
@@ -114,11 +129,14 @@ export class Data360VizToolChartCardComponent implements OnChanges {
     this.cdr.markForCheck();
 
     try {
-      const res = await fetch(fetchUrl);
+      const res = await fetch(fetchUrl, { signal: abortController.signal });
       if (!res.ok) {
         throw new Error(`Failed to load chart: ${res.status}`);
       }
       const data: unknown = await res.json();
+      if (requestId !== this.loadRequestId) {
+        return;
+      }
       const normalized = normalizeChartPayloadFromJson(data);
       this.spec = normalized.spec as VLSpec;
       this.title = normalized.title;
@@ -126,11 +144,23 @@ export class Data360VizToolChartCardComponent implements OnChanges {
         normalized.subtitle ?? formatData360VizSubtitleLine(tr);
       this.loadError = null;
     } catch (e: unknown) {
+      if (requestId !== this.loadRequestId) {
+        return;
+      }
+      if (e instanceof DOMException && e.name === "AbortError") {
+        return;
+      }
       this.spec = null;
       this.loadError =
         e instanceof Error ? e.message : "Failed to load chart";
     } finally {
+      if (requestId !== this.loadRequestId) {
+        return;
+      }
       this.isLoading = false;
+      if (this.loadAbortController === abortController) {
+        this.loadAbortController = null;
+      }
       this.cdr.markForCheck();
     }
   }

--- a/packages/mcp-ui-angular/src/lib/data360-viz-tool-chart-card.component.ts
+++ b/packages/mcp-ui-angular/src/lib/data360-viz-tool-chart-card.component.ts
@@ -1,0 +1,137 @@
+import {
+  ChangeDetectorRef,
+  Component,
+  Input,
+  OnChanges,
+  SimpleChanges,
+  TemplateRef,
+} from "@angular/core";
+import { normalizeChartPayloadFromJson } from "@data360/chart-payload-normalize";
+import {
+  formatData360VizSourceLine,
+  formatData360VizSubtitleLine,
+  type Data360VizToolResult,
+} from "@data360/tool-types";
+import type { VLSpec } from "@data360/mcp-viz-core";
+import { Data360VegaChartCardComponent } from "./data360-vega-chart-card.component";
+
+@Component({
+  selector: "data360-viz-tool-chart-card",
+  standalone: true,
+  imports: [Data360VegaChartCardComponent],
+  template: `
+    @if (loadError) {
+      <div class="d360-viz-tool-err">{{ loadError }}</div>
+    } @else if (hasChartUrl()) {
+      @if (isLoading || spec === null) {
+        <div class="d360-viz-tool-loading">Loading chart…</div>
+      } @else {
+        <data360-vega-chart-card
+          [spec]="spec"
+          [title]="title"
+          [subtitle]="subtitle"
+          [source]="source"
+          [chartHeight]="chartHeight"
+          [railTopSlot]="railTopSlot"
+          [className]="className"
+        />
+      }
+    }
+  `,
+  styles: [
+    `
+      .d360-viz-tool-err {
+        color: #b91c1c;
+        padding: 16px;
+        border: 1px solid rgba(239, 68, 68, 0.35);
+        border-radius: 8px;
+      }
+      .d360-viz-tool-loading {
+        min-height: 200px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 8px;
+        border: 1px dashed rgba(0, 0, 0, 0.12);
+        background: rgba(0, 0, 0, 0.03);
+      }
+    `,
+  ],
+})
+export class Data360VizToolChartCardComponent implements OnChanges {
+  /**
+   * Parsed viz tool payload from {@link parseData360VizToolResult}
+   * (must include `url` when successful).
+   */
+  @Input({ required: true }) toolResult!: Data360VizToolResult;
+
+  /** Host-specific URL rewrite (proxy / base path). */
+  @Input() mapUrlForFetch?: (url: string) => string;
+
+  @Input() chartHeight = 280;
+  @Input() className = "";
+  @Input() railTopSlot: TemplateRef<unknown> | null = null;
+
+  spec: VLSpec | null = null;
+  title = "Chart";
+  subtitle: string | undefined;
+  source = "";
+  loadError: string | null = null;
+  isLoading = false;
+
+  constructor(private readonly cdr: ChangeDetectorRef) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes["toolResult"] || changes["mapUrlForFetch"]) {
+      void this.load();
+    }
+  }
+
+  /** Same semantics as {@link isData360VizToolSuccess} without a narrowing type that breaks ng-packagr. */
+  hasChartUrl(): boolean {
+    const tr = this.toolResult;
+    return Boolean(tr.url) && (tr.error === null || tr.error === undefined);
+  }
+
+  private async load(): Promise<void> {
+    this.loadError = null;
+    this.spec = null;
+    this.isLoading = false;
+
+    const tr = this.toolResult;
+    if (!tr.url || !(tr.error === null || tr.error === undefined)) {
+      this.cdr.markForCheck();
+      return;
+    }
+
+    const fetchUrl = this.mapUrlForFetch
+      ? this.mapUrlForFetch(tr.url)
+      : tr.url;
+
+    this.source = formatData360VizSourceLine(tr);
+    this.subtitle = undefined;
+    this.isLoading = true;
+    this.cdr.markForCheck();
+
+    try {
+      const res = await fetch(fetchUrl);
+      if (!res.ok) {
+        throw new Error(`Failed to load chart: ${res.status}`);
+      }
+      const data: unknown = await res.json();
+      const normalized = normalizeChartPayloadFromJson(data);
+      this.spec = normalized.spec as VLSpec;
+      this.title = normalized.title;
+      this.subtitle =
+        normalized.subtitle ?? formatData360VizSubtitleLine(tr);
+      this.loadError = null;
+    } catch (e: unknown) {
+      this.spec = null;
+      this.loadError =
+        e instanceof Error ? e.message : "Failed to load chart";
+    } finally {
+      this.isLoading = false;
+      this.cdr.markForCheck();
+    }
+  }
+}

--- a/packages/mcp-ui-angular/src/public-api.ts
+++ b/packages/mcp-ui-angular/src/public-api.ts
@@ -2,3 +2,4 @@
  * Public API Surface of @data360/mcp-ui-angular
  */
 export { Data360VegaChartCardComponent } from "./lib/data360-vega-chart-card.component";
+export { Data360VizToolChartCardComponent } from "./lib/data360-viz-tool-chart-card.component";

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data360/mcp-ui",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "React UI for presenting Data360 MCP tool output (chart card, search results card, and future surfaces).",
   "type": "module",
   "files": [
@@ -24,7 +24,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@data360/mcp-viz-core": "0.0.1",
+    "@data360/chart-payload-normalize": "0.0.1",
+    "@data360/mcp-viz-core": "0.0.2",
     "html-to-image": "^1.11.13"
   },
   "peerDependencies": {

--- a/packages/mcp-ui/src/viz-card/Data360ChartFromVizTool.tsx
+++ b/packages/mcp-ui/src/viz-card/Data360ChartFromVizTool.tsx
@@ -1,0 +1,164 @@
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { normalizeChartPayloadFromJson } from "@data360/chart-payload-normalize";
+import {
+  formatData360VizSourceLine,
+  formatData360VizSubtitleLine,
+  isData360VizToolSuccess,
+  type Data360VizToolResult,
+} from "@data360/tool-types";
+import VegaChartCard from "./VegaChartCard";
+import type { VLSpec } from "./types";
+
+export type Data360ChartFromVizToolProps = {
+  /** Parsed viz tool payload (must include a chart `url` on success). */
+  toolResult: Data360VizToolResult;
+  /** Host-specific URL rewrite (e.g. Next.js basePath / same-origin proxy). */
+  mapUrlForFetch?: (url: string) => string;
+  chartHeight?: number;
+  railTopSlot?: ReactNode;
+  className?: string;
+  /** Shown while loading instead of default inline message. */
+  loadingFallback?: ReactNode;
+  /** Called after JSON is fetched and normalized (e.g. host artifact viewer). */
+  onChartReady?: (info: {
+    spec: Record<string, unknown>;
+    title: string;
+    specJson: string;
+    /** From Vega-Lite `title.subtitle` when present. */
+    subtitleFromSpec?: string;
+  }) => void;
+};
+
+export function Data360ChartFromVizTool({
+  toolResult,
+  mapUrlForFetch,
+  chartHeight = 280,
+  railTopSlot,
+  className,
+  loadingFallback,
+  onChartReady,
+}: Data360ChartFromVizToolProps) {
+  const fetchUrl = useMemo(() => {
+    if (!isData360VizToolSuccess(toolResult)) {
+      return null;
+    }
+    const u = toolResult.url;
+    return mapUrlForFetch ? mapUrlForFetch(u) : u;
+  }, [toolResult, mapUrlForFetch]);
+
+  const source = formatData360VizSourceLine(toolResult);
+  const toolMetadataSubtitle = formatData360VizSubtitleLine(toolResult);
+
+  const [chartData, setChartData] = useState<{
+    spec: Record<string, unknown>;
+    title: string;
+    specSubtitle?: string;
+  } | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadError(null);
+    setChartData(null);
+    if (!fetchUrl) {
+      return () => {
+        cancelled = true;
+      };
+    }
+    fetch(fetchUrl)
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`Failed to load chart: ${res.status}`);
+        }
+        return res.json() as Promise<unknown>;
+      })
+      .then((data) => {
+        if (cancelled) {
+          return;
+        }
+        const { spec, title, subtitle: specSubtitle } =
+          normalizeChartPayloadFromJson(data);
+        const specJson = JSON.stringify(spec);
+        setChartData({ spec, title, specSubtitle });
+        onChartReady?.({ spec, title, specJson, subtitleFromSpec: specSubtitle });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) {
+          return;
+        }
+        setChartData(null);
+        setLoadError(
+          err instanceof Error ? err.message : "Failed to load chart",
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchUrl, onChartReady]);
+
+  if (!isData360VizToolSuccess(toolResult)) {
+    return null;
+  }
+
+  if (loadError) {
+    return (
+      <div className={className}>
+        <div
+          style={{
+            borderRadius: 8,
+            border: "1px solid rgba(239,68,68,0.35)",
+            background: "rgba(239,68,68,0.08)",
+            padding: 16,
+            color: "#b91c1c",
+          }}
+        >
+          {loadError}
+        </div>
+      </div>
+    );
+  }
+
+  if (!chartData) {
+    return (
+      loadingFallback ?? (
+        <div className={className}>
+          <div
+            style={{
+              display: "flex",
+              minHeight: 200,
+              width: "100%",
+              alignItems: "center",
+              justifyContent: "center",
+              borderRadius: 8,
+              border: "1px dashed rgba(0,0,0,0.12)",
+              background: "rgba(0,0,0,0.03)",
+            }}
+          >
+            <span style={{ opacity: 0.6 }}>Loading chart…</span>
+          </div>
+        </div>
+      )
+    );
+  }
+
+  const displaySubtitle =
+    chartData.specSubtitle ?? toolMetadataSubtitle;
+
+  return (
+    <div className={className}>
+      <VegaChartCard
+        chartHeight={chartHeight}
+        railTopSlot={railTopSlot}
+        source={source}
+        spec={chartData.spec as VLSpec}
+        subtitle={displaySubtitle}
+        title={chartData.title}
+      />
+    </div>
+  );
+}

--- a/packages/mcp-ui/src/viz-card/index.ts
+++ b/packages/mcp-ui/src/viz-card/index.ts
@@ -1,5 +1,9 @@
 export { default as VegaChartCard } from "./VegaChartCard";
 export {
+  Data360ChartFromVizTool,
+  type Data360ChartFromVizToolProps,
+} from "./Data360ChartFromVizTool";
+export {
   getMark,
   parseSpec,
   prepareSpec,

--- a/packages/mcp-ui/vite.config.ts
+++ b/packages/mcp-ui/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        "@data360/chart-payload-normalize",
         "@data360/mcp-viz-core",
         "@data360/tool-types",
         "react",

--- a/packages/mcp-viz-core/package.json
+++ b/packages/mcp-viz-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data360/mcp-viz-core",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Framework-agnostic Vega-Lite prep and World Bank theme for Data360 MCP viz tools.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/tool-types/src/index.ts
+++ b/packages/tool-types/src/index.ts
@@ -5,6 +5,11 @@ export {
   isData360VizToolSuccess,
 } from "./viz-contract";
 export type { Data360VizToolResult } from "./viz-contract";
+export {
+  DATA360_CHART_SOURCE_FALLBACK,
+  formatData360VizSourceLine,
+  formatData360VizSubtitleLine,
+} from "./viz-display-format";
 
 export {
   enrichedIndicatorSchema,

--- a/packages/tool-types/src/search-contract.test.ts
+++ b/packages/tool-types/src/search-contract.test.ts
@@ -37,7 +37,7 @@ describe("Data360SearchToolResult", () => {
           periodicity: "Annual",
           latest_data: "2023",
           time_period_range: "1990–2023",
-          covers_country: true,
+          covers_country: { KEN: true },
           requested_country: "KEN",
           dimensions: ["SEX", "AGE"],
         },
@@ -49,7 +49,7 @@ describe("Data360SearchToolResult", () => {
     });
     expect(ok.success).toBe(true);
     if (ok.success) {
-      expect(ok.data.indicators[0].covers_country).toBe(true);
+      expect(ok.data.indicators[0].covers_country).toEqual({ KEN: true });
       expect(ok.data.indicators[0].requested_country).toBe("KEN");
     }
   });

--- a/packages/tool-types/src/viz-contract.ts
+++ b/packages/tool-types/src/viz-contract.ts
@@ -16,6 +16,10 @@ export const data360VizToolResultSchema = z
     database_id: z.string().optional(),
     indicator_name: z.string().optional(),
     indicator_id: z.string().optional(),
+    /** Preformatted one-line footer (preferred over computing from attribution fields). */
+    source_line: z.string().optional(),
+    /** Preformatted subtitle under the chart title (warning · strategy — reason). */
+    subtitle_line: z.string().optional(),
   })
   .passthrough();
 

--- a/packages/tool-types/src/viz-display-format.ts
+++ b/packages/tool-types/src/viz-display-format.ts
@@ -1,0 +1,70 @@
+/** Default chart footer when MCP does not return attribution fields. */
+export const DATA360_CHART_SOURCE_FALLBACK = "World Bank — Data360";
+
+function readOptionalString(obj: Record<string, unknown>, key: string): string {
+  const v = obj[key];
+  if (typeof v !== "string") {
+    return "";
+  }
+  return v.trim();
+}
+
+/**
+ * One-line attribution for Data360 viz tool results (Vega chart card "Source").
+ * Uses `source_line` from the server when present; otherwise formats from
+ * structured `database_*` / `indicator_*` fields (matches server and legacy client).
+ */
+export function formatData360VizSourceLine(result: unknown): string {
+  if (!result || typeof result !== "object") {
+    return DATA360_CHART_SOURCE_FALLBACK;
+  }
+  const r = result as Record<string, unknown>;
+  const fromServer = readOptionalString(r, "source_line");
+  if (fromServer) {
+    return fromServer;
+  }
+  const db =
+    readOptionalString(r, "database_name") ||
+    readOptionalString(r, "database_id");
+  const ind =
+    readOptionalString(r, "indicator_name") ||
+    readOptionalString(r, "indicator_id");
+  if (db && ind) {
+    return `World Bank — ${db} — ${ind}`;
+  }
+  if (ind) {
+    return `World Bank — ${ind}`;
+  }
+  if (db) {
+    return `World Bank — ${db}`;
+  }
+  return DATA360_CHART_SOURCE_FALLBACK;
+}
+
+/**
+ * Subtitle under chart title when `subtitle_line` is absent (older MCP servers).
+ */
+export function formatData360VizSubtitleLine(result: unknown): string | undefined {
+  if (!result || typeof result !== "object") {
+    return undefined;
+  }
+  const r = result as Record<string, unknown>;
+  const fromServer = readOptionalString(r, "subtitle_line");
+  if (fromServer) {
+    return fromServer;
+  }
+  const parts: string[] = [];
+  const warning = readOptionalString(r, "warning");
+  if (warning) {
+    parts.push(warning);
+  }
+  const strategy = readOptionalString(r, "strategy");
+  const reason = readOptionalString(r, "reason");
+  if (strategy || reason) {
+    parts.push([strategy, reason].filter(Boolean).join(" — "));
+  }
+  if (parts.length === 0) {
+    return undefined;
+  }
+  return parts.join(" · ");
+}

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -13,8 +13,9 @@ Vega-Lite specifications, then persists them either through the optional Charts 
   dispatches multi-series strategies (scatter, layered lines, connected scatter, etc.).
 
 Return shape for both: ``{"url": str|None, "error": str|None, ...}`` plus optional
-``database_id``, ``database_name``, ``indicator_id``, ``indicator_name`` for client
-source lines. Before any HTTP
+``database_id``, ``database_name``, ``indicator_id``, ``indicator_name``, optional
+``strategy`` / ``reason``, and optional preformatted ``source_line`` /
+``subtitle_line`` for clients that only render strings. Before any HTTP
 or ``json.dump``, specs are passed through ``_vega_spec_to_json_safe`` so
 ``data.values`` never contains raw ``pandas.Timestamp`` / numpy scalars that would
 break JSON encoding.
@@ -183,6 +184,8 @@ def _ok(
     warning: str | None = None,
     *,
     source_attribution: dict[str, str] | None = None,
+    strategy: str | None = None,
+    reason: str | None = None,
 ) -> VizResult:
     r: VizResult = {"url": url, "error": None}
     if warning:
@@ -191,11 +194,71 @@ def _ok(
         for key, val in source_attribution.items():
             if val:
                 r[key] = val
+    if strategy:
+        r["strategy"] = strategy
+    if reason:
+        r["reason"] = reason
+    attrib_for_line = {
+        k: str(v)
+        for k, v in r.items()
+        if k
+        in (
+            "database_id",
+            "database_name",
+            "indicator_id",
+            "indicator_name",
+        )
+        and v
+    }
+    r["source_line"] = _format_source_line_from_attribution(attrib_for_line)
+    strat_v = r.get("strategy")
+    reas_v = r.get("reason")
+    sub = _format_subtitle_line(
+        warning,
+        strat_v if isinstance(strat_v, str) else None,
+        reas_v if isinstance(reas_v, str) else None,
+    )
+    if sub:
+        r["subtitle_line"] = sub
     return r
 
 
 def _err(msg: str) -> VizResult:
     return {"url": None, "error": msg}
+
+
+_SOURCE_FALLBACK = "World Bank — Data360"
+
+
+def _format_source_line_from_attribution(attrib: dict[str, str]) -> str:
+    """One-line \"Source\" string; matches client `formatData360VizChartSource`."""
+    db = (attrib.get("database_name") or attrib.get("database_id") or "").strip()
+    ind = (attrib.get("indicator_name") or attrib.get("indicator_id") or "").strip()
+    if db and ind:
+        return f"World Bank — {db} — {ind}"
+    if ind:
+        return f"World Bank — {ind}"
+    if db:
+        return f"World Bank — {db}"
+    return _SOURCE_FALLBACK
+
+
+def _format_subtitle_line(
+    warning: str | None,
+    strategy: str | None,
+    reason: str | None,
+) -> str | None:
+    """Optional subtitle under chart title; matches chat `message.tsx` viz branch."""
+    parts: list[str] = []
+    if warning:
+        parts.append(warning)
+    if strategy or reason:
+        parts.append(
+            " — ".join(x for x in (strategy or "", reason or "") if x)
+        )
+    if not parts:
+        return None
+    return " · ".join(parts)
 
 
 def _scalar_for_json(value: object) -> object:
@@ -635,7 +698,10 @@ async def get_viz_spec(
             unit_measure=raw_unit,
         )
         return _ok(
-            await _store_spec(spec), source_attribution=source_attribution
+            await _store_spec(spec),
+            source_attribution=source_attribution,
+            strategy=strategy_result.strategy.value,
+            reason=strategy_result.reason,
         )
 
     # 8. Draco path (temporal_single, fallback)
@@ -740,7 +806,10 @@ async def get_viz_spec(
             vl_spec = rule.apply(vl_spec, data_frequency, raw_unit or None)
 
         return _ok(
-            await _store_spec(vl_spec), source_attribution=source_attribution
+            await _store_spec(vl_spec),
+            source_attribution=source_attribution,
+            strategy=strategy_result.strategy.value,
+            reason=strategy_result.reason,
         )
 
     except StopIteration:
@@ -758,6 +827,8 @@ async def get_viz_spec(
                 await _store_spec(spec),
                 warning=_FALLBACK_WARNING,
                 source_attribution=source_attribution,
+                strategy=strategy_result.strategy.value,
+                reason=strategy_result.reason,
             )
         except Exception as fallback_err:
             _logger.exception(f"Fallback failed: {fallback_err}")
@@ -1000,7 +1071,9 @@ async def get_multi_indicator_viz_spec(
     }
 
     url = await _store_spec(spec)
-    result = _ok(url, source_attribution=source_attribution_multi)
-    result["strategy"] = strategy_result.strategy.value
-    result["reason"] = strategy_result.reason
-    return result
+    return _ok(
+        url,
+        source_attribution=source_attribution_multi,
+        strategy=strategy_result.strategy.value,
+        reason=strategy_result.reason,
+    )

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -231,7 +231,7 @@ _SOURCE_FALLBACK = "World Bank — Data360"
 
 
 def _format_source_line_from_attribution(attrib: dict[str, str]) -> str:
-    """One-line \"Source\" string; matches client `formatData360VizChartSource`."""
+    """One-line \"Source\" string; matches client `formatData360VizSourceLine`."""
     db = (attrib.get("database_name") or attrib.get("database_id") or "").strip()
     ind = (attrib.get("indicator_name") or attrib.get("indicator_id") or "").strip()
     if db and ind:

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -248,7 +248,7 @@ def _format_subtitle_line(
     strategy: str | None,
     reason: str | None,
 ) -> str | None:
-    """Optional subtitle under chart title; matches chat `message.tsx` viz branch."""
+    """Optional subtitle under chart title; matches client `formatData360VizSubtitleLine`."""
     parts: list[str] = []
     if warning:
         parts.append(warning)


### PR DESCRIPTION
#### Summary

This change decouples chart **presentation** from individual hosts by moving URL→JSON normalization into **`@data360/chart-payload-normalize`**, adding **React and Angular “load from viz tool result” wrappers**, and emitting **canonical display strings** from the MCP server on successful viz tools. Consumers can rely on **`source_line` / `subtitle_line`** and structured fields as before; older servers remain supported via client-side fallbacks.

#### Server (`data360-mcp`)

- Extend successful **`VizResult`** with optional **`source_line`** and **`subtitle_line`** (additive, backward compatible).
- Align **single-indicator** success paths with multi-indicator by attaching **`strategy`** and **`reason`** where applicable.
- Document return shape in module docstring.

#### `@data360/tool-types`

- Zod schema: optional **`source_line`**, **`subtitle_line`**.
- New **`viz-display-format`**: **`formatData360VizSourceLine`**, **`formatData360VizSubtitleLine`**, **`DATA360_CHART_SOURCE_FALLBACK`** (prefers server strings, then structured fields).

#### `@data360/chart-payload-normalize` (new)

- **`normalizeChartPayloadFromJson`**: Charts API envelopes vs raw Vega-Lite.
- **`NormalizedChartPayload`**: optional **`subtitle`** from Vega-Lite compound **`title.subtitle`** (e.g. geography · years · unit from **`build_chart_title_with_context`**).
- Exported **`subtitleFromSpec`** for reuse.

#### `@data360/mcp-ui`

- **`Data360ChartFromVizTool`**: `fetch` → normalize → **`VegaChartCard`**; optional **`mapUrlForFetch`**; **`onChartReady`** for hosts that need spec JSON.
- Card subtitle: **spec `title.subtitle` first**, then tool **`subtitle_line` / strategy metadata** fallback.
- Dependency on **`@data360/chart-payload-normalize`**; Vite marks it external.

#### `@data360/mcp-ui-angular`

- **`Data360VizToolChartCardComponent`**: same fetch / normalize / display behavior; peers **`@data360/chart-payload-normalize`** and **`@data360/tool-types`**.
- **`ng-packagr`**: allowlisted non-peer deps for the new packages.

#### Docs

- **`mcp-ui-angular` README**: demo links use canonical **GitHub `tree` / `blob`** URLs instead of relative-only links (works on npm and GitHub).

#### Testing

- `npm install` at monorepo root; `npm run build` (workspaces).
- Manual: run MCP viz tools and confirm tool JSON includes **`source_line` / `subtitle_line`** where expected; open chart URL in a host using **`Data360ChartFromVizTool`** / Angular wrapper and confirm subtitle matches **spec context** when **`title.subtitle`** is present.