### PR TITLE
fix(quick-answer): resolve country names in summarize_data group keys

### DIFF
--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -1764,6 +1764,16 @@ async def get_data(
                     "filter was not applied."
                 )
 
+        # Inject REF_AREA_NAME for UX label resolution
+        if raw_data:
+            unique_ref_areas = list({str(r.get("REF_AREA")) for r in raw_data if r.get("REF_AREA")})
+            if unique_ref_areas:
+                _name_map = await _resolve_country_names(unique_ref_areas)
+                for row in raw_data:
+                    ref_area = str(row.get("REF_AREA", ""))
+                    if ref_area in _name_map:
+                        row["REF_AREA_NAME"] = _name_map[ref_area]
+
         return IndicatorDataResponse(
             data=raw_data,
             metadata=api_metadata,

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -2543,6 +2543,24 @@ async def summarize_data(
         reverse=True,
     )
 
+    # Resolve human-readable country names for ref_area groups.
+    # Reuses the same _resolve_country_names helper used by rank_countries and
+    # compare_countries. ref_area_name is injected into group_key so it flows
+    # through GroupSummary.to_compact() → "group" dict without any model change.
+    # Silently no-ops on error — country name is optional enrichment.
+    _area_codes = [
+        g.group_key["ref_area"]
+        for g in group_summaries
+        if "ref_area" in g.group_key
+    ]
+    if _area_codes:
+        _name_map = await _resolve_country_names(_area_codes)
+        for g in group_summaries:
+            if "ref_area" in g.group_key:
+                g.group_key["ref_area_name"] = _name_map.get(
+                    g.group_key["ref_area"], ""
+                )
+
     return DataSummaryResponse(
         groups=group_summaries,
         metadata=data_response.metadata,

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -1764,16 +1764,6 @@ async def get_data(
                     "filter was not applied."
                 )
 
-        # Inject REF_AREA_NAME for UX label resolution
-        if raw_data:
-            unique_ref_areas = list({str(r.get("REF_AREA")) for r in raw_data if r.get("REF_AREA")})
-            if unique_ref_areas:
-                _name_map = await _resolve_country_names(unique_ref_areas)
-                for row in raw_data:
-                    ref_area = str(row.get("REF_AREA", ""))
-                    if ref_area in _name_map:
-                        row["REF_AREA_NAME"] = _name_map[ref_area]
-
         return IndicatorDataResponse(
             data=raw_data,
             metadata=api_metadata,
@@ -2555,19 +2545,21 @@ async def summarize_data(
 
     # Resolve human-readable country names for ref_area groups.
     # Reuses the same _resolve_country_names helper used by rank_countries and
-    # compare_countries. Sets GroupSummary.ref_area_name (declared field) so it
-    # flows through GroupSummary.to_compact() → "group" dict without dict mutation.
+    # compare_countries. Injects ref_area_name directly into the group_key dict
+    # so it flows through GroupSummary.to_compact() without a schema change.
     # Silently no-ops on error — country name is optional enrichment.
-    _area_codes = [
+    _area_codes = sorted({
         g.group_key["ref_area"]
         for g in group_summaries
         if "ref_area" in g.group_key
-    ]
+    })
     if _area_codes:
         _name_map = await _resolve_country_names(_area_codes)
         for g in group_summaries:
             if "ref_area" in g.group_key:
-                g.ref_area_name = _name_map.get(g.group_key["ref_area"]) or None
+                name = _name_map.get(g.group_key["ref_area"])
+                if name:
+                    g.group_key["ref_area_name"] = name
 
     return DataSummaryResponse(
         groups=group_summaries,

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -2545,8 +2545,8 @@ async def summarize_data(
 
     # Resolve human-readable country names for ref_area groups.
     # Reuses the same _resolve_country_names helper used by rank_countries and
-    # compare_countries. ref_area_name is injected into group_key so it flows
-    # through GroupSummary.to_compact() → "group" dict without any model change.
+    # compare_countries. Sets GroupSummary.ref_area_name (declared field) so it
+    # flows through GroupSummary.to_compact() → "group" dict without dict mutation.
     # Silently no-ops on error — country name is optional enrichment.
     _area_codes = [
         g.group_key["ref_area"]
@@ -2557,9 +2557,7 @@ async def summarize_data(
         _name_map = await _resolve_country_names(_area_codes)
         for g in group_summaries:
             if "ref_area" in g.group_key:
-                g.group_key["ref_area_name"] = _name_map.get(
-                    g.group_key["ref_area"], ""
-                )
+                g.ref_area_name = _name_map.get(g.group_key["ref_area"]) or None
 
     return DataSummaryResponse(
         groups=group_summaries,

--- a/src/data360/models.py
+++ b/src/data360/models.py
@@ -430,6 +430,12 @@ class GroupSummary(BaseModel):
         default_factory=list,
         description="Source claim_ids from underlying raw observations",
     )
+    ref_area_name: str | None = Field(
+        None,
+        description="Human-readable country name resolved from ref_area code. "
+        "Populated after construction by the summarize_data provider when "
+        "ref_area is present in the group_key.",
+    )
 
     def to_compact(self) -> dict[str, Any]:
         """Return a slimmed dict for LLM context.
@@ -439,8 +445,11 @@ class GroupSummary(BaseModel):
         is bounded (one hash per observation per group) and preserves the
         group→claim_ids association that a flat top-level list would lose.
         """
+        group = dict(self.group_key)
+        if self.ref_area_name:
+            group["ref_area_name"] = self.ref_area_name
         return {
-            "group": self.group_key,
+            "group": group,
             "n": self.count,
             "latest": {"value": self.latest_value, "year": self.latest_year},
             "earliest": {"value": self.earliest_value, "year": self.earliest_year},

--- a/src/data360/models.py
+++ b/src/data360/models.py
@@ -430,12 +430,6 @@ class GroupSummary(BaseModel):
         default_factory=list,
         description="Source claim_ids from underlying raw observations",
     )
-    ref_area_name: str | None = Field(
-        None,
-        description="Human-readable country name resolved from ref_area code. "
-        "Populated after construction by the summarize_data provider when "
-        "ref_area is present in the group_key.",
-    )
 
     def to_compact(self) -> dict[str, Any]:
         """Return a slimmed dict for LLM context.
@@ -445,11 +439,8 @@ class GroupSummary(BaseModel):
         is bounded (one hash per observation per group) and preserves the
         group→claim_ids association that a flat top-level list would lose.
         """
-        group = dict(self.group_key)
-        if self.ref_area_name:
-            group["ref_area_name"] = self.ref_area_name
         return {
-            "group": group,
+            "group": self.group_key,
             "n": self.count,
             "latest": {"value": self.latest_value, "year": self.latest_year},
             "earliest": {"value": self.earliest_value, "year": self.earliest_year},

--- a/tests/test_aggregation_tools.py
+++ b/tests/test_aggregation_tools.py
@@ -708,6 +708,100 @@ class TestSummarizeData:
         assert result.error is None
         assert not result.ambiguous_dimensions
 
+    @pytest.mark.asyncio
+    async def test_ref_area_name_injected_into_compact_output(self):
+        """ref_area_name should appear in group dict when _resolve_country_names succeeds."""
+        rows = [
+            _make_row("KEN", "2020", 100.0),
+            _make_row("KEN", "2021", 110.0),
+            _make_row("NGA", "2020", 200.0),
+            _make_row("NGA", "2021", 220.0),
+        ]
+        full_page = _make_data_page(rows, has_more=False)
+
+        async def fake_fetch_all(**kwargs):
+            return full_page
+
+        async def fake_resolve(codes):
+            return {"KEN": "Kenya", "NGA": "Nigeria"}
+
+        with (
+            patch("data360.api._fetch_all_pages", side_effect=fake_fetch_all),
+            patch("data360.api._resolve_country_names", side_effect=fake_resolve),
+        ):
+            result = await summarize_data(
+                "WB_WDI", "IND_ID",
+                country_code="KEN;NGA",
+                group_by=["ref_area"],
+            )
+
+        assert result.error is None
+        compact = result.to_compact()
+        group_dicts = {g["group"]["ref_area"]: g["group"] for g in compact["groups"]}
+        assert group_dicts["KEN"]["ref_area_name"] == "Kenya"
+        assert group_dicts["NGA"]["ref_area_name"] == "Nigeria"
+
+    @pytest.mark.asyncio
+    async def test_ref_area_name_omitted_when_resolution_fails(self):
+        """If _resolve_country_names returns empty, compact output omits ref_area_name."""
+        rows = [
+            _make_row("KEN", "2020", 100.0),
+            _make_row("KEN", "2021", 110.0),
+        ]
+        full_page = _make_data_page(rows, has_more=False)
+
+        async def fake_fetch_all(**kwargs):
+            return full_page
+
+        async def fake_resolve(codes):
+            return {}  # simulates resolution failure / empty response
+
+        with (
+            patch("data360.api._fetch_all_pages", side_effect=fake_fetch_all),
+            patch("data360.api._resolve_country_names", side_effect=fake_resolve),
+        ):
+            result = await summarize_data(
+                "WB_WDI", "IND_ID",
+                country_code="KEN",
+                group_by=["ref_area"],
+            )
+
+        assert result.error is None
+        compact = result.to_compact()
+        assert len(compact["groups"]) == 1
+        assert "ref_area_name" not in compact["groups"][0]["group"]
+
+    @pytest.mark.asyncio
+    async def test_area_codes_deduplicated_before_resolution(self):
+        """Duplicate ref_area values across groups should be resolved only once."""
+        rows = [
+            _make_row("KEN", "2020", 100.0),
+            _make_row("KEN", "2021", 110.0),
+        ]
+        full_page = _make_data_page(rows, has_more=False)
+        resolve_calls: list[list[str]] = []
+
+        async def fake_fetch_all(**kwargs):
+            return full_page
+
+        async def fake_resolve(codes):
+            resolve_calls.append(list(codes))
+            return {c: c for c in codes}
+
+        with (
+            patch("data360.api._fetch_all_pages", side_effect=fake_fetch_all),
+            patch("data360.api._resolve_country_names", side_effect=fake_resolve),
+        ):
+            await summarize_data(
+                "WB_WDI", "IND_ID",
+                country_code="KEN",
+                group_by=["ref_area"],
+            )
+
+        # Should have called _resolve_country_names exactly once with deduplicated codes
+        assert len(resolve_calls) == 1
+        assert resolve_calls[0].count("KEN") == 1
+
 
 # ---------------------------------------------------------------------------
 # compare_countries


### PR DESCRIPTION
## Context

This is a targeted patch fix for the **Quick Answer** card rendering in the chatbot UI. When a user asks a trend question (e.g. "How has Ghana's population changed?"), the `data360_summarize_data` tool returns group summaries with only ISO country codes (e.g. `GHA`). The Quick Answer card synthesizer has no way to resolve these to display names, causing ISO codes to appear directly in the rendered card instead of full country names.

## Problem

`summarize_data` returned group keys with only ISO codes:

```json
{"group": {"ref_area": "GHA"}, ...}
```

Downstream consumers (including the Quick Answer synthesizer) received `GHA` with no corresponding name field, while `rank_countries` and `compare_countries` already returned full country names via `_resolve_country_names`.

## Fix

After building group summaries, batch-resolve all unique `ref_area` codes to display names and inject `ref_area_name` into each group's `group_key` dict — consistent with the pattern already established in `rank_countries` and `compare_countries`:

```python
# Before
{"group": {"ref_area": "GHA"}, ...}

# After
{"group": {"ref_area": "GHA", "ref_area_name": "Ghana"}, ...}
```

## Design decisions

- **No model schema change** — `ref_area_name` is injected into the existing `group_key: dict[str, str]` field which `GroupSummary.to_compact()` already serializes. No Pydantic field additions needed.
- **Consistent with existing pattern** — identical to `rank_countries` (line 2765) and `compare_countries` (line 2929).
- **Graceful degradation** — `_resolve_country_names` silently returns `{}` on any error; the ISO code is always a valid fallback.
- **Single batch call** — all unique codes resolved in one codelist API call.

## Files changed

- `src/data360/api.py` — 18-line insertion in `summarize_data`, no other changes.