### PR TITLE
fix: resolve country names in summarize_data group keys

### DIFF
--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -2543,6 +2543,24 @@ async def summarize_data(
         reverse=True,
     )
 
+    # Resolve human-readable country names for ref_area groups.
+    # Reuses the same _resolve_country_names helper used by rank_countries and
+    # compare_countries. ref_area_name is injected into group_key so it flows
+    # through GroupSummary.to_compact() → "group" dict without any model change.
+    # Silently no-ops on error — country name is optional enrichment.
+    _area_codes = [
+        g.group_key["ref_area"]
+        for g in group_summaries
+        if "ref_area" in g.group_key
+    ]
+    if _area_codes:
+        _name_map = await _resolve_country_names(_area_codes)
+        for g in group_summaries:
+            if "ref_area" in g.group_key:
+                g.group_key["ref_area_name"] = _name_map.get(
+                    g.group_key["ref_area"], ""
+                )
+
     return DataSummaryResponse(
         groups=group_summaries,
         metadata=data_response.metadata,


### PR DESCRIPTION
## Summary

Adds human-readable country name resolution to `data360_summarize_data` by reusing the existing `_resolve_country_names` helper already used by `rank_countries` and `compare_countries`.

## Problem

`summarize_data` returned group keys with only ISO codes (e.g. `{"ref_area": "GHA"}`). Downstream consumers had no way to display country names without a separate lookup, leading to raw ISO codes appearing in UI cards.

## Solution

After building group summaries and before the return statement, batch-resolve all unique `ref_area` codes to display names and inject `ref_area_name` into each group's `group_key` dict.

```python
# Before
{"group": {"ref_area": "GHA"}, ...}

# After  
{"group": {"ref_area": "GHA", "ref_area_name": "Ghana"}, ...}
```

## Design decisions

- **No model schema change** — `ref_area_name` is injected directly into the existing `group_key: dict[str, str]` field, which `GroupSummary.to_compact()` already serializes into the `"group"` dict. No Pydantic field additions or migration needed.
- **Consistent with existing pattern** — identical approach to `rank_countries` (line 2765) and `compare_countries` (line 2929).
- **Graceful degradation** — `_resolve_country_names` already silently returns `{}` on any error, so the ISO code is always a valid fallback.
- **Single batch call** — all unique codes are resolved in one codelist API call, not one per group.

## Files changed

- `src/data360/api.py` — 18-line insertion in `summarize_data`, no other changes.