### PR TITLE
feat(mcp): ranking improvements + outbound telemetry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,11 @@ MCP_PORT=8000  # use 8022 in dev
 MCP_TRANSPORT=http
 MCP_CHARTS_API_URL=https://localhost:8001/api/v1/charts
 MCP_CHARTS_API_TOKEN=replace-with-charts-write-token
+
+# Optional: set to 'local' to enable local telemetry (OTLP or console).
+# MCP_ENV=local
+# Run docker container: docker run --rm -d --name jaeger -p 16686:16686 -p 4317:4317 -p 4318:4318 jaegertracing/jaeger:latest
+# Then set the following environment variables:
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+# OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+# OTEL_SERVICE_NAME=data360-mcp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
   "pandas>=3.0.0",
   "cachetools>=6.2.4",
   "scikit-learn>=1.8.0",
+  "opentelemetry-instrumentation-httpx>=0.50b0",
+  "opentelemetry-sdk>=1.28.0",
+  "opentelemetry-exporter-otlp>=1.28.0",
 ]
 
 [project.optional-dependencies]

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -1,9 +1,10 @@
 import asyncio
 import json
 import logging
+import math
 import threading
 import zlib
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import urlencode
 
 import cachetools
@@ -23,9 +24,9 @@ from .errors import (
 )
 from .errors import ValidationError as Data360ValidationError
 from .models import (
-    CountryComparisonResponse,
     ComparisonSnapshot,
     ComparisonTimeSeries,
+    CountryComparisonResponse,
     DataSummaryResponse,
     DerivedDataResponse,
     DiagnosticSummaryResponse,
@@ -114,6 +115,26 @@ def _short_hash(data: dict[str, Any]) -> str:
     return f"{zlib.crc32(json.dumps(data, sort_keys=True).encode()) & 0xFFFFFFFF:08x}"
 
 
+def _obs_value_to_float(val: Any) -> float | None:
+    """Parse OBS_VALUE for aggregation paths; None if missing or non-numeric.
+
+    The Data API sometimes returns the literal string ``\"null\"`` for missing
+    values; ``val is not None`` is therefore not sufficient before ``float()``."""
+    if val is None:
+        return None
+    if isinstance(val, str):
+        stripped = val.strip()
+        if not stripped or stripped.lower() in ("null", "nan", "none"):
+            return None
+    try:
+        out = float(val)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(out):
+        return None
+    return out
+
+
 def _get_valid_disaggregations(
     disagg_res: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -196,9 +217,7 @@ def _strip_disaggregation(
             entry["count"] = len(values)
             if queried_countries:
                 ref_set = set(values)
-                entry["queried"] = {
-                    code: code in ref_set for code in queried_countries
-                }
+                entry["queried"] = {code: code in ref_set for code in queried_countries}
             else:
                 entry["sample"] = sorted(values)[:_REF_AREA_SAMPLE_SIZE]
         else:
@@ -753,11 +772,13 @@ async def search(  # noqa: PLR0911
         _logger.debug("queries=%r normalised to None (all entries empty)", queries)
         queries = None
 
-    active_modes = sum((
-        query is not None,
-        queries is not None,
-        query_groups is not None,
-    ))
+    active_modes = sum(
+        (
+            query is not None,
+            queries is not None,
+            query_groups is not None,
+        )
+    )
     if active_modes > 1:
         return EnrichedSearchResponse(
             error="Provide exactly one of 'query', 'queries', or 'query_groups', not multiple."
@@ -766,7 +787,6 @@ async def search(  # noqa: PLR0911
         return EnrichedSearchResponse(
             error="One of 'query', 'queries', or 'query_groups' must be provided."
         )
-
 
     # --- Multi-query path (queries= flat list) ---
     if queries is not None:
@@ -820,7 +840,12 @@ async def search(  # noqa: PLR0911
 
         # Fan out concurrent _search_raw calls, one per query
         raw_tasks = [
-            _search_raw(query=q, limit=limit, offset=offset, select_fields=_ENRICHMENT_SELECT_FIELDS)
+            _search_raw(
+                query=q,
+                limit=limit,
+                offset=offset,
+                select_fields=_ENRICHMENT_SELECT_FIELDS,
+            )
             for q in clean_queries
         ]
         raw_results = await asyncio.gather(*raw_tasks, return_exceptions=True)
@@ -896,14 +921,16 @@ async def search(  # noqa: PLR0911
             resolved_map = dict(zip(unique_countries, codes))
 
         clean_queries = [q for q, _ in flat_pairs]
-        per_query_codes = [
-            resolved_map.get(c) if c else None
-            for _, c in flat_pairs
-        ]
+        per_query_codes = [resolved_map.get(c) if c else None for _, c in flat_pairs]
 
         # Fan out concurrent _search_raw calls, one per flattened query
         raw_tasks = [
-            _search_raw(query=q, limit=limit, offset=offset, select_fields=_ENRICHMENT_SELECT_FIELDS)
+            _search_raw(
+                query=q,
+                limit=limit,
+                offset=offset,
+                select_fields=_ENRICHMENT_SELECT_FIELDS,
+            )
             for q in clean_queries
         ]
         raw_results = await asyncio.gather(*raw_tasks, return_exceptions=True)
@@ -972,11 +999,7 @@ async def search(  # noqa: PLR0911
     # For flagged indicators, concurrently query the disaggregation endpoint to
     # determine the definitive True/False for each regional code.
     if country_code and indicators_to_verify:
-        regional_codes = [
-            c.strip()
-            for c in country_code.split(";")
-            if c.strip()
-        ]
+        regional_codes = [c.strip() for c in country_code.split(";") if c.strip()]
 
         async def _verify_regional_coverage(ind: EnrichedIndicator) -> None:
             try:
@@ -996,7 +1019,9 @@ async def search(  # noqa: PLR0911
                     "Failed to verify regional coverage for %s: %s", ind.idno, e
                 )
 
-        await asyncio.gather(*(_verify_regional_coverage(ind) for ind in indicators_to_verify))
+        await asyncio.gather(
+            *(_verify_regional_coverage(ind) for ind in indicators_to_verify)
+        )
 
         indicators.sort(
             key=lambda x: (
@@ -1038,18 +1063,22 @@ async def _build_multi_query_response(
     for i, (q, raw_result) in enumerate(zip(clean_queries, raw_results)):
         code_for_query = per_query_codes[i]
         if isinstance(raw_result, Exception):
-            groups.append(QueryGroupResult(
-                query=q,
-                country_code=code_for_query,
-                error=str(raw_result),
-            ))
+            groups.append(
+                QueryGroupResult(
+                    query=q,
+                    country_code=code_for_query,
+                    error=str(raw_result),
+                )
+            )
             continue
         if raw_result.error or not raw_result.items:
-            groups.append(QueryGroupResult(
-                query=q,
-                country_code=code_for_query,
-                error=raw_result.error or f"No indicators found for: '{q}'",
-            ))
+            groups.append(
+                QueryGroupResult(
+                    query=q,
+                    country_code=code_for_query,
+                    error=raw_result.error or f"No indicators found for: '{q}'",
+                )
+            )
             continue
 
         # Multi-query uses sovereign country codes per group; regional aggregate
@@ -1067,31 +1096,35 @@ async def _build_multi_query_response(
                 existing_ind = seen_dict[key]
 
                 # Merge covers_country data across queries/groups
-                if existing_ind.covers_country is not None and ind.covers_country is not None:
+                if (
+                    existing_ind.covers_country is not None
+                    and ind.covers_country is not None
+                ):
                     existing_ind.covers_country.update(ind.covers_country)
 
                 if dedupe and result_layout == "merged":
                     # Global deduplication: discard from subsequent groups in merged layout
                     deduplicated_count += 1
+                # In by_query layout, or if dedupe=False, we keep the indicator.
+                # But if dedupe=True, we still deduplicate WITHIN the same group.
+                elif dedupe and key in group_seen:
+                    deduplicated_count += 1
                 else:
-                    # In by_query layout, or if dedupe=False, we keep the indicator.
-                    # But if dedupe=True, we still deduplicate WITHIN the same group.
-                    if dedupe and key in group_seen:
-                        deduplicated_count += 1
-                    else:
-                        group_seen.add(key)
-                        group_indicators.append(existing_ind)
+                    group_seen.add(key)
+                    group_indicators.append(existing_ind)
             else:
                 seen_dict[key] = ind
                 group_seen.add(key)
                 group_indicators.append(ind)
 
-        groups.append(QueryGroupResult(
-            query=q,
-            country_code=code_for_query,
-            indicators=group_indicators,
-            count=len(group_indicators),
-        ))
+        groups.append(
+            QueryGroupResult(
+                query=q,
+                country_code=code_for_query,
+                indicators=group_indicators,
+                count=len(group_indicators),
+            )
+        )
 
     # Compute response-level required_country: join all unique resolved codes with ";"
     all_codes = sorted({c for c in per_query_codes if c})
@@ -1106,7 +1139,11 @@ async def _build_multi_query_response(
             merged_indicators.sort(
                 key=lambda x: (
                     not any((x.covers_country or {}).values()),
-                    -(int(x.latest_data or 0) if str(x.latest_data or "").isdigit() else 0),
+                    -(
+                        int(x.latest_data or 0)
+                        if str(x.latest_data or "").isdigit()
+                        else 0
+                    ),
                 )
             )
         return MultiQuerySearchResponse(
@@ -1359,7 +1396,9 @@ async def get_disaggregation(
             raw_data = response.json()
             # Filter out _Z values and format response
             valid_dimensions = _get_valid_disaggregations(raw_data)
-            result_disagg = {"dimensions": _strip_disaggregation(valid_dimensions, queried_countries)}
+            result_disagg = {
+                "dimensions": _strip_disaggregation(valid_dimensions, queried_countries)
+            }
             with _disaggregation_cache_lock:
                 _disaggregation_cache[_disagg_cache_key] = result_disagg
             return result_disagg
@@ -1378,6 +1417,7 @@ async def get_data(
     end_year: int | None = None,
     limit: int = 50,
     offset: int = 0,
+    ref_area_filter: Literal["none", "member_economies_only"] = "none",
 ) -> IndicatorDataResponse:
     """Fetch indicator data from the Data360 API with pagination.
 
@@ -1393,11 +1433,17 @@ async def get_data(
         disaggregation_filters: Optional dict of dimension filters. Keys: REF_AREA, SEX, AGE,
             URBANISATION, UNIT_MEASURE, etc. Values are str or None (not lists). REF_AREA supports
             comma-separated ISO codes (e.g. "KEN,TZA"); semicolons are normalized to commas.
-            Use value None to request all values for a dimension (e.g. {"SEX": None}).
+            Use value None to request all values for a dimension (e.g. {"SEX": None}). When REF_AREA
+            is omitted or None, the Data API returns all geographic series—including regional aggregates
+            (e.g. EAS, EMU)—mixed with member economies.
         start_year: Optional start year (inclusive). Defaults to last 5 years if both start/end omitted.
         end_year: Optional end year (inclusive). Defaults to current year if both start/end omitted.
         limit: Maximum records per page (default 50, max 100).
         offset: Number of records to skip for pagination (default 0).
+        ref_area_filter: When ``member_economies_only``, drop rows whose ``REF_AREA`` is not an FMR
+            leaf member economy **only if** REF_AREA is not pinned (no ``country_code`` and no explicit
+            ``REF_AREA`` string in filters). Otherwise a note is added to ``failed_validation`` and
+            no filtering is applied.
 
     Returns:
         IndicatorDataResponse:
@@ -1523,6 +1569,7 @@ async def get_data(
         valid_filters, available_disaggregations=available_disaggregations
     )
     params.update(effective_disagg)
+    ref_area_unpinned = not country_code and "REF_AREA" not in params
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
             _logger.debug("Fetching data from %s with params: %s", data_url, params)
@@ -1573,6 +1620,26 @@ async def get_data(
             # Strip boilerplate fields for LLM token savings
             raw_data = [_strip_data_row(row) for row in raw_data]
 
+            filter_notes: list[str] = (
+                list(validation_errors) if validation_errors else []
+            )
+            if ref_area_filter == "member_economies_only":
+                if ref_area_unpinned:
+                    from .providers import get_group_hierarchy_manager  # noqa: PLC0415
+
+                    _ghm = get_group_hierarchy_manager()
+                    raw_data = [
+                        r
+                        for r in raw_data
+                        if _ghm.is_country(str(r.get("REF_AREA", "")))
+                    ]
+                else:
+                    filter_notes.append(
+                        "ref_area_filter=member_economies_only applies only when REF_AREA is "
+                        "unpinned (omit country_code and do not set REF_AREA to specific codes); "
+                        "filter was not applied."
+                    )
+
             return IndicatorDataResponse(
                 data=raw_data,
                 metadata=api_metadata,
@@ -1582,7 +1649,7 @@ async def get_data(
                 has_more=has_more,
                 next_offset=api_next_offset,
                 error=None,
-                failed_validation=validation_errors if validation_errors else None,
+                failed_validation=filter_notes if filter_notes else None,
             )
 
     except Exception as e:
@@ -1838,7 +1905,10 @@ async def _fetch_all_pages(
             _logger.warning(
                 "_fetch_all_pages: hit safety page limit (%d) for %s/%s after %d rows. "
                 "Returning partial results.",
-                _MAX_PAGES, database_id, indicator_id, len(all_rows),
+                _MAX_PAGES,
+                database_id,
+                indicator_id,
+                len(all_rows),
             )
             break
 
@@ -1859,7 +1929,10 @@ async def _fetch_all_pages(
                 return page
             _logger.warning(
                 "Pagination error at offset %d for %s/%s: %s",
-                offset, database_id, indicator_id, page.error,
+                offset,
+                database_id,
+                indicator_id,
+                page.error,
             )
             break
 
@@ -1908,7 +1981,11 @@ async def _resolve_country_names(codes: list[str]) -> dict[str, str]:
 # Disaggregation dimensions that may carry meaningful sub-categories.
 # UNIT_MEASURE is handled via a separate branch in the helper below.
 _DISAGG_DIMS_TO_DETECT: tuple[str, ...] = (
-    "SEX", "AGE", "URBANISATION", "COMP_BREAKDOWN_1", "COMP_BREAKDOWN_2",
+    "SEX",
+    "AGE",
+    "URBANISATION",
+    "COMP_BREAKDOWN_1",
+    "COMP_BREAKDOWN_2",
 )
 
 
@@ -1995,7 +2072,9 @@ async def _auto_detect_disagg_dimensions(
             auto_expanded_dims.append(field_name.lower())
         else:
             # Pin to _T (aggregate total) when available to avoid duplicate rows.
-            effective_filters[field_name] = "_T" if "_T" in values else non_total_values[0]
+            effective_filters[field_name] = (
+                "_T" if "_T" in values else non_total_values[0]
+            )
 
     return effective_filters, auto_expanded_dims
 
@@ -2085,10 +2164,8 @@ def _build_group_summary(
     # See docstring for rationale on TIME_PERIOD deduplication.
     df_sorted = df.sort_values("TIME_PERIOD").dropna(subset=["OBS_VALUE"])
     n_before_dedup = len(df_sorted)
-    df = (
-        df_sorted
-        .drop_duplicates(subset=["TIME_PERIOD"], keep="last")
-        .reset_index(drop=True)
+    df = df_sorted.drop_duplicates(subset=["TIME_PERIOD"], keep="last").reset_index(
+        drop=True
     )
     n_dropped = n_before_dedup - len(df)
     if n_dropped > 0:
@@ -2298,9 +2375,18 @@ async def summarize_data(
             if val is None:
                 # The upstream API omits disaggregation keys when their value is
                 # the default aggregate total (_T).
-                val = "_T" if f in (
-                    "SEX", "AGE", "URBANISATION", "COMP_BREAKDOWN_1", "COMP_BREAKDOWN_2"
-                ) else "_MISSING"
+                val = (
+                    "_T"
+                    if f
+                    in (
+                        "SEX",
+                        "AGE",
+                        "URBANISATION",
+                        "COMP_BREAKDOWN_1",
+                        "COMP_BREAKDOWN_2",
+                    )
+                    else "_MISSING"
+                )
             key_parts.append(str(val))
         key = tuple(key_parts)
         groups_dict.setdefault(key, []).append(row)
@@ -2334,6 +2420,7 @@ async def rank_countries(
     order: str = "desc",
     top_n: int = 10,
     disaggregation_filters: dict[str, str | None] | None = None,
+    rank_universe: Literal["explicit", "all_member_economies"] = "explicit",
 ) -> RankingResponse:
     """Rank countries by indicator value for a specific year.
 
@@ -2341,6 +2428,11 @@ async def rank_countries(
     "Which South Asian country has the lowest poverty rate?", "Rank Sub-Saharan African
     countries by life expectancy". Handles ties, missing data, and group expansion internally
     (calls data360_expand_country_group when country_group is provided).
+
+    **Global rankings ("top 10 in the world"):** set ``rank_universe='all_member_economies'``
+    and omit both ``country_group`` and ``country_codes``. The tool fetches unpinned
+    geographic data from the Data API (full REF_AREA coverage) and keeps only FMR leaf
+    member economies—regional aggregates such as ``EAS`` or ``EMU`` are excluded.
 
     When year is None, the tool selects the ranking year automatically. It considers both
     the latest available year and the year with broadest country coverage, and reports which
@@ -2359,7 +2451,10 @@ async def rank_countries(
         year: Ranking year. None = auto-select (see year_selection_note in response).
         order: "desc" (highest first) or "asc" (lowest first).
         top_n: Number of top results to return (default 10).
-        disaggregation_filters: Optional dimension filters.
+        disaggregation_filters: Optional dimension filters. Do not pin ``REF_AREA`` when
+            using ``rank_universe='all_member_economies'`` (it is ignored for the fetch).
+        rank_universe: ``explicit`` (default) requires ``country_codes`` or ``country_group``.
+            Use ``all_member_economies`` for worldwide leaderboards when both are omitted.
 
     Returns:
         RankingResponse:
@@ -2368,6 +2463,7 @@ async def rank_countries(
             order: "desc" or "asc".
             total_with_data: Countries that had data.
             total_requested: Countries attempted.
+            universe / universe_size: Scope metadata (see field descriptions).
             rankings: Ranked list with rank, ref_area, country_name, obs_value,
                 percentile, claim_id. Ties share the same rank.
             excluded: Countries with no data and reason.
@@ -2376,16 +2472,26 @@ async def rank_countries(
             error: Error message if request failed; otherwise None.
                 Falls back to data360_get_data if this tool encounters an error.
     """
-    from .providers import expand_country_group, get_group_hierarchy_manager  # noqa: PLC0415
+    from .providers import (  # noqa: PLC0415
+        expand_country_group,
+        get_group_hierarchy_manager,
+    )
 
-    # Resolve country codes
+    ghm = get_group_hierarchy_manager()
+    universe: str | None = None
+    universe_size: int | None = None
+    global_member_ranking = False
+
+    # Resolve country codes (explicit scope wins over rank_universe)
     resolved_codes: list[str] = []
     if country_codes:
-        resolved_codes = [c.strip() for c in country_codes.replace(";", ",").split(",") if c.strip()]
+        resolved_codes = [
+            c.strip() for c in country_codes.replace(";", ",").split(",") if c.strip()
+        ]
+        universe = "explicit"
     elif country_group:
         # Gate on is_group() before attempting expansion — this prevents silent
         # failures where an unrecognised code reaches the API and returns 0 rows.
-        ghm = get_group_hierarchy_manager()
         if not ghm.is_group(country_group):
             return RankingResponse(
                 error=(
@@ -2397,41 +2503,62 @@ async def rank_countries(
         try:
             expand_result = await expand_country_group(country_group)
             if isinstance(expand_result, dict) and expand_result.get("country_codes"):
-                resolved_codes = [c.strip() for c in expand_result["country_codes"].split(",") if c.strip()]
+                resolved_codes = [
+                    c.strip()
+                    for c in expand_result["country_codes"].split(",")
+                    if c.strip()
+                ]
             elif isinstance(expand_result, dict) and expand_result.get("error"):
                 return RankingResponse(error=expand_result["error"])
             else:
-                return RankingResponse(error=f"Could not expand country group '{country_group}'.")
+                return RankingResponse(
+                    error=f"Could not expand country group '{country_group}'."
+                )
         except Exception as e:
             return RankingResponse(error=f"Failed to expand country group: {e}")
-
-    if not resolved_codes:
+        universe = "explicit"
+    elif rank_universe == "all_member_economies":
+        resolved_codes = ghm.list_rankable_country_codes()
+        global_member_ranking = True
+        universe = "all_member_economies"
+    else:
         return RankingResponse(
-            error="No countries specified. Provide country_codes or country_group."
+            error=(
+                "No countries specified. Provide country_codes or country_group, "
+                "or set rank_universe='all_member_economies' to rank all World Bank "
+                "member economies (regional aggregates excluded)."
+            )
         )
 
     total_requested = len(resolved_codes)
+    universe_size = total_requested
+
+    filters_for_auto = dict(disaggregation_filters or {})
+    if global_member_ranking:
+        filters_for_auto.pop("REF_AREA", None)
 
     # Auto-detect UNIT_MEASURE and pin non-trivial disaggregation dims (SEX, AGE,
     # URBANISATION, COMP_BREAKDOWN_1/2) to their _T (aggregate total) value.
     # This prevents duplicate rows per country per year — which would otherwise
     # corrupt ranking statistics — when an indicator carries sex/age breakdowns.
     # Caller-provided disaggregation_filters always take precedence.
-    sample_country = resolved_codes[0] if resolved_codes else None
+    sample_country = resolved_codes[0] if resolved_codes else "WLD"
     effective_filters, _ = await _auto_detect_disagg_dimensions(
         database_id=database_id,
         indicator_id=indicator_id,
         sample_country=sample_country,
-        existing_filters=dict(disaggregation_filters or {}),
+        existing_filters=filters_for_auto,
         expand_non_trivial=False,
     )
+    if global_member_ranking and effective_filters:
+        effective_filters.pop("REF_AREA", None)
 
-    # Fetch all pages for all countries in one batched call
+    # Fetch all pages: explicit list uses REF_AREA pin; global uses unpinned full geography.
     try:
         data_response = await _fetch_all_pages(
             database_id=database_id,
             indicator_id=indicator_id,
-            country_code=";".join(resolved_codes),
+            country_code=(None if global_member_ranking else ";".join(resolved_codes)),
             disaggregation_filters=effective_filters or None,
             start_year=year - 2 if year else None,
             end_year=year + 1 if year else None,
@@ -2455,10 +2582,13 @@ async def rank_countries(
     for row in data_response.data:
         tp = str(row.get("TIME_PERIOD", ""))
         ra = str(row.get("REF_AREA", ""))
+        if global_member_ranking and not ghm.is_country(ra):
+            continue
         val = row.get("OBS_VALUE")
         cid = row.get("claim_id", "")
-        if tp and ra and val is not None:
-            year_country_map.setdefault(tp, {})[ra] = (float(val), cid)
+        obs = _obs_value_to_float(val)
+        if tp and ra and obs is not None:
+            year_country_map.setdefault(tp, {})[ra] = (obs, cid)
 
     # Select ranking year
     year_selection_note = None
@@ -2468,7 +2598,9 @@ async def rank_countries(
         # If exact year not available, try closest
         if ranking_year not in year_country_map:
             available = sorted(year_country_map.keys())
-            closest = min(available, key=lambda y: abs(int(y) - year)) if available else None
+            closest = (
+                min(available, key=lambda y: abs(int(y) - year)) if available else None
+            )
             if closest:
                 ranking_year = closest
                 year_selection_note = f"Requested {year}, closest available: {closest}"
@@ -2529,27 +2661,33 @@ async def rank_countries(
             # Different value — rank is one past the previous entry's position
             rank = i + 1
 
-        percentile = round(((n_ranked - i) / n_ranked) * 100, 1) if n_ranked > 0 else None
+        percentile = (
+            round(((n_ranked - i) / n_ranked) * 100, 1) if n_ranked > 0 else None
+        )
 
-        rankings.append(RankedCountry(
-            rank=rank,
-            ref_area=code,
-            country_name=name_map.get(code),
-            obs_value=round(val, 4),
-            percentile=percentile,
-            claim_id=cid,
-        ))
+        rankings.append(
+            RankedCountry(
+                rank=rank,
+                ref_area=code,
+                country_name=name_map.get(code),
+                obs_value=round(val, 4),
+                percentile=percentile,
+                claim_id=cid,
+            )
+        )
 
     # Build excluded list
     excluded = []
     countries_with_data = set(year_data.keys())
     for code in resolved_codes:
         if code not in countries_with_data:
-            excluded.append(ExcludedCountry(
-                ref_area=code,
-                country_name=name_map.get(code),
-                reason=f"No data for {ranking_year}",
-            ))
+            excluded.append(
+                ExcludedCountry(
+                    ref_area=code,
+                    country_name=name_map.get(code),
+                    reason=f"No data for {ranking_year}",
+                )
+            )
 
     return RankingResponse(
         year=ranking_year,
@@ -2557,6 +2695,8 @@ async def rank_countries(
         order=order,
         total_with_data=len(year_data),
         total_requested=total_requested,
+        universe=universe,
+        universe_size=universe_size,
         rankings=rankings,
         excluded=excluded,
         metadata=data_response.metadata,
@@ -2657,13 +2797,16 @@ async def compare_countries(
         tp = str(row.get("TIME_PERIOD", ""))
         val = row.get("OBS_VALUE")
         cid = row.get("claim_id", "")
-        if ra and tp and val is not None:
-            country_year_map.setdefault(ra, {})[tp] = (float(val), cid)
+        obs = _obs_value_to_float(val)
+        if ra and tp and obs is not None:
+            country_year_map.setdefault(ra, {})[tp] = (obs, cid)
 
     # Batch-resolve country names in a single call
     name_map = await _resolve_country_names(codes)
 
-    unit_measure = data_response.data[0].get("UNIT_MEASURE") if data_response.data else None
+    unit_measure = (
+        data_response.data[0].get("UNIT_MEASURE") if data_response.data else None
+    )
 
     # Determine snapshot year
     all_years = set()
@@ -2696,15 +2839,21 @@ async def compare_countries(
 
         ranked = []
         for i, (code, val, cid) in enumerate(snap_entries):
-            gap = round(((val - leader_val) / leader_val) * 100, 2) if leader_val != 0 else 0
-            ranked.append(RankedCountry(
-                rank=i + 1,
-                ref_area=code,
-                country_name=name_map.get(code),
-                obs_value=round(val, 4),
-                percentile=None,
-                claim_id=cid,
-            ))
+            gap = (
+                round(((val - leader_val) / leader_val) * 100, 2)
+                if leader_val != 0
+                else 0
+            )
+            ranked.append(
+                RankedCountry(
+                    rank=i + 1,
+                    ref_area=code,
+                    country_name=name_map.get(code),
+                    obs_value=round(val, 4),
+                    percentile=None,
+                    claim_id=cid,
+                )
+            )
 
         vals_s = pd.Series([e[1] for e in snap_entries], dtype=float)
         spread: dict[str, float | None] = {}
@@ -2721,7 +2870,9 @@ async def compare_countries(
             }
 
         snapshot = ComparisonSnapshot(
-            year=snap_year, rankings=ranked, spread=spread,
+            year=snap_year,
+            rankings=ranked,
+            spread=spread,
         )
 
     # Build time series (if requested) using pandas for alignment, CAGR, convergence
@@ -2750,7 +2901,11 @@ async def compare_countries(
         for code in codes:
             code_data = country_year_map.get(code, {})
             series[code] = [
-                {"time_period": y, "obs_value": code_data[y][0], "claim_id": code_data[y][1]}
+                {
+                    "time_period": y,
+                    "obs_value": code_data[y][0],
+                    "claim_id": code_data[y][1],
+                }
                 for y in aligned_years
                 if y in code_data
             ]
@@ -2783,7 +2938,11 @@ async def compare_countries(
             row_means = aligned_pivot[codes].mean(axis=1)
             row_stds = aligned_pivot[codes].std(axis=1, ddof=1)
             # CV per year — only where mean != 0
-            cvs_s = (row_stds / row_means).replace([float("inf"), float("-inf")], pd.NA).dropna()
+            cvs_s = (
+                (row_stds / row_means)
+                .replace([float("inf"), float("-inf")], pd.NA)
+                .dropna()
+            )
             if len(cvs_s) >= 3:
                 cv_trend = _compute_trend_direction(cvs_s.tolist())
                 convergence = {

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -9,13 +9,13 @@ from urllib.parse import urlencode
 
 import cachetools
 import dotenv
-import httpx
 import numpy as np
 import pandas as pd
 from pydantic import ValidationError as PydanticValidationError
 from sklearn.linear_model import HuberRegressor
 
 from .config import get_data360_settings
+from .http_client import get_shared_httpx_client
 from .errors import (
     Data360MCPError,
     NotFoundError,
@@ -481,23 +481,23 @@ async def _search_raw(
 
     mcp_error: Data360MCPError | None = None
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.post(url, json=payload)
-            response.raise_for_status()
+        client = get_shared_httpx_client()
+        response = await client.post(url, json=payload)
+        response.raise_for_status()
 
+        try:
+            response_data = response.json()
+        except ValueError as e:
+            mcp_error = ParseError(context="search", original_error=e)
+        else:
             try:
-                response_data = response.json()
-            except ValueError as e:
-                mcp_error = ParseError(context="search", original_error=e)
-            else:
-                try:
-                    return _process_search_response(response_data, request)
-                except Exception as e:
-                    mcp_error = ParseError(
-                        context="search",
-                        detail=f"Failed to parse API response: {str(e)}",
-                        original_error=e,
-                    )
+                return _process_search_response(response_data, request)
+            except Exception as e:
+                mcp_error = ParseError(
+                    context="search",
+                    detail=f"Failed to parse API response: {str(e)}",
+                    original_error=e,
+                )
 
     except Exception as e:
         mcp_error = classify_error(e, context="search")
@@ -1255,42 +1255,42 @@ async def get_metadata(
 
     # 1. Fetch Metadata
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            metadata_res = await client.post(
-                metadata_url, json=metadata_payload, headers=headers
-            )
-            metadata_res.raise_for_status()
+        client = get_shared_httpx_client()
+        metadata_res = await client.post(
+            metadata_url, json=metadata_payload, headers=headers
+        )
+        metadata_res.raise_for_status()
 
-            try:
-                metadata_json = metadata_res.json()
-                if metadata_json and metadata_json.get("value"):
-                    indicator_metadata = metadata_json["value"][0].get(
-                        "series_description", {}
-                    )
-                    # Inject database_name so clients always have the correct, grounded
-                    # label for the database_id — prevents LLMs from guessing
-                    # (e.g. WB_GS is "Gender Statistics", not "Global Statistics").
-                    if indicator_metadata:
-                        db_id = indicator_metadata.get("database_id", database_id)
-                        db_mapping = await get_database_mapping()
-                        indicator_metadata["database_name"] = db_mapping.get(db_id)
-                    # Force filtering if select_fields provided (API might return more).
-                    # Always retain database_name regardless of select_fields.
-                    if select_fields and indicator_metadata:
-                        indicator_metadata = {
-                            k: v
-                            for k, v in indicator_metadata.items()
-                            if k in select_fields or k == "database_name"
-                        }
-                else:
-                    mcp_err = NotFoundError(
-                        context="metadata",
-                        detail=f"No metadata found for indicator ID '{indicator_id}'",
-                    )
-                    errors.append(mcp_err.detail)
-            except ValueError as e:
-                mcp_err = ParseError(context="metadata", original_error=e)
+        try:
+            metadata_json = metadata_res.json()
+            if metadata_json and metadata_json.get("value"):
+                indicator_metadata = metadata_json["value"][0].get(
+                    "series_description", {}
+                )
+                # Inject database_name so clients always have the correct, grounded
+                # label for the database_id — prevents LLMs from guessing
+                # (e.g. WB_GS is "Gender Statistics", not "Global Statistics").
+                if indicator_metadata:
+                    db_id = indicator_metadata.get("database_id", database_id)
+                    db_mapping = await get_database_mapping()
+                    indicator_metadata["database_name"] = db_mapping.get(db_id)
+                # Force filtering if select_fields provided (API might return more).
+                # Always retain database_name regardless of select_fields.
+                if select_fields and indicator_metadata:
+                    indicator_metadata = {
+                        k: v
+                        for k, v in indicator_metadata.items()
+                        if k in select_fields or k == "database_name"
+                    }
+            else:
+                mcp_err = NotFoundError(
+                    context="metadata",
+                    detail=f"No metadata found for indicator ID '{indicator_id}'",
+                )
                 errors.append(mcp_err.detail)
+        except ValueError as e:
+            mcp_err = ParseError(context="metadata", original_error=e)
+            errors.append(mcp_err.detail)
 
     except Exception as e:
         mcp_err = classify_error(e, context="metadata")
@@ -1299,23 +1299,23 @@ async def get_metadata(
     # 2. Fetch Disaggregation
     if fetch_disaggregation:
         try:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                disagg_res = await client.get(
-                    disaggregation_url,
-                    params={"datasetId": database_id, "indicatorId": indicator_id},
-                    headers=headers,
-                )
-                disagg_res.raise_for_status()
+            client = get_shared_httpx_client()
+            disagg_res = await client.get(
+                disaggregation_url,
+                params={"datasetId": database_id, "indicatorId": indicator_id},
+                headers=headers,
+            )
+            disagg_res.raise_for_status()
 
-                try:
-                    raw_disaggregations = disagg_res.json()
-                    disaggregations = _strip_disaggregation(
-                        get_valid_disaggregations_func(raw_disaggregations),
-                        queried_countries,
-                    )
-                except ValueError as e:
-                    mcp_err = ParseError(context="disaggregation", original_error=e)
-                    errors.append(mcp_err.detail)
+            try:
+                raw_disaggregations = disagg_res.json()
+                disaggregations = _strip_disaggregation(
+                    get_valid_disaggregations_func(raw_disaggregations),
+                    queried_countries,
+                )
+            except ValueError as e:
+                mcp_err = ParseError(context="disaggregation", original_error=e)
+                errors.append(mcp_err.detail)
 
         except Exception as e:
             mcp_err = classify_error(e, context="disaggregation")
@@ -1385,23 +1385,23 @@ async def get_disaggregation(
     headers = {"accept": "*/*", "Content-Type": "application/json"}
 
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(
-                disaggregation_url,
-                params={"datasetId": database_id, "indicatorId": indicator_id},
-                headers=headers,
-            )
-            response.raise_for_status()
+        client = get_shared_httpx_client()
+        response = await client.get(
+            disaggregation_url,
+            params={"datasetId": database_id, "indicatorId": indicator_id},
+            headers=headers,
+        )
+        response.raise_for_status()
 
-            raw_data = response.json()
-            # Filter out _Z values and format response
-            valid_dimensions = _get_valid_disaggregations(raw_data)
-            result_disagg = {
-                "dimensions": _strip_disaggregation(valid_dimensions, queried_countries)
-            }
-            with _disaggregation_cache_lock:
-                _disaggregation_cache[_disagg_cache_key] = result_disagg
-            return result_disagg
+        raw_data = response.json()
+        # Filter out _Z values and format response
+        valid_dimensions = _get_valid_disaggregations(raw_data)
+        result_disagg = {
+            "dimensions": _strip_disaggregation(valid_dimensions, queried_countries)
+        }
+        with _disaggregation_cache_lock:
+            _disaggregation_cache[_disagg_cache_key] = result_disagg
+        return result_disagg
 
     except Exception as e:
         mcp_err = classify_error(e, context="disaggregation")
@@ -1571,86 +1571,86 @@ async def get_data(
     params.update(effective_disagg)
     ref_area_unpinned = not country_code and "REF_AREA" not in params
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            _logger.debug("Fetching data from %s with params: %s", data_url, params)
-            data_res = await client.get(data_url, params=params)
-            data_res.raise_for_status()
+        client = get_shared_httpx_client()
+        _logger.debug("Fetching data from %s with params: %s", data_url, params)
+        data_res = await client.get(data_url, params=params)
+        data_res.raise_for_status()
 
-            try:
-                data_json = data_res.json()
-            except ValueError as e:
-                mcp_err = ParseError(context="data", original_error=e)
-                return IndicatorDataResponse(data=None, error=mcp_err.detail)
+        try:
+            data_json = data_res.json()
+        except ValueError as e:
+            mcp_err = ParseError(context="data", original_error=e)
+            return IndicatorDataResponse(data=None, error=mcp_err.detail)
 
-            raw_data = data_json.get("value", [])
-            total_count = data_json.get("@odata.count")  # May be None
+        raw_data = data_json.get("value", [])
+        total_count = data_json.get("@odata.count")  # May be None
 
-            # Compute API-level pagination BEFORE any filtering
-            # This ensures next_offset correctly tracks position in the API result set
-            api_returned_count = len(raw_data)
-            has_more = api_returned_count > limit
+        # Compute API-level pagination BEFORE any filtering
+        # This ensures next_offset correctly tracks position in the API result set
+        api_returned_count = len(raw_data)
+        has_more = api_returned_count > limit
 
-            # Trim the extra detection row (we requested limit+1 to detect has_more)
-            if api_returned_count > limit:
-                raw_data = raw_data[:limit]
+        # Trim the extra detection row (we requested limit+1 to detect has_more)
+        if api_returned_count > limit:
+            raw_data = raw_data[:limit]
 
-            # Compute API-based next_offset - the true cursor position for next page
-            api_next_offset = offset + len(raw_data) if has_more else None
+        # Compute API-based next_offset - the true cursor position for next page
+        api_next_offset = offset + len(raw_data) if has_more else None
 
-            # Sort by TIME_PERIOD descending (most recent first)
-            raw_data.sort(key=lambda x: str(x.get("TIME_PERIOD", "")), reverse=True)
+        # Sort by TIME_PERIOD descending (most recent first)
+        raw_data.sort(key=lambda x: str(x.get("TIME_PERIOD", "")), reverse=True)
 
-            # Final limit enforcement (safety check)
-            if len(raw_data) > limit:
-                raw_data = raw_data[:limit]
+        # Final limit enforcement (safety check)
+        if len(raw_data) > limit:
+            raw_data = raw_data[:limit]
 
-            # Add claim_id for data verification (computed on raw row)
-            for row in raw_data:
-                row["claim_id"] = _short_hash(row)
+        # Add claim_id for data verification (computed on raw row)
+        for row in raw_data:
+            row["claim_id"] = _short_hash(row)
 
-            # Promote COMMENT_TS to metadata (repeats identically per row)
-            if raw_data and api_metadata is not None:
-                comment_ts = next(
-                    (r.get("COMMENT_TS") for r in raw_data if r.get("COMMENT_TS")),
-                    None,
+        # Promote COMMENT_TS to metadata (repeats identically per row)
+        if raw_data and api_metadata is not None:
+            comment_ts = next(
+                (r.get("COMMENT_TS") for r in raw_data if r.get("COMMENT_TS")),
+                None,
+            )
+            if comment_ts:
+                api_metadata["indicator_description"] = comment_ts
+
+        # Strip boilerplate fields for LLM token savings
+        raw_data = [_strip_data_row(row) for row in raw_data]
+
+        filter_notes: list[str] = (
+            list(validation_errors) if validation_errors else []
+        )
+        if ref_area_filter == "member_economies_only":
+            if ref_area_unpinned:
+                from .providers import get_group_hierarchy_manager  # noqa: PLC0415
+
+                _ghm = get_group_hierarchy_manager()
+                raw_data = [
+                    r
+                    for r in raw_data
+                    if _ghm.is_country(str(r.get("REF_AREA", "")))
+                ]
+            else:
+                filter_notes.append(
+                    "ref_area_filter=member_economies_only applies only when REF_AREA is "
+                    "unpinned (omit country_code and do not set REF_AREA to specific codes); "
+                    "filter was not applied."
                 )
-                if comment_ts:
-                    api_metadata["indicator_description"] = comment_ts
 
-            # Strip boilerplate fields for LLM token savings
-            raw_data = [_strip_data_row(row) for row in raw_data]
-
-            filter_notes: list[str] = (
-                list(validation_errors) if validation_errors else []
-            )
-            if ref_area_filter == "member_economies_only":
-                if ref_area_unpinned:
-                    from .providers import get_group_hierarchy_manager  # noqa: PLC0415
-
-                    _ghm = get_group_hierarchy_manager()
-                    raw_data = [
-                        r
-                        for r in raw_data
-                        if _ghm.is_country(str(r.get("REF_AREA", "")))
-                    ]
-                else:
-                    filter_notes.append(
-                        "ref_area_filter=member_economies_only applies only when REF_AREA is "
-                        "unpinned (omit country_code and do not set REF_AREA to specific codes); "
-                        "filter was not applied."
-                    )
-
-            return IndicatorDataResponse(
-                data=raw_data,
-                metadata=api_metadata,
-                count=len(raw_data),
-                total_count=total_count,
-                offset=offset,
-                has_more=has_more,
-                next_offset=api_next_offset,
-                error=None,
-                failed_validation=filter_notes if filter_notes else None,
-            )
+        return IndicatorDataResponse(
+            data=raw_data,
+            metadata=api_metadata,
+            count=len(raw_data),
+            total_count=total_count,
+            offset=offset,
+            has_more=has_more,
+            next_offset=api_next_offset,
+            error=None,
+            failed_validation=filter_notes if filter_notes else None,
+        )
 
     except Exception as e:
         mcp_err = classify_error(e, context="data")
@@ -1673,15 +1673,15 @@ async def get_indicators(database_id: str) -> list[str]:
     params = {"datasetId": database_id}
 
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(url, params=params)
-            response.raise_for_status()
+        client = get_shared_httpx_client()
+        response = await client.get(url, params=params)
+        response.raise_for_status()
 
-            data = response.json()
-            if isinstance(data, list):
-                # Data is a list of indicator ID strings
-                return data
-            return []
+        data = response.json()
+        if isinstance(data, list):
+            # Data is a list of indicator ID strings
+            return data
+        return []
 
     except Exception as e:
         _logger.error(f"Failed to fetch indicators for {database_id}: {e}")

--- a/src/data360/config.py
+++ b/src/data360/config.py
@@ -1,17 +1,19 @@
 import functools as ft
 import logging
 import os
-import sys
-from pathlib import Path
-
-from dotenv import load_dotenv
 
 # Load environment variables from .env file at import time, but only when not
 # running under pytest.  Test sessions set env vars explicitly via conftest/fixtures;
 # unconditional load_dotenv() would stomp on those values with whatever is in a
 # local .env file, making tests environment-dependent.
 import os as _os
-if not _os.environ.get("PYTEST_CURRENT_TEST"):
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Skip .env during pytest (collection and execution) so tests control DATA360_* URLs.
+if not _os.environ.get("PYTEST_CURRENT_TEST") and not _os.environ.get("PYTEST_RUNNING"):
     load_dotenv()
 del _os
 
@@ -48,7 +50,10 @@ class MCPServerSettings(BaseSettings):
     )
     env: str | None = Field(
         default=None,
-        description="Deployment environment (e.g. local, dev, staging, prod). Azure App Insights logging is disabled when set to 'local'.",
+        description="Deployment environment (e.g. local, dev, staging, prod). Azure App Insights "
+        "and OpenTelemetry export are disabled when set to 'local' unless you set "
+        "OTEL_EXPORTER_OTLP_ENDPOINT (or OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) and/or "
+        "MCP_OTEL_CONSOLE=1 for local trace export; see data360.otel_setup.",
     )
     azure_connection_string: str | None = Field(
         default=None,
@@ -113,8 +118,8 @@ class Data360Settings(BaseSettings):
 
     @property
     def api_url(self) -> str:
-        """Get the full search API URL."""
-        return f"{self.api_base_url}/data360/"
+        """Base path for Data360 HTTP APIs: ``{api_base_url}/data360`` (no trailing slash)."""
+        return f"{self.api_base_url.rstrip('/')}/data360"
 
 
 @ft.cache

--- a/src/data360/http_client.py
+++ b/src/data360/http_client.py
@@ -1,0 +1,31 @@
+"""Shared httpx.AsyncClient for connection reuse and consistent outbound behavior."""
+
+from __future__ import annotations
+
+import httpx
+
+_DEFAULT_TIMEOUT = 30.0
+
+_client: httpx.AsyncClient | None = None
+
+
+def get_shared_httpx_client() -> httpx.AsyncClient:
+    """Return a process-wide async HTTP client (lazy singleton)."""
+    global _client  # noqa: PLW0603
+    if _client is None:
+        _client = httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT)
+    return _client
+
+
+async def aclose_shared_httpx_client() -> None:
+    """Close the shared client (call from ASGI shutdown)."""
+    global _client  # noqa: PLW0603
+    if _client is not None:
+        await _client.aclose()
+        _client = None
+
+
+def reset_shared_httpx_client_for_tests() -> None:
+    """Sync reset for pytest (clears singleton without async close when unused)."""
+    global _client  # noqa: PLW0603
+    _client = None

--- a/src/data360/http_client.py
+++ b/src/data360/http_client.py
@@ -2,30 +2,44 @@
 
 from __future__ import annotations
 
+import threading
+
 import httpx
 
 _DEFAULT_TIMEOUT = 30.0
 
 _client: httpx.AsyncClient | None = None
+_client_lock = threading.Lock()
 
 
 def get_shared_httpx_client() -> httpx.AsyncClient:
     """Return a process-wide async HTTP client (lazy singleton)."""
     global _client  # noqa: PLW0603
-    if _client is None:
-        _client = httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT)
-    return _client
+    client = _client
+    if client is not None and not client.is_closed:
+        return client
+
+    with _client_lock:
+        client = _client
+        if client is None or client.is_closed:
+            client = httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT)
+            _client = client
+        return client
 
 
 async def aclose_shared_httpx_client() -> None:
     """Close the shared client (call from ASGI shutdown)."""
     global _client  # noqa: PLW0603
-    if _client is not None:
-        await _client.aclose()
+    with _client_lock:
+        client = _client
         _client = None
+
+    if client is not None and not client.is_closed:
+        await client.aclose()
 
 
 def reset_shared_httpx_client_for_tests() -> None:
     """Sync reset for pytest (clears singleton without async close when unused)."""
     global _client  # noqa: PLW0603
-    _client = None
+    with _client_lock:
+        _client = None

--- a/src/data360/http_client.py
+++ b/src/data360/http_client.py
@@ -37,9 +37,3 @@ async def aclose_shared_httpx_client() -> None:
     if client is not None and not client.is_closed:
         await client.aclose()
 
-
-def reset_shared_httpx_client_for_tests() -> None:
-    """Sync reset for pytest (clears singleton without async close when unused)."""
-    global _client  # noqa: PLW0603
-    with _client_lock:
-        _client = None

--- a/src/data360/mcp_server/prompts.py
+++ b/src/data360/mcp_server/prompts.py
@@ -79,7 +79,8 @@ Do not answer with guesses. Do not stop after describing a plan.
 4) If you need raw data values for a **specific point lookup or small dataset** → call data360_get_data.
    - **CRITICAL**: pass disaggregation_filters={"REF_AREA": "..."} when the user asked for a geography.
    - Multiple countries: {"REF_AREA": "KEN,TZA"} in **one** call — not one call per country.
-   - Do not call get_data with no REF_AREA filter unless you intentionally want global/world aggregates.
+   - Unpinned REF_AREA (no country_code / no REF_AREA string) returns **all geographic series** from the Data API, including regional aggregates (EAS, EMU, …). For **member economies only**, pass ref_area_filter="member_economies_only".
+   - Do not call get_data with no REF_AREA filter unless you want that full mix—or use ref_area_filter to narrow it.
    - The response already includes indicator name/definition in many cases; you may not need a separate metadata call only for the title.
    - **PAGINATION**: get_data returns ONE page. When has_more=True, call again with next_offset.
      EXCEPTION: If the query involves 20+ countries (e.g. from data360_expand_country_group), do NOT
@@ -102,9 +103,11 @@ Do not answer with guesses. Do not stop after describing a plan.
    └───────────────────────────────────────────────────────────────────────┘
 
    ┌─ RANKING (large group / top-N)? ──────────────────────────────────────┐
-   │  "Top 10 countries by X" / "Which country has the highest/lowest?"    │
+   │  **Within a region or group:**                                         │
    │  → data360_rank_countries(country_group="SAS", top_n=10)              │
-   │  Returns ordered list with percentiles + excluded countries.          │
+   │  **Worldwide / all economies:** omit country_group and country_codes; │
+   │  → data360_rank_countries(..., rank_universe="all_member_economies")  │
+   │  Returns ordered list + universe metadata; aggregates excluded.       │
    │  For expanded groups (SSF=48, HIC=83), this handles all pagination.  │
    └───────────────────────────────────────────────────────────────────────┘
 

--- a/src/data360/mcp_server/tool_spans.py
+++ b/src/data360/mcp_server/tool_spans.py
@@ -1,0 +1,40 @@
+"""OpenTelemetry parent spans for each MCP tool invocation (nests httpx child spans)."""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from collections.abc import Callable
+from typing import Any, cast
+
+from opentelemetry import trace
+
+_tracer = trace.get_tracer("data360.mcp.tools")
+
+
+def instrument_mcp_tool(fn: Callable[..., Any], *, tool_name: str) -> Callable[..., Any]:
+    """Wrap a tool function so each call runs under ``mcp.tool.<name>`` span."""
+    if inspect.iscoroutinefunction(fn):
+        fn_async = cast("Callable[..., Any]", fn)
+
+        @functools.wraps(fn_async)
+        async def _async_impl(*args: Any, **kwargs: Any) -> Any:
+            with _tracer.start_as_current_span(
+                f"mcp.tool.{tool_name}",
+                attributes={"mcp.tool.name": tool_name},
+            ):
+                return await fn_async(*args, **kwargs)
+
+        return _async_impl
+
+    fn_sync = cast("Callable[..., Any]", fn)
+
+    @functools.wraps(fn_sync)
+    def _sync_impl(*args: Any, **kwargs: Any) -> Any:
+        with _tracer.start_as_current_span(
+            f"mcp.tool.{tool_name}",
+            attributes={"mcp.tool.name": tool_name},
+        ):
+            return fn_sync(*args, **kwargs)
+
+    return _sync_impl

--- a/src/data360/mcp_server/tools.py
+++ b/src/data360/mcp_server/tools.py
@@ -10,69 +10,84 @@ from data360 import providers as data360_providers
 from data360 import visualization as data360_viz
 
 from ._server_definition import mcp
+from .tool_spans import instrument_mcp_tool
 
 search_indicators = mcp.tool(
-    data360_api.search,
+    instrument_mcp_tool(data360_api.search, tool_name="data360_search_indicators"),
     name="data360_search_indicators",
     description=data360_api.search.__doc__,
 )
 
 get_metadata = mcp.tool(
-    data360_api.get_metadata,
+    instrument_mcp_tool(data360_api.get_metadata, tool_name="data360_get_metadata"),
     name="data360_get_metadata",
     description=data360_api.get_metadata.__doc__,
 )
 
 get_data = mcp.tool(
-    data360_api.get_data,
+    instrument_mcp_tool(data360_api.get_data, tool_name="data360_get_data"),
     name="data360_get_data",
     description=data360_api.get_data.__doc__,
 )
 
 get_disaggregation = mcp.tool(
-    data360_api.get_disaggregation,
+    instrument_mcp_tool(
+        data360_api.get_disaggregation, tool_name="data360_get_disaggregation"
+    ),
     name="data360_get_disaggregation",
     description=data360_api.get_disaggregation.__doc__,
 )
 
 find_codelist_value = mcp.tool(
-    data360_providers.find_codelist_value,
+    instrument_mcp_tool(
+        data360_providers.find_codelist_value, tool_name="data360_find_codelist_value"
+    ),
     name="data360_find_codelist_value",
     description=data360_providers.find_codelist_value.__doc__,
 )
 
 list_indicators = mcp.tool(
-    data360_api.get_indicators,
+    instrument_mcp_tool(data360_api.get_indicators, tool_name="data360_list_indicators"),
     name="data360_list_indicators",
     description=data360_api.get_indicators.__doc__,
 )
 
 get_data_api_url = mcp.tool(
-    data360_api.get_data_api_url,
+    instrument_mcp_tool(
+        data360_api.get_data_api_url, tool_name="data360_get_data_api_url"
+    ),
     name="data360_get_data_api_url",
     description="[LOW-LEVEL] " + (data360_api.get_data_api_url.__doc__ or ""),
 )
 
 get_viz_spec = mcp.tool(
-    data360_viz.get_viz_spec,
+    instrument_mcp_tool(data360_viz.get_viz_spec, tool_name="data360_get_viz_spec"),
     name="data360_get_viz_spec",
     description=data360_viz.get_viz_spec.__doc__,
 )
 
 get_multi_indicator_viz_spec = mcp.tool(
-    data360_viz.get_multi_indicator_viz_spec,
+    instrument_mcp_tool(
+        data360_viz.get_multi_indicator_viz_spec,
+        tool_name="data360_get_multi_indicator_viz_spec",
+    ),
     name="data360_get_multi_indicator_viz_spec",
     description=data360_viz.get_multi_indicator_viz_spec.__doc__,
 )
 
 get_supported_chart_types = mcp.tool(
-    data360_viz.get_supported_chart_types,
+    instrument_mcp_tool(
+        data360_viz.get_supported_chart_types,
+        tool_name="data360_get_supported_chart_types",
+    ),
     name="data360_get_supported_chart_types",
     description=data360_viz.get_supported_chart_types.__doc__,
 )
 
 expand_country_group = mcp.tool(
-    data360_providers.expand_country_group,
+    instrument_mcp_tool(
+        data360_providers.expand_country_group, tool_name="data360_expand_country_group"
+    ),
     name="data360_expand_country_group",
     description=data360_providers.expand_country_group.__doc__,
 )
@@ -82,37 +97,41 @@ expand_country_group = mcp.tool(
 # ---------------------------------------------------------------------------
 
 summarize_data = mcp.tool(
-    data360_api.summarize_data,
+    instrument_mcp_tool(data360_api.summarize_data, tool_name="data360_summarize_data"),
     name="data360_summarize_data",
     description=data360_api.summarize_data.__doc__,
 )
 
 rank_countries = mcp.tool(
-    data360_api.rank_countries,
+    instrument_mcp_tool(data360_api.rank_countries, tool_name="data360_rank_countries"),
     name="data360_rank_countries",
     description=data360_api.rank_countries.__doc__,
 )
 
 compare_countries = mcp.tool(
-    data360_api.compare_countries,
+    instrument_mcp_tool(
+        data360_api.compare_countries, tool_name="data360_compare_countries"
+    ),
     name="data360_compare_countries",
     description=data360_api.compare_countries.__doc__,
 )
 
 compute_derived = mcp.tool(
-    data360_api.compute_derived,
+    instrument_mcp_tool(data360_api.compute_derived, tool_name="data360_compute_derived"),
     name="data360_compute_derived",
     description=data360_api.compute_derived.__doc__,
 )
 
 pivot_table = mcp.tool(
-    data360_api.pivot_table,
+    instrument_mcp_tool(data360_api.pivot_table, tool_name="data360_pivot_table"),
     name="data360_pivot_table",
     description=data360_api.pivot_table.__doc__,
 )
 
 diagnostic_summary = mcp.tool(
-    data360_api.diagnostic_summary,
+    instrument_mcp_tool(
+        data360_api.diagnostic_summary, tool_name="data360_diagnostic_summary"
+    ),
     name="data360_diagnostic_summary",
     description=data360_api.diagnostic_summary.__doc__,
 )

--- a/src/data360/models.py
+++ b/src/data360/models.py
@@ -341,7 +341,6 @@ class IndicatorDataResponse(MCPPagedResponse):
     )
 
 
-
 # ---------------------------------------------------------------------------
 # Data Aggregation Tool Models (Tier 1 — full implementation)
 # ---------------------------------------------------------------------------
@@ -356,16 +355,10 @@ class GroupSummary(BaseModel):
         '(e.g. {"ref_area": "KEN"} or {"ref_area": "KEN", "sex": "F"})',
     )
     count: int = Field(..., description="Number of observations in this group")
-    latest_value: float | None = Field(
-        None, description="Most recent obs_value"
-    )
+    latest_value: float | None = Field(None, description="Most recent obs_value")
     latest_year: str | None = Field(None, description="Year of latest_value")
-    earliest_value: float | None = Field(
-        None, description="Oldest obs_value in range"
-    )
-    earliest_year: str | None = Field(
-        None, description="Year of earliest_value"
-    )
+    earliest_value: float | None = Field(None, description="Oldest obs_value in range")
+    earliest_year: str | None = Field(None, description="Year of earliest_value")
     min: float | None = Field(None, description="Minimum obs_value")
     max: float | None = Field(None, description="Maximum obs_value")
     mean: float | None = Field(None, description="Arithmetic mean of obs_values")
@@ -448,9 +441,7 @@ class ExcludedCountry(BaseModel):
 class RankingResponse(BaseModel):
     """Response model for data360_rank_countries."""
 
-    year: str | None = Field(
-        None, description="The year used for ranking"
-    )
+    year: str | None = Field(None, description="The year used for ranking")
     year_selection_note: str | None = Field(
         None,
         description="Explains how the ranking year was chosen. "
@@ -460,11 +451,22 @@ class RankingResponse(BaseModel):
     order: str = Field(
         "desc", description="'desc' (highest first) or 'asc' (lowest first)"
     )
-    total_with_data: int = Field(
-        0, description="Number of countries that had data"
+    total_with_data: int = Field(0, description="Number of countries that had data")
+    total_requested: int = Field(0, description="Number of countries attempted")
+    universe: str | None = Field(
+        None,
+        description=(
+            "'explicit' when country_group or country_codes was used; "
+            "'all_member_economies' when ranking used full geographic fetch with "
+            "member-economy row filtering."
+        ),
     )
-    total_requested: int = Field(
-        0, description="Number of countries attempted"
+    universe_size: int | None = Field(
+        None,
+        description=(
+            "For explicit scope: same as total_requested. For all_member_economies: "
+            "count of known FMR leaf economies in the ranking universe."
+        ),
     )
     rankings: list[RankedCountry] = Field(
         default_factory=list, description="Ranked list of countries"
@@ -472,9 +474,7 @@ class RankingResponse(BaseModel):
     excluded: list[ExcludedCountry] = Field(
         default_factory=list, description="Countries with no data for ranking year"
     )
-    metadata: dict[str, Any] | None = Field(
-        None, description="Indicator metadata"
-    )
+    metadata: dict[str, Any] | None = Field(None, description="Indicator metadata")
     unit_measure: str | None = Field(None, description="Unit of measurement")
     error: str | None = Field(None, description="Error message if request failed")
 
@@ -522,7 +522,8 @@ class CountryComparisonResponse(BaseModel):
         None, description="Single-year ranked comparison"
     )
     time_series: ComparisonTimeSeries | None = Field(
-        None, description="Aligned time-series comparison (when include_time_series=True)"
+        None,
+        description="Aligned time-series comparison (when include_time_series=True)",
     )
     metadata: dict[str, Any] | None = Field(None, description="Indicator metadata")
     unit_measure: str | None = Field(None, description="Unit of measurement")
@@ -545,9 +546,7 @@ class DerivedDataResponse(BaseModel):
     data: list[dict[str, Any]] = Field(
         default_factory=list, description="Computed values"
     )
-    summary: str | None = Field(
-        None, description="Human-readable one-line summary"
-    )
+    summary: str | None = Field(None, description="Human-readable one-line summary")
     metadata: dict[str, Any] | None = Field(None, description="Indicator metadata")
     unit_measure: str | None = Field(None, description="Original unit")
     derived_unit: str | None = Field(
@@ -563,9 +562,7 @@ class PivotTableResponse(BaseModel):
     organized as a structured table with row/column dimensions.
     """
 
-    table: list[dict[str, Any]] = Field(
-        default_factory=list, description="Table rows"
-    )
+    table: list[dict[str, Any]] = Field(default_factory=list, description="Table rows")
     column_metadata: list[dict[str, Any]] = Field(
         default_factory=list, description="Per-column metadata"
     )

--- a/src/data360/otel_setup.py
+++ b/src/data360/otel_setup.py
@@ -1,0 +1,179 @@
+"""OpenTelemetry setup: Azure Monitor (deployed), OTLP/console (local), httpx outbound spans."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from data360.config import MCPServerSettings
+
+_logger = logging.getLogger(__name__)
+
+_HTTPX_INSTRUMENTED = False
+_MIN_TRANSPORT_PARTS_FOR_URL = 2
+
+
+def data360_operation_from_url(url: str | None) -> str:  # noqa: PLR0911
+    """Derive a stable operation label for spans from the outbound request URL (no query logged)."""
+    if not url:
+        return "http"
+    try:
+        path = urlparse(url).path.lower()
+    except Exception:
+        return "http"
+    if "searchv2" in path:
+        return "search"
+    if "metadata" in path:
+        return "metadata"
+    if "disaggregation" in path:
+        return "disaggregation"
+    # Avoid matching .../metadata/... "data" substring before generic data path
+    if path.rstrip("/").endswith("/data") or "/data360/data" in path:
+        return "data"
+    if "codelist" in path:
+        return "codelist"
+    if path.rstrip("/").endswith("/indicators"):
+        return "indicators"
+    if "chart" in path or "vega" in path:
+        return "charts"
+    return "http"
+
+
+def _httpx_request_hook(span, request: object) -> None:
+    """Attach Data360-specific attributes; never log bodies or full URLs with secrets."""
+    try:
+        if span is None:
+            return
+        is_recording = getattr(span, "is_recording", None)
+        if callable(is_recording) and not is_recording():
+            return
+        url_str: str | None = None
+        if isinstance(request, tuple) and len(request) >= _MIN_TRANSPORT_PARTS_FOR_URL:
+            url_str = str(request[1])
+        else:
+            req_any = cast("Any", request)
+            url_attr = getattr(req_any, "url", None)
+            if url_attr is not None:
+                url_str = str(url_attr)
+        op = data360_operation_from_url(url_str)
+        span.set_attribute("data360.operation", op)
+        if url_str:
+            try:
+                parsed = urlparse(url_str)
+                netloc = parsed.netloc.split("@")[-1]
+                span.set_attribute("server.address", netloc.split(":")[0])
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+
+def _httpx_response_hook(span, request: object, response: object) -> None:
+    """Record outcome; avoid logging bodies."""
+    try:
+        if span is None:
+            return
+        is_recording = getattr(span, "is_recording", None)
+        if callable(is_recording) and not is_recording():
+            return
+        status = getattr(response, "status_code", None)
+        if status is not None:
+            span.set_attribute("http.response.status_code", int(status))
+    except Exception:
+        pass
+
+
+def configure_open_telemetry_for_server(settings: MCPServerSettings) -> None:
+    """Configure trace export: Azure Monitor when deployed; OTLP or console when local."""
+    connection_string = settings.azure_connection_string or os.environ.get(
+        "APPLICATIONINSIGHTS_CONNECTION_STRING"
+    )
+    env = (settings.env or "").lower()
+
+    if env != "local" and connection_string:
+        try:
+            from azure.monitor.opentelemetry import (  # type: ignore[import-untyped]  # noqa: PLC0415
+                configure_azure_monitor,
+            )
+
+            configure_azure_monitor(connection_string=connection_string)
+            _logger.info("Azure Monitor OpenTelemetry configured.")
+        except ImportError:
+            _logger.warning("azure-monitor-opentelemetry not available.")
+        return
+
+    # Local / no Azure: optional OTLP (Jaeger, collector) or console exporter
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") or os.environ.get(
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+    )
+    console = os.environ.get("MCP_OTEL_CONSOLE", "").lower() in ("1", "true", "yes")
+
+    if not endpoint and not console:
+        _logger.debug(
+            "Local telemetry: no OTLP endpoint and MCP_OTEL_CONSOLE unset; "
+            "traces use noop unless OTEL_* env configures a provider elsewhere."
+        )
+        return
+
+    from opentelemetry import trace  # noqa: PLC0415
+    from opentelemetry.sdk.resources import SERVICE_NAME, Resource  # noqa: PLC0415
+    from opentelemetry.sdk.trace import TracerProvider  # noqa: PLC0415
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor  # noqa: PLC0415
+
+    service_name = os.environ.get("OTEL_SERVICE_NAME", "data360-mcp")
+    resource = Resource.create({SERVICE_NAME: service_name})
+    provider = TracerProvider(resource=resource)
+
+    if console:
+        from opentelemetry.sdk.trace.export import ConsoleSpanExporter  # noqa: PLC0415
+
+        provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+        _logger.info("OpenTelemetry console span export enabled (MCP_OTEL_CONSOLE).")
+
+    if endpoint:
+        try:
+            use_http = endpoint.startswith(("http://", "https://"))
+            proto = os.environ.get("OTEL_EXPORTER_OTLP_PROTOCOL", "").lower()
+            if proto in ("http/protobuf", "http/json"):
+                use_http = True
+            if use_http:
+                from opentelemetry.exporter.otlp.proto.http.trace_exporter import (  # noqa: PLC0415
+                    OTLPSpanExporter,
+                )
+            else:
+                from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (  # noqa: PLC0415
+                    OTLPSpanExporter,
+                )
+
+            exporter = OTLPSpanExporter()
+            provider.add_span_processor(BatchSpanProcessor(exporter))
+            _logger.info(
+                "OpenTelemetry OTLP trace export enabled (endpoint from OTEL_EXPORTER_OTLP_*)."
+            )
+        except Exception:
+            _logger.exception("Failed to configure OTLP trace exporter; traces may be incomplete.")
+
+    trace.set_tracer_provider(provider)
+
+
+def instrument_httpx_outbound() -> None:
+    """Patch httpx so all AsyncClient/Client requests emit dependency spans."""
+    global _HTTPX_INSTRUMENTED  # noqa: PLW0603
+    if _HTTPX_INSTRUMENTED:
+        return
+    try:
+        from opentelemetry.instrumentation.httpx import (  # noqa: PLC0415
+            HTTPXClientInstrumentor,
+        )
+
+        HTTPXClientInstrumentor().instrument(
+            request_hook=_httpx_request_hook,
+            response_hook=_httpx_response_hook,
+        )
+        _HTTPX_INSTRUMENTED = True
+        _logger.info("HTTPX OpenTelemetry instrumentation enabled.")
+    except ImportError:
+        _logger.warning("opentelemetry-instrumentation-httpx not installed.")

--- a/src/data360/providers.py
+++ b/src/data360/providers.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Any
@@ -10,6 +11,7 @@ from typing import Any
 import httpx
 
 from data360.config import get_data360_settings
+from data360.http_client import get_shared_httpx_client
 
 data360_config = get_data360_settings()
 
@@ -62,6 +64,8 @@ class DatabaseManager:
 
     def _ensure_background_sync(self) -> None:
         """Spawn the background refresh loop if it is not already running."""
+        if os.environ.get("PYTEST_RUNNING"):
+            return
         if self._bg_task is None or self._bg_task.done():
             self._bg_task = asyncio.create_task(self._background_sync_loop())
 
@@ -88,65 +92,65 @@ class DatabaseManager:
 
     async def _fetch_all(self) -> dict[str, str]:
         """Fetch all datasets from the search endpoint using pagination."""
-        url = f"{data360_config.api_url}searchv2"
+        url = data360_config.search_url or f"{data360_config.api_url}/searchv2"
         mapping: dict[str, str] = {}
         skip = 0
         limit = 50
 
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            while True:
-                items = None
-                last_error = None
-                for attempt in range(3):
-                    try:
-                        response = await client.post(
-                            url,
-                            headers={
-                                "accept": "*/*",
-                                "Content-Type": "application/json",
-                            },
-                            json={
-                                "filter": "type eq 'dataset' and (is_active ne false or is_active eq null)",
-                                "orderby": "series_description/name",
-                                "select": "series_description/database_id, series_description/name",
-                                "skip": skip,
-                                "top": limit,
-                            },
-                        )
-                        response.raise_for_status()
-                        data = response.json()
-                        items = data.get("value", [])
-                        break  # Success
-                    except Exception as e:
-                        last_error = e
-                        _logger.warning(
-                            "Fetch attempt %d failed for skip=%d: %s",
-                            attempt + 1,
-                            skip,
-                            e,
-                        )
-                        if attempt < 2:
-                            await asyncio.sleep(2**attempt)  # Backoff: 1s, 2s
-
-                if items is None:
-                    # All attempts failed
-                    raise (
-                        last_error
-                        if last_error
-                        else Exception("Unknown error during fetch")
+        client = get_shared_httpx_client()
+        while True:
+            items = None
+            last_error = None
+            for attempt in range(3):
+                try:
+                    response = await client.post(
+                        url,
+                        headers={
+                            "accept": "*/*",
+                            "Content-Type": "application/json",
+                        },
+                        json={
+                            "filter": "type eq 'dataset' and (is_active ne false or is_active eq null)",
+                            "orderby": "series_description/name",
+                            "select": "series_description/database_id, series_description/name",
+                            "skip": skip,
+                            "top": limit,
+                        },
                     )
+                    response.raise_for_status()
+                    data = response.json()
+                    items = data.get("value", [])
+                    break  # Success
+                except Exception as e:
+                    last_error = e
+                    _logger.warning(
+                        "Fetch attempt %d failed for skip=%d: %s",
+                        attempt + 1,
+                        skip,
+                        e,
+                    )
+                    if attempt < 2:
+                        await asyncio.sleep(2**attempt)  # Backoff: 1s, 2s
 
-                if not items:
-                    break
+            if items is None:
+                # All attempts failed
+                raise (
+                    last_error
+                    if last_error
+                    else Exception("Unknown error during fetch")
+                )
 
-                for x in items:
-                    sd = x.get("series_description", {})
-                    db_id = sd.get("database_id")
-                    db_name = sd.get("name")
-                    if db_id and db_name and db_id not in mapping:
-                        mapping[db_id] = db_name
+            if not items:
+                break
 
-                skip += limit
+            for x in items:
+                sd = x.get("series_description", {})
+                db_id = sd.get("database_id")
+                db_name = sd.get("name")
+                if db_id and db_name and db_id not in mapping:
+                    mapping[db_id] = db_name
+
+            skip += limit
 
         return mapping
 
@@ -395,6 +399,8 @@ class GroupHierarchyManager:
         or during module import). The bundled JSON is always pre-loaded, so
         the background task is only an update mechanism, not a prerequisite.
         """
+        if os.environ.get("PYTEST_RUNNING"):
+            return
         try:
             asyncio.get_running_loop()
         except RuntimeError:
@@ -473,15 +479,15 @@ class GroupHierarchyManager:
         hierarchy_url = _FMR_HIERARCHY_URL.format(version=hierarchy_version)
         codelist_url = _FMR_CODELIST_URL.format(version=codelist_version)
 
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            h_resp, cl_resp = await asyncio.gather(
-                client.get(hierarchy_url, headers={"Accept": "application/json"}),
-                client.get(codelist_url, headers={"Accept": "application/json"}),
-            )
-            h_resp.raise_for_status()
-            cl_resp.raise_for_status()
-            hierarchy_data = h_resp.json()
-            codelist_data = cl_resp.json()
+        client = get_shared_httpx_client()
+        h_resp, cl_resp = await asyncio.gather(
+            client.get(hierarchy_url, headers={"Accept": "application/json"}),
+            client.get(codelist_url, headers={"Accept": "application/json"}),
+        )
+        h_resp.raise_for_status()
+        cl_resp.raise_for_status()
+        hierarchy_data = h_resp.json()
+        codelist_data = cl_resp.json()
 
         name_map = self.parse_name_map(codelist_data)
         return self.parse_hierarchy(hierarchy_data, name_map, self._include_types)
@@ -674,19 +680,19 @@ class CodelistManager:
 
     async def _load_from_api(self, codelist_type: str) -> None:
         """Fetch a global codelist from the API."""
-        url = f"{data360_config.api_url}codelist"
+        url = f"{data360_config.api_url}/codelist"
         params = {"type": codelist_type}
 
         try:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.get(url, params=params)
-                response.raise_for_status()
-                data = response.json()
-                self._cache[codelist_type] = data.get("value", [])
-                self._loaded.add(codelist_type)
-                _logger.info(
-                    f"Loaded {len(self._cache[codelist_type])} items for {codelist_type}"
-                )
+            client = get_shared_httpx_client()
+            response = await client.get(url, params=params)
+            response.raise_for_status()
+            data = response.json()
+            self._cache[codelist_type] = data.get("value", [])
+            self._loaded.add(codelist_type)
+            _logger.info(
+                f"Loaded {len(self._cache[codelist_type])} items for {codelist_type}"
+            )
         except httpx.HTTPStatusError as e:
             error_msg = f"HTTP error fetching {codelist_type} codelist: {e.response.status_code}"
             _logger.error(error_msg)

--- a/src/data360/providers.py
+++ b/src/data360/providers.py
@@ -15,6 +15,7 @@ data360_config = get_data360_settings()
 
 _logger = logging.getLogger(__name__)
 
+
 class DatabaseManager:
     """Manages the list of databases dynamically fetched from the Data360 API.
 
@@ -37,9 +38,7 @@ class DatabaseManager:
         try:
             with open(fallback_path, encoding="utf-8") as f:
                 self._cache = json.load(f)
-            _logger.info(
-                "Loaded %d databases from fallback JSON.", len(self._cache)
-            )
+            _logger.info("Loaded %d databases from fallback JSON.", len(self._cache))
         except Exception as e:
             _logger.error("Failed to load fallback database mapping: %s", e)
             self._cache = {}
@@ -102,7 +101,10 @@ class DatabaseManager:
                     try:
                         response = await client.post(
                             url,
-                            headers={"accept": "*/*", "Content-Type": "application/json"},
+                            headers={
+                                "accept": "*/*",
+                                "Content-Type": "application/json",
+                            },
                             json={
                                 "filter": "type eq 'dataset' and (is_active ne false or is_active eq null)",
                                 "orderby": "series_description/name",
@@ -117,13 +119,22 @@ class DatabaseManager:
                         break  # Success
                     except Exception as e:
                         last_error = e
-                        _logger.warning("Fetch attempt %d failed for skip=%d: %s", attempt + 1, skip, e)
+                        _logger.warning(
+                            "Fetch attempt %d failed for skip=%d: %s",
+                            attempt + 1,
+                            skip,
+                            e,
+                        )
                         if attempt < 2:
-                            await asyncio.sleep(2 ** attempt)  # Backoff: 1s, 2s
+                            await asyncio.sleep(2**attempt)  # Backoff: 1s, 2s
 
                 if items is None:
                     # All attempts failed
-                    raise last_error if last_error else Exception("Unknown error during fetch")
+                    raise (
+                        last_error
+                        if last_error
+                        else Exception("Unknown error during fetch")
+                    )
 
                 if not items:
                     break
@@ -183,19 +194,19 @@ async def get_database_mapping() -> dict[str, str]:
 # ---------------------------------------------------------------------------
 _GROUP_ALIASES: dict[str, str] = {
     # Category 1: "and" vs "&" — fuzzy fails because "&" != "and"
-    "east asia and pacific": "EAS",           # official: "East Asia & Pacific"
-    "europe and central asia": "ECS",          # official: "Europe & Central Asia"
+    "east asia and pacific": "EAS",  # official: "East Asia & Pacific"
+    "europe and central asia": "ECS",  # official: "Europe & Central Asia"
     "latin america and the caribbean": "LCN",  # official: "Latin America & Caribbean"
-    "middle east and north africa": "MEA",     # official: "Middle East, North Africa, Afghanistan & Pakistan"
-    "middle east & north africa": "MEA",       # same but omits "Afghanistan & Pakistan"
-    "low and middle income": "LMY",            # official: "Low & middle income"
+    "middle east and north africa": "MEA",  # official: "Middle East, North Africa, Afghanistan & Pakistan"
+    "middle east & north africa": "MEA",  # same but omits "Afghanistan & Pakistan"
+    "low and middle income": "LMY",  # official: "Low & middle income"
     # Category 2: abbreviation not in official name
-    "mena": "MEA",                             # common abbreviation for the region
+    "mena": "MEA",  # common abbreviation for the region
     # Category 3: shorthands whose words don't appear in the official name
-    "fragile states": "FCS",                   # official: "Fragile and conflict affected situations"
-    "small island states": "SST",              # official: "Small states"
-    "eastern africa": "AFE",                   # official: "Africa Eastern and Southern"
-    "western africa": "AFW",                   # official: "Africa Western and Central"
+    "fragile states": "FCS",  # official: "Fragile and conflict affected situations"
+    "small island states": "SST",  # official: "Small states"
+    "eastern africa": "AFE",  # official: "Africa Eastern and Southern"
+    "western africa": "AFW",  # official: "Africa Western and Central"
     # Category 4: semantic synonym — "lower" absent from "Low income"
     "lower income": "LIC",
 }
@@ -489,6 +500,17 @@ class GroupHierarchyManager:
         """Return True if the code is an individual country in the hierarchy."""
         self._ensure_loaded()
         return code.upper() in self._all_countries and not self.is_group(code.upper())
+
+    def list_rankable_country_codes(self) -> list[str]:
+        """Return sorted leaf economy codes (FMR member countries, excluding group aggregates).
+
+        Used for ranking metadata and for ``member_economies_only`` filtering; the Data API
+        may still return additional aggregate codes when ``REF_AREA`` is unpinned—those
+        should be dropped with :meth:`is_country` per row.
+        """
+        self._ensure_loaded()
+        self._ensure_background_sync()
+        return sorted(c for c in self._all_countries if self.is_country(c))
 
     def get_group_info(self, code: str) -> dict[str, Any] | None:
         """Return {name, type, countries} for a group code, or None if unknown."""
@@ -1086,8 +1108,7 @@ async def expand_country_group(
         )
 
     countries = [
-        {"code": c, "name": country_name_map.get(c, c)}
-        for c in info["countries"]
+        {"code": c, "name": country_name_map.get(c, c)} for c in info["countries"]
     ]
 
     meta = ghm.get_meta()

--- a/src/data360/server.py
+++ b/src/data360/server.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import uuid
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 
 from fastapi import FastAPI, Request
@@ -10,7 +11,11 @@ from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from data360.config import get_mcp_server_settings, setup_logging
-from data360.mcp_server import mcp
+from data360.http_client import aclose_shared_httpx_client
+from data360.otel_setup import (
+    configure_open_telemetry_for_server,
+    instrument_httpx_outbound,
+)
 
 _audit_logger = logging.getLogger("audit")
 
@@ -23,19 +28,16 @@ setup_logging(
     azure_connection_string=mcp_settings.azure_connection_string,
 )
 
-# Configure Azure Monitor OpenTelemetry for request/dependency tracking
+# Tracer export (Azure in deployed envs; optional OTLP/console when MCP_ENV=local) and httpx spans
+configure_open_telemetry_for_server(mcp_settings)
+instrument_httpx_outbound()
+
+# Import MCP after telemetry so the process uses an instrumented httpx from the first request.
+from data360.mcp_server import mcp  # noqa: E402
+
 _connection_string = mcp_settings.azure_connection_string or os.environ.get(
     "APPLICATIONINSIGHTS_CONNECTION_STRING"
 )
-if mcp_settings.env != "local" and _connection_string:
-    try:
-        from azure.monitor.opentelemetry import (
-            configure_azure_monitor,  # type: ignore[import-untyped]
-        )
-
-        configure_azure_monitor(connection_string=_connection_string)
-    except ImportError:
-        pass
 
 
 class AuditLogMiddleware(BaseHTTPMiddleware):
@@ -88,11 +90,20 @@ mcp.settings.stateless_http = True
 # path="/mcp" means the MCP endpoint lives at /mcp (no trailing slash needed)
 mcp_app = mcp.http_app(path="/mcp")
 
+
+@asynccontextmanager
+async def _lifespan_with_http_cleanup(app: FastAPI):
+    """Run MCP startup/shutdown, then close the shared httpx client."""
+    async with mcp_app.router.lifespan_context(mcp_app):
+        yield
+    await aclose_shared_httpx_client()
+
+
 # https://gofastmcp.com/deployment/http#asgi-application
 # redirect_slashes=False prevents 308 redirects between /mcp and /mcp/
 app = FastAPI(
     title="Data360 MCP Server",
-    lifespan=mcp_app.lifespan,
+    lifespan=_lifespan_with_http_cleanup,
     redirect_slashes=False,
 )  # pyright: ignore[reportUnusedExpression]
 

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -35,6 +35,8 @@ from urllib.parse import parse_qs, urlparse
 
 import altair as alt
 import httpx
+
+from data360.http_client import get_shared_httpx_client
 import numpy as np
 import pandas as pd
 from draco import Draco, answer_set_to_dict, dict_to_facts, schema_from_dataframe
@@ -97,13 +99,13 @@ async def post_spec_to_charts_api(vl_spec: dict) -> str:
     headers = {"accept": "application/json", "Content-Type": "application/json"}
     if settings.charts_api_token:
         headers["Authorization"] = f"Bearer {settings.charts_api_token}"
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        response = await client.post(
-            url,
-            json=payload,
-            headers=headers,
-        )
-        response.raise_for_status()
+    client = get_shared_httpx_client()
+    response = await client.post(
+        url,
+        json=payload,
+        headers=headers,
+    )
+    response.raise_for_status()
     location = response.headers.get("Location")
     if location:
         return (
@@ -285,10 +287,10 @@ def _sanitize_dataframe_for_json_records(df: pd.DataFrame) -> pd.DataFrame:
 
 
 async def _fetch_data_internal(url: str) -> pd.DataFrame:
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        response = await client.get(url)
-        response.raise_for_status()
-        data = response.json()
+    client = get_shared_httpx_client()
+    response = await client.get(url)
+    response.raise_for_status()
+    data = response.json()
     raw_data = data.get("value", [])
     if not raw_data:
         raise ValueError("No data found at the provided URL.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,11 +26,11 @@ from data360.api import (
     _metadata_cache,
     _metadata_cache_lock,
 )
-from data360.http_client import reset_shared_httpx_client_for_tests
+from data360.http_client import aclose_shared_httpx_client
 
 
 @pytest.fixture(autouse=True)
-def _isolate_data360_api_state():
+async def _isolate_data360_api_state():
     """Clear API TTL caches and shared httpx so tests do not share mocked responses."""
     if os.environ.get("PYTEST_RUNNING"):
         with _metadata_cache_lock:
@@ -43,4 +43,4 @@ def _isolate_data360_api_state():
             _metadata_cache.clear()
         with _disaggregation_cache_lock:
             _disaggregation_cache.clear()
-    reset_shared_httpx_client_for_tests()
+    await aclose_shared_httpx_client()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,58 +1,46 @@
-"""Pytest configuration and shared fixtures."""
+"""Pytest configuration — test API host and shared httpx client isolation."""
 
-from unittest.mock import patch
+from __future__ import annotations
+
+import os
+
+# Must run before any import of data360.config (skip load_dotenv in config.py).
+os.environ["PYTEST_RUNNING"] = "1"
+_test_api = "https://api.test.example.com"
+os.environ.setdefault("DATA360_API_BASE_URL", _test_api)
+os.environ.setdefault(
+    "DATA360_CODELIST_API_BASE_URL",
+    f"{_test_api}/codelist",
+)
+# Match httpx_mock URLs in tests (short paths without /data360/).
+os.environ.setdefault("DATA360_SEARCH_URL", f"{_test_api}/searchv2")
+os.environ.setdefault("DATA360_METADATA_URL", f"{_test_api}/metadata")
+os.environ.setdefault("DATA360_DISAGGREGATION_URL", f"{_test_api}/disaggregation")
+os.environ.setdefault("DATA360_DATA_URL", f"{_test_api}/data")
 
 import pytest
 
-from data360.config import Data360Settings
-
-
-@pytest.fixture
-def mock_data360_settings():
-    """Mock Data360Settings for testing."""
-    return Data360Settings(
-        api_base_url="https://api.test.example.com",
-        codelist_api_base_url="https://api.test.example.com/codelist",
-        search_url="https://api.test.example.com/searchv2",
-        metadata_url="https://api.test.example.com/metadata",
-        disaggregation_url="https://api.test.example.com/disaggregation",
-        data_url="https://api.test.example.com/data",
-    )
+from data360.api import (
+    _disaggregation_cache,
+    _disaggregation_cache_lock,
+    _metadata_cache,
+    _metadata_cache_lock,
+)
+from data360.http_client import reset_shared_httpx_client_for_tests
 
 
 @pytest.fixture(autouse=True)
-def mock_database_mapping():
-    """Mock the dynamic database mapping fetch from search API so we don't break existing tests that mock the search endpoint."""
-    with patch(
-        "data360.providers.DatabaseManager.get_mapping",
-        return_value={"WB_WDI": "World Development Indicators", "WB_GS": "Gender Statistics"}
-    ) as mock:
-        yield mock
-
-
-@pytest.fixture(autouse=True)
-def patch_data360_config(mock_data360_settings):
-    """Automatically patch the data360 config in all tests."""
-    # Patch both the function and the module-level config variable
-    with patch("data360.api.get_data360_settings", return_value=mock_data360_settings):
-        with patch(
-            "data360.config.get_data360_settings", return_value=mock_data360_settings
-        ):
-            with patch("data360.api.data360_config", mock_data360_settings):
-                yield mock_data360_settings
-
-
-@pytest.fixture(autouse=True)
-def clear_api_caches():
-    """Clear module-level TTL caches before each test.
-
-    The metadata and disaggregation caches in data360.api persist across tests
-    at module scope. Without this fixture, a test that mocks an HTTP response
-    and populates the cache will cause the next test (with a different mock) to
-    receive the cached value instead of hitting its own mock, producing false
-    results.
-    """
-    import data360.api as api_module  # noqa: PLC0415
-    api_module._metadata_cache.clear()
-    api_module._disaggregation_cache.clear()
+def _isolate_data360_api_state():
+    """Clear API TTL caches and shared httpx so tests do not share mocked responses."""
+    if os.environ.get("PYTEST_RUNNING"):
+        with _metadata_cache_lock:
+            _metadata_cache.clear()
+        with _disaggregation_cache_lock:
+            _disaggregation_cache.clear()
     yield
+    if os.environ.get("PYTEST_RUNNING"):
+        with _metadata_cache_lock:
+            _metadata_cache.clear()
+        with _disaggregation_cache_lock:
+            _disaggregation_cache.clear()
+    reset_shared_httpx_client_for_tests()

--- a/tests/test_aggregation_tools.py
+++ b/tests/test_aggregation_tools.py
@@ -11,7 +11,7 @@ Covers the functionality gaps identified in the code review:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -287,6 +287,93 @@ class TestRankCountriesTieHandling:
         result = await rank_countries("WB_WDI", "IND_ID")
         assert result.error is not None
         assert "No countries specified" in result.error
+        assert "rank_universe" in result.error
+
+    @pytest.mark.asyncio
+    async def test_all_member_economies_filters_aggregate_rows(self):
+        """Global ranking: unpinned fetch includes aggregates; is_country keeps leaf rows."""
+        rows = [
+            _make_row("EAS", "2022", 999999.0),
+            _make_row("KEN", "2022", 50.0),
+            _make_row("NGA", "2022", 200.0),
+        ]
+        full_page = _make_data_page(rows, has_more=False)
+
+        async def fake_fetch_all(**kwargs):
+            assert kwargs.get("country_code") is None
+            return full_page
+
+        async def fake_resolve(codes):
+            return {c: c for c in codes}
+
+        async def fake_disagg(**kwargs):
+            return {"dimensions": []}
+
+        mock_ghm = MagicMock()
+        mock_ghm.list_rankable_country_codes.return_value = ["KEN", "NGA", "BRA"]
+        mock_ghm.is_country.side_effect = lambda code: code in ("KEN", "NGA", "BRA")
+        mock_ghm.is_group.return_value = False
+
+        with (
+            patch("data360.api._fetch_all_pages", side_effect=fake_fetch_all),
+            patch("data360.api._resolve_country_names", side_effect=fake_resolve),
+            patch("data360.api.get_disaggregation", side_effect=fake_disagg),
+            patch(
+                "data360.providers.get_group_hierarchy_manager",
+                return_value=mock_ghm,
+            ),
+        ):
+            result = await rank_countries(
+                "WB_WDI",
+                "IND_ID",
+                rank_universe="all_member_economies",
+                order="desc",
+                top_n=5,
+            )
+
+        assert result.error is None
+        assert result.universe == "all_member_economies"
+        assert result.universe_size == 3
+        assert len(result.rankings) == 2
+        assert result.rankings[0].ref_area == "NGA"
+        assert result.rankings[1].ref_area == "KEN"
+        assert len(result.excluded) == 1
+        assert result.excluded[0].ref_area == "BRA"
+
+    @pytest.mark.asyncio
+    async def test_rank_skips_string_null_obs_value(self):
+        """API may send OBS_VALUE as the string 'null'; ranking must not crash."""
+        rows = [
+            {**_make_row("KEN", "2022", 0.0), "OBS_VALUE": "null"},
+            _make_row("NGA", "2022", 7.0),
+        ]
+        full_page = _make_data_page(rows, has_more=False)
+
+        async def fake_fetch_all(**kwargs):
+            return full_page
+
+        async def fake_resolve(codes):
+            return {c: c for c in codes}
+
+        async def fake_disagg(**kwargs):
+            return {"dimensions": []}
+
+        with (
+            patch("data360.api._fetch_all_pages", side_effect=fake_fetch_all),
+            patch("data360.api._resolve_country_names", side_effect=fake_resolve),
+            patch("data360.api.get_disaggregation", side_effect=fake_disagg),
+        ):
+            result = await rank_countries(
+                "WB_WDI",
+                "IND_ID",
+                country_codes="KEN;NGA",
+                top_n=5,
+            )
+
+        assert result.error is None
+        assert len(result.rankings) == 1
+        assert result.rankings[0].ref_area == "NGA"
+        assert any(e.ref_area == "KEN" for e in result.excluded)
 
     @pytest.mark.asyncio
     async def test_tie_gives_same_rank_to_tied_countries(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -922,6 +922,44 @@ class TestGetDataResilience:
         assert "REF_AREA=KEN%2CMAR" in captured_urls[0] or "REF_AREA=KEN,MAR" in captured_urls[0]
         assert result.data is not None
 
+    @pytest.mark.asyncio
+    async def test_get_data_ref_area_filter_drops_aggregates_when_unpinned(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
+        """member_economies_only removes regional aggregate rows from an unpinned REF_AREA page."""
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.test.example.com/metadata",
+            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL", "name": "Pop"}}]},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(r".*/disaggregation.*"),
+            json=[],
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(r".*/data\?.*"),
+            json={
+                "value": [
+                    {"REF_AREA": "EAS", "TIME_PERIOD": "2020", "OBS_VALUE": 1e9},
+                    {"REF_AREA": "KEN", "TIME_PERIOD": "2020", "OBS_VALUE": 5000},
+                ]
+            },
+        )
+
+        result = await get_data(
+            "WB_WDI",
+            "WB_WDI_SP_POP_TOTL",
+            ref_area_filter="member_economies_only",
+        )
+
+        assert result.error is None
+        assert result.data is not None
+        areas = {r["REF_AREA"] for r in result.data}
+        assert "EAS" not in areas
+        assert "KEN" in areas
+
 
 class TestDatabaseNameInSearch:
     """Tests that search results carry the correct database_name for each indicator."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1040,6 +1040,9 @@ class TestDatabaseNameInSearch:
 
         mapping = await get_database_mapping()
         registered_ids = list(mapping.keys())
+        # SearchRequest enforces limit <= 50; fallback databases.json can exceed that.
+        limit = min(len(registered_ids), 50)
+        slice_ids = registered_ids[:limit]
 
         value = [
             {
@@ -1051,7 +1054,7 @@ class TestDatabaseNameInSearch:
                     "dimensions": [],
                 }
             }
-            for db_id in registered_ids
+            for db_id in slice_ids
         ]
         httpx_mock.add_response(
             method="POST",
@@ -1059,7 +1062,7 @@ class TestDatabaseNameInSearch:
             json={"@odata.count": len(value), "value": value},
         )
 
-        result = await search("indicator", limit=len(registered_ids))
+        result = await search("indicator", limit=limit)
 
         assert isinstance(result, EnrichedSearchResponse)
         for ind in result.indicators:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,7 @@ import pytest
 import pytest_httpx
 from data360.api import (
     _get_valid_disaggregations,
+    _obs_value_to_float,
     _strip_data_row,
     get_data,
     get_metadata,
@@ -50,6 +51,29 @@ class TestGetValidDisaggregations:
         result = _get_valid_disaggregations(disagg_res)
         # Default is ["_T"], which is not in null_values, so it should be included
         assert len(result) == 1
+
+
+@pytest.mark.parametrize(
+    ("val", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("  ", None),
+        ("null", None),
+        ("NaN", None),
+        ("none", None),
+        (float("nan"), None),
+        ("abc", None),
+        (42, 42.0),
+        ("42.5", 42.5),
+        (0, 0.0),
+        ("0", 0.0),
+        (" 3.14 ", 3.14),
+    ],
+)
+def test_obs_value_to_float(val, expected):
+    """_obs_value_to_float normalizes API edge-case values for ranking/comparison."""
+    assert _obs_value_to_float(val) == expected
 
 
 class TestSearch:

--- a/uv.lock
+++ b/uv.lock
@@ -681,6 +681,9 @@ dependencies = [
     { name = "gunicorn" },
     { name = "mcp" },
     { name = "opencensus-ext-azure" },
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-instrumentation-httpx" },
+    { name = "opentelemetry-sdk" },
     { name = "pandas" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -721,6 +724,9 @@ requires-dist = [
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "mcp", specifier = ">=1.18.0" },
     { name = "opencensus-ext-azure", specifier = ">=1.1.13" },
+    { name = "opentelemetry-exporter-otlp", specifier = ">=1.28.0" },
+    { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.50b0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.28.0" },
     { name = "pandas", specifier = ">=3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
@@ -978,6 +984,57 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254, upload-time = "2026-04-02T21:23:26.679Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743, upload-time = "2026-04-02T21:22:49.108Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/db/1d56e5f5823257b291962d6c0ce106146c6447f405b60b234c4f222a7cde/grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a", size = 6055009, upload-time = "2026-03-30T08:46:46.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/18/c83f3cad64c5ca63bca7e91e5e46b0d026afc5af9d0a9972472ceba294b3/grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060", size = 12035295, upload-time = "2026-03-30T08:46:49.099Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8e/e14966b435be2dda99fbe89db9525ea436edc79780431a1c2875a3582644/grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2", size = 6610297, upload-time = "2026-03-30T08:46:52.123Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/26/d5eb38f42ce0e3fdc8174ea4d52036ef8d58cc4426cb800f2610f625dd75/grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3cb8130ba457d2aa09fa6b7c3ed6b6e4e6a2685fce63cb803d479576c4d80e21", size = 7300208, upload-time = "2026-03-30T08:46:54.859Z" },
+    { url = "https://files.pythonhosted.org/packages/25/51/bd267c989f85a17a5b3eea65a6feb4ff672af41ca614e5a0279cc0ea381c/grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09e5e478b3d14afd23f12e49e8b44c8684ac3c5f08561c43a5b9691c54d136ab", size = 6813442, upload-time = "2026-03-30T08:46:57.056Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d9/d80eef735b19e9169e30164bbf889b46f9df9127598a83d174eb13a48b26/grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00168469238b022500e486c1c33916acf2f2a9b2c022202cf8a1885d2e3073c1", size = 7414743, upload-time = "2026-03-30T08:46:59.682Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f2/567f5bd5054398ed6b0509b9a30900376dcf2786bd936812098808b49d8d/grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8502122a3cc1714038e39a0b071acb1207ca7844208d5ea0d091317555ee7106", size = 8426046, upload-time = "2026-03-30T08:47:02.474Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/73ef0141b4732ff5eacd68430ff2512a65c004696997f70476a83e548e7e/grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce1794f4ea6cc3ca29463f42d665c32ba1b964b48958a66497917fe9069f26e6", size = 7851641, upload-time = "2026-03-30T08:47:05.462Z" },
+    { url = "https://files.pythonhosted.org/packages/46/69/abbfa360eb229a8623bab5f5a4f8105e445bd38ce81a89514ba55d281ad0/grpcio-1.80.0-cp311-cp311-win32.whl", hash = "sha256:51b4a7189b0bef2aa30adce3c78f09c83526cf3dddb24c6a96555e3b97340440", size = 4154368, upload-time = "2026-03-30T08:47:08.027Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d4/ae92206d01183b08613e846076115f5ac5991bae358d2a749fa864da5699/grpcio-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e64bb0bb2da14d947a49e6f120a75e947250aebe65f9629b62bb1f5c14e6e9", size = 4894235, upload-time = "2026-03-30T08:47:10.839Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
 ]
 
 [[package]]
@@ -1979,6 +2036,67 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/37/b6708e0eff5c5fb9aba2e0ea09f7f3bcbfd12a592d2a780241b5f6014df7/opentelemetry_exporter_otlp-1.40.0.tar.gz", hash = "sha256:7caa0870b95e2fcb59d64e16e2b639ecffb07771b6cd0000b5d12e5e4fef765a", size = 6152, upload-time = "2026-03-04T14:17:23.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/fc/aea77c28d9f3ffef2fdafdc3f4a235aee4091d262ddabd25882f47ce5c5f/opentelemetry_exporter_otlp-1.40.0-py3-none-any.whl", hash = "sha256:48c87e539ec9afb30dc443775a1334cc5487de2f72a770a4c00b1610bf6c697d", size = 7023, upload-time = "2026-03-04T14:17:03.612Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/bc/1559d46557fe6eca0b46c88d4c2676285f1f3be2e8d06bb5d15fbffc814a/opentelemetry_exporter_otlp_proto_common-1.40.0.tar.gz", hash = "sha256:1cbee86a4064790b362a86601ee7934f368b81cd4cc2f2e163902a6e7818a0fa", size = 20416, upload-time = "2026-03-04T14:17:23.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ca/8f122055c97a932311a3f640273f084e738008933503d0c2563cd5d591fc/opentelemetry_exporter_otlp_proto_common-1.40.0-py3-none-any.whl", hash = "sha256:7081ff453835a82417bf38dccf122c827c3cbc94f2079b03bba02a3165f25149", size = 18369, upload-time = "2026-03-04T14:17:04.796Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/7f/b9e60435cfcc7590fa87436edad6822240dddbc184643a2a005301cc31f4/opentelemetry_exporter_otlp_proto_grpc-1.40.0.tar.gz", hash = "sha256:bd4015183e40b635b3dab8da528b27161ba83bf4ef545776b196f0fb4ec47740", size = 25759, upload-time = "2026-03-04T14:17:24.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/6f/7ee0980afcbdcd2d40362da16f7f9796bd083bf7f0b8e038abfbc0300f5d/opentelemetry_exporter_otlp_proto_grpc-1.40.0-py3-none-any.whl", hash = "sha256:2aa0ca53483fe0cf6405087a7491472b70335bc5c7944378a0a8e72e86995c52", size = 20304, upload-time = "2026-03-04T14:17:05.942Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/fa/73d50e2c15c56be4d000c98e24221d494674b0cc95524e2a8cb3856d95a4/opentelemetry_exporter_otlp_proto_http-1.40.0.tar.gz", hash = "sha256:db48f5e0f33217588bbc00274a31517ba830da576e59503507c839b38fa0869c", size = 17772, upload-time = "2026-03-04T14:17:25.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/3a/8865d6754e61c9fb170cdd530a124a53769ee5f740236064816eb0ca7301/opentelemetry_exporter_otlp_proto_http-1.40.0-py3-none-any.whl", hash = "sha256:a8d1dab28f504c5d96577d6509f80a8150e44e8f45f82cdbe0e34c99ab040069", size = 19960, upload-time = "2026-03-04T14:17:07.153Z" },
+]
+
+[[package]]
 name = "opentelemetry-exporter-prometheus"
 version = "0.61b0"
 source = { registry = "https://pypi.org/simple" }
@@ -2088,6 +2206,22 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-httpx"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/2a/e2becd55e33c29d1d9ef76e2579040ed1951cb33bacba259f6aff2fdd2a6/opentelemetry_instrumentation_httpx-0.61b0.tar.gz", hash = "sha256:6569ec097946c5551c2a4252f74c98666addd1bf047c1dde6b4ef426719ff8dd", size = 24104, upload-time = "2026-03-04T14:20:34.752Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/88/dde310dce56e2d85cf1a09507f5888544955309edc4b8d22971d6d3d1417/opentelemetry_instrumentation_httpx-0.61b0-py3-none-any.whl", hash = "sha256:dee05c93a6593a5dc3ae5d9d5c01df8b4e2c5d02e49275e5558534ee46343d5e", size = 17198, upload-time = "2026-03-04T14:19:33.585Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation-logging"
 version = "0.61b0"
 source = { registry = "https://pypi.org/simple" }
@@ -2173,6 +2307,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/89/e5/189f2845362cfe78e356ba127eab21456309def411c6874aa4800c3de816/opentelemetry_instrumentation_wsgi-0.61b0.tar.gz", hash = "sha256:380f2ae61714e5303275a80b2e14c58571573cd1fddf496d8c39fb9551c5e532", size = 19898, upload-time = "2026-03-04T14:20:54.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/75/d6b42ba26f3c921be6d01b16561b7bb863f843bad7ac3a5011f62617bcab/opentelemetry_instrumentation_wsgi-0.61b0-py3-none-any.whl", hash = "sha256:bd33b0824166f24134a3400648805e8d2e6a7951f070241294e8b8866611d7fa", size = 14628, upload-time = "2026-03-04T14:20:03.934Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/77/dd38991db037fdfce45849491cb61de5ab000f49824a00230afb112a4392/opentelemetry_proto-1.40.0.tar.gz", hash = "sha256:03f639ca129ba513f5819810f5b1f42bcb371391405d99c168fe6937c62febcd", size = 45667, upload-time = "2026-03-04T14:17:31.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/b2/189b2577dde745b15625b3214302605b1353436219d42b7912e77fa8dc24/opentelemetry_proto-1.40.0-py3-none-any.whl", hash = "sha256:266c4385d88923a23d63e353e9761af0f47a6ed0d486979777fe4de59dc9b25f", size = 72073, upload-time = "2026-03-04T14:17:16.673Z" },
 ]
 
 [[package]]
@@ -2593,17 +2739,17 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "7.34.1"
+version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
-    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
-    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
-    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
-    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds **global / unpinned country rankings** (`rank_universe=all_member_economies`), safer handling of **indicator values** (`OBS_VALUE`), optional **member-economy-only** rows when geography is unpinned, and **OpenTelemetry** instrumentation for MCP tools and outbound HTTP.

## Ranking & data behavior

- **`rank_countries`**: `rank_universe=all_member_economies` runs over World Bank member economies when scope is unpinned; response includes `universe` / `universe_size`; clearer errors when scope is omitted; uses **WLD** as disaggregation probe fallback where appropriate.
- **`GroupHierarchyManager`**: `list_rankable_country_codes()` for universe metadata.
- **`get_data`**: `ref_area_filter=member_economies_only` drops non-member **REF_AREA** rows when geography is unpinned (with validation notes when filters conflict).
- **`rank_countries` / `compare_countries`**: robust numeric parsing via **`_obs_value_to_float`** (e.g. string `"null"`, NaN).
- **`SYSTEM_PROMPT`**: documents global rankings and `ref_area_filter`.

## Observability

- **OTLP / console / Azure Monitor**: `configure_open_telemetry_for_server()` (`data360/otel_setup.py`); local traces via `OTEL_EXPORTER_OTLP_*` / `MCP_OTEL_CONSOLE` when `MCP_ENV=local`.
- **MCP tool spans**: each tool wrapped with `instrument_mcp_tool` → spans named `mcp.tool.<name>` (`data360/mcp_server/tool_spans.py`).
- **Shared `httpx.AsyncClient`**: single outbound client (`data360/http_client.py`) so **httpx** instrumentation applies consistently; lifespan closes the client on shutdown.
- **`.env.example`**: optional Jaeger/OTLP snippet for local debugging.

_Note: spans intentionally omit tool arguments and HTTP bodies (privacy / secrets)._

## Tests & docs

- Extended **`tests/test_aggregation_tools.py`** and **`tests/test_api.py`** for global ranking, `OBS_VALUE` edge cases, and `get_data` aggregate filtering.
- **`tests/conftest.py`**: `PYTEST_RUNNING`, env defaults for test URLs, cache + shared-client isolation.

## How to verify

- `uv run pytest tests/`
- Optional: run Jaeger (see `.env.example`), set `MCP_ENV=local` and OTLP vars, invoke MCP tools, confirm traces for `mcp.tool.*` and outbound HTTP spans.