### PR TITLE
(chore): Fix bar year axes, temporal line gaps, and viz strategy/tooltip consistency

### DIFF
--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -35,8 +35,6 @@ from urllib.parse import parse_qs, urlparse
 
 import altair as alt
 import httpx
-
-from data360.http_client import get_shared_httpx_client
 import numpy as np
 import pandas as pd
 from draco import Draco, answer_set_to_dict, dict_to_facts, schema_from_dataframe
@@ -44,6 +42,7 @@ from draco.renderer import AltairRenderer
 
 from data360 import viz_config
 from data360.config import get_mcp_server_settings
+from data360.http_client import get_shared_httpx_client
 from data360.providers import get_database_mapping
 
 _logger = logging.getLogger(__name__)
@@ -255,9 +254,7 @@ def _format_subtitle_line(
     if warning:
         parts.append(warning)
     if strategy or reason:
-        parts.append(
-            " — ".join(x for x in (strategy or "", reason or "") if x)
-        )
+        parts.append(" — ".join(x for x in (strategy or "", reason or "") if x))
     if not parts:
         return None
     return " · ".join(parts)
@@ -642,9 +639,7 @@ async def get_viz_spec(
         db_map = {}
     database_display = db_map.get(database_id, database_id)
     indicator_display = (
-        chart_title
-        if chart_title != "Generated Visualization"
-        else indicator_id
+        chart_title if chart_title != "Generated Visualization" else indicator_id
     )
     source_attribution: dict[str, str] = {
         "database_id": database_id,
@@ -796,7 +791,7 @@ async def get_viz_spec(
         # Structured tooltips
         mark_type_for_tt = viz_config.parse_chart_type_hint(chart_type)
         structured_tooltips = viz_config.build_structured_tooltips(
-            list(viz_data.columns), mark_type_for_tt
+            list(viz_data.columns), mark_type_for_tt, viz_data=viz_data
         )
         chart = chart.encode(tooltip=[alt.Tooltip(**t) for t in structured_tooltips])
 

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -806,11 +806,19 @@ async def get_viz_spec(
         for rule in viz_config.POST_PROCESSING_RULES:
             vl_spec = rule.apply(vl_spec, data_frequency, raw_unit or None)
 
+        out_reason = strategy_result.reason
+        if strategy_result.strategy == viz_config.ChartStrategy.TEMPORAL_SINGLE:
+            resolved_mark = viz_config.extract_top_level_mark_type(vl_spec)
+            if resolved_mark:
+                out_reason = viz_config.patch_strategy_reason_chart_phrase(
+                    strategy_result.reason, resolved_mark
+                )
+
         return _ok(
             await _store_spec(vl_spec),
             source_attribution=source_attribution,
             strategy=strategy_result.strategy.value,
-            reason=strategy_result.reason,
+            reason=out_reason,
         )
 
     except StopIteration:

--- a/src/data360/viz_config.py
+++ b/src/data360/viz_config.py
@@ -165,14 +165,15 @@ def inject_wb_config(vl_spec: dict) -> dict:
 # STRUCTURED TOOLTIPS
 # ============================================================================
 
+# ``year`` / ``time_period`` are built in ``build_structured_tooltips`` from ``viz_data``:
+# marking them ``temporal`` when values are plain strings like "2018" makes Vega-Lite parse
+# the field as dates for all encodings, so an ordinal x-axis shows epoch milliseconds.
 _TOOLTIP_SPECS: dict[str, dict] = {
-    "year": {"title": "Year", "format": "%Y", "type": "temporal"},
     "value": {"title": "Value", "format": ",.2f", "type": "quantitative"},
     "country": {"title": "Country", "type": "nominal"},
     "sex": {"title": "Sex", "type": "nominal"},
     "age": {"title": "Age Group", "type": "nominal"},
     "urbanisation": {"title": "Urbanisation", "type": "nominal"},
-    "time_period": {"title": "Period", "type": "temporal"},
     "obs_value": {"title": "Value", "format": ",.2f", "type": "quantitative"},
     "ref_area": {"title": "Country", "type": "nominal"},
     "region": {"title": "Region", "type": "nominal"},
@@ -271,7 +272,9 @@ _MULTI_IND_TOOLTIP_DIMS: tuple[str, ...] = (
 _LINE_HOVER_POINT: dict[str, object] = {"filled": True, "size": 56}
 
 
-def _multi_indicator_tooltip_columns(df_columns: list[str], value_col: str) -> list[str]:
+def _multi_indicator_tooltip_columns(
+    df_columns: list[str], value_col: str
+) -> list[str]:
     colset = set(df_columns)
     out: list[str] = []
     for c in _MULTI_IND_TOOLTIP_DIMS:
@@ -282,23 +285,45 @@ def _multi_indicator_tooltip_columns(df_columns: list[str], value_col: str) -> l
     return out
 
 
+def _tooltip_spec_for_time_dim(col: str, viz_data: pd.DataFrame | None) -> dict:
+    """Year/period tooltips: temporal only when the frame actually has datetime values."""
+    title = "Year" if col == "year" else "Period"
+    if viz_data is not None and col in viz_data.columns:
+        s = viz_data[col]
+        if pd.api.types.is_datetime64_any_dtype(s):
+            return {
+                "field": col,
+                "title": title,
+                "type": "temporal",
+                "format": "%Y",
+            }
+    return {"field": col, "title": title, "type": "nominal"}
+
+
 def build_structured_tooltips(
     columns: list[str],
     mark_type: str,
     indicator_labels: dict[str, str] | None = None,
     value_format: str = ",.2f",
+    viz_data: pd.DataFrame | None = None,
 ) -> list[dict]:
     """Build typed, labelled tooltip list for a Vega-Lite encoding.
 
     indicator_labels: optional {col_name: human_label} for indicator value columns
     in multi-indicator charts (e.g. {"gdp_per_capita": "GDP per capita (USD)"}).
     value_format: D3 format string for quantitative value fields.
+    viz_data: when set, ``year`` / ``time_period`` tooltips use ``temporal`` only if
+        that column is datetime64; otherwise ``nominal`` so VL does not parse string
+        years as dates (which breaks ordinal x-axes).
     """
     ordered = [c for c in _TOOLTIP_PRIORITY if c in columns]
     ordered += [c for c in columns if c not in _TOOLTIP_PRIORITY]
 
     tooltips = []
     for col in ordered:
+        if col in ("year", "time_period"):
+            tooltips.append(_tooltip_spec_for_time_dim(col, viz_data))
+            continue
         if indicator_labels and col in indicator_labels:
             tip = {
                 "field": col,
@@ -326,8 +351,11 @@ def apply_structured_tooltips(
     columns: list[str],
     mark_type: str,
     indicator_labels: dict[str, str] | None = None,
+    viz_data: pd.DataFrame | None = None,
 ) -> dict:
-    tips = build_structured_tooltips(columns, mark_type, indicator_labels)
+    tips = build_structured_tooltips(
+        columns, mark_type, indicator_labels, viz_data=viz_data
+    )
     vl_spec.setdefault("encoding", {})["tooltip"] = tips
     return vl_spec
 
@@ -643,7 +671,11 @@ def build_temporal_single_spec(
             "scale": {"zero": False},
         },
         "tooltip": build_structured_tooltips(
-            list(df.columns), "line", indicator_labels, value_format=tt_fmt
+            list(df.columns),
+            "line",
+            indicator_labels,
+            value_format=tt_fmt,
+            viz_data=df,
         ),
     }
     if result.color_dim:
@@ -726,7 +758,11 @@ def build_cross_sectional_spec(
             },
             "color": color_enc,
             "tooltip": build_structured_tooltips(
-                list(df.columns), "bar", indicator_labels, value_format=tt_fmt
+                list(df.columns),
+                "bar",
+                indicator_labels,
+                value_format=tt_fmt,
+                viz_data=sorted_df,
             ),
         },
         "width": 500,
@@ -779,7 +815,11 @@ def build_distribution_spec(
             },
             "color": _color_encoding("country"),
             "tooltip": build_structured_tooltips(
-                list(sorted_df.columns), "tick", indicator_labels, value_format=tt_fmt
+                list(sorted_df.columns),
+                "tick",
+                indicator_labels,
+                value_format=tt_fmt,
+                viz_data=sorted_df,
             ),
         },
         "width": 500,
@@ -826,7 +866,11 @@ def build_breakdown_comparison_spec(
             "x": {
                 "field": x_field,
                 "type": x_type,
-                "axis": {"title": None, "labelFontWeight": "bold"},
+                "axis": {
+                    "title": None,
+                    "labelFontWeight": "bold",
+                    **({"labelAngle": 0} if x_field in ("year", "time_period") else {}),
+                },
             },
             "xOffset": {"field": color_dim, "type": "nominal"},
             "y": {
@@ -847,7 +891,11 @@ def build_breakdown_comparison_spec(
                 },
             },
             "tooltip": build_structured_tooltips(
-                list(df.columns), "bar", indicator_labels, value_format=tt_fmt
+                list(df.columns),
+                "bar",
+                indicator_labels,
+                value_format=tt_fmt,
+                viz_data=df,
             ),
         },
         "width": max(300, df[x_field].nunique() * 80),
@@ -894,7 +942,11 @@ def build_small_multiples_spec(
                 "scale": {"zero": False},
             },
             "tooltip": build_structured_tooltips(
-                list(df.columns), "line", indicator_labels, value_format=tt_fmt
+                list(df.columns),
+                "line",
+                indicator_labels,
+                value_format=tt_fmt,
+                viz_data=df,
             ),
         },
     }
@@ -962,7 +1014,9 @@ def build_correlation_spec(
                 "scale": {"zero": False},
             },
             "color": _color_encoding(result.color_dim or "country"),
-            "tooltip": build_structured_tooltips(list(df.columns), "point", lab),
+            "tooltip": build_structured_tooltips(
+                list(df.columns), "point", lab, viz_data=df
+            ),
         },
         "width": 550,
         "height": 450,
@@ -1005,7 +1059,9 @@ def build_correlation_temporal_spec(
         },
         "color": _color_encoding(color_dim),
         "order": {"field": "year", "type": "temporal"},
-        "tooltip": build_structured_tooltips(list(df.columns), "line", lab),
+        "tooltip": build_structured_tooltips(
+            list(df.columns), "line", lab, viz_data=df
+        ),
     }
 
     spec: dict = {
@@ -1084,7 +1140,7 @@ def build_temporal_multi_indicator_spec(
             },
             "color": {"value": color},
             "tooltip": build_structured_tooltips(
-                tooltip_cols, "line", lab, value_format=tt_fmt
+                tooltip_cols, "line", lab, value_format=tt_fmt, viz_data=df
             ),
         }
         layers.append(
@@ -1148,7 +1204,11 @@ def build_fallback_line_spec(
         },
         "y": {"field": y_col, "type": "quantitative", "axis": y_ax},
         "tooltip": build_structured_tooltips(
-            list(df.columns), "line", indicator_labels, value_format=tt_fmt
+            list(df.columns),
+            "line",
+            indicator_labels,
+            value_format=tt_fmt,
+            viz_data=df,
         ),
     }
     if result.color_dim and result.color_dim in cols:
@@ -1348,6 +1408,12 @@ DATA_PREPARATION_RULES: list[DataPreparationRule] = [
     DataPreparationRule(
         "bar", "A", "year_strings", "Bar charts with annual data use year strings"
     ),
+    DataPreparationRule(
+        "bar",
+        None,
+        "year_strings",
+        "Bar charts when API frequency is unknown — assume annual WDI-style years",
+    ),
     DataPreparationRule("*", "*", "datetime", "Default: datetime"),
 ]
 
@@ -1392,12 +1458,39 @@ class PostProcessingRule:
         raise NotImplementedError
 
 
+def _first_non_null_dataset_value(dataset: list, field: str) -> object:
+    for row in dataset:
+        if field in row:
+            v = row[field]
+            if v is not None:
+                return v
+    return None
+
+
+# Ordinal ``year`` values at or above this magnitude are treated as epoch milliseconds
+# (typical Altair / Vega-Lite JSON for datetimes), not calendar years.
+_YEAR_ORDINAL_EPOCH_MS_THRESHOLD = 1e12
+
+
+def _year_ordinal_value_needs_temporal_encoding(value: object) -> bool:
+    """True when x is ordinal but values are ISO datetimes or epoch ms (Vega-Lite)."""
+    if value is None or isinstance(value, bool):
+        return False
+    if isinstance(value, str):
+        return "T" in value
+    if isinstance(value, (int, float)):
+        fv = float(value)
+        # Altair often serializes datetimes as milliseconds in embedded datasets
+        return abs(fv) >= _YEAR_ORDINAL_EPOCH_MS_THRESHOLD
+    return False
+
+
 class OrdinalToTemporalRule(PostProcessingRule):
     def __init__(self):
         super().__init__(
             "ordinal_to_temporal",
-            ["line", "area", "point", "tick"],
-            "Fix ordinal→temporal for time fields",
+            ["line", "area", "point", "tick", "bar"],
+            "Fix ordinal→temporal for time fields (ISO or epoch ms), including bars",
         )
 
     def should_apply(self, mark_type, x_enc, dataset):
@@ -1408,9 +1501,10 @@ class OrdinalToTemporalRule(PostProcessingRule):
         x_field = x_enc.get("field")
         if x_field not in ["year", "time_period"]:
             return False
-        if dataset and x_field in dataset[0]:
-            return isinstance(dataset[0][x_field], str) and "T" in dataset[0][x_field]
-        return False
+        if not dataset:
+            return False
+        sample = _first_non_null_dataset_value(dataset, x_field)
+        return _year_ordinal_value_needs_temporal_encoding(sample)
 
     def apply(self, spec, data_frequency=None, unit_measure=None):
         mark_type = (
@@ -1493,7 +1587,7 @@ class TemporalAxisCleanupRule(PostProcessingRule):
     def __init__(self):
         super().__init__(
             "temporal_axis_cleanup",
-            ["line", "area", "point"],
+            ["line", "area", "point", "bar"],
             "Remove title from temporal x-axis",
         )
 
@@ -1516,6 +1610,38 @@ class TemporalAxisCleanupRule(PostProcessingRule):
         x["axis"]["labelAngle"] = 0
         x["axis"].setdefault("format", "%Y")
         x["axis"].setdefault("tickCount", 5)
+        return spec
+
+
+class DiscreteYearBarXAxisRule(PostProcessingRule):
+    """Vega-Lite defaults often rotate discrete x labels on bars; force horizontal years."""
+
+    def __init__(self):
+        super().__init__(
+            "discrete_year_bar_x_axis",
+            ["bar"],
+            "Horizontal labels for ordinal/nominal year on column/bar x-axis",
+        )
+
+    def should_apply(self, spec, data_frequency=None):
+        mark_type = (
+            spec.get("mark", {}).get("type")
+            if isinstance(spec.get("mark"), dict)
+            else spec.get("mark")
+        )
+        if mark_type not in self.applies_to_mark_types:
+            return False
+        x = spec.get("encoding", {}).get("x", {})
+        if x.get("field") not in ("year", "time_period"):
+            return False
+        return x.get("type") in ("ordinal", "nominal")
+
+    def apply(self, spec, data_frequency=None, unit_measure=None):
+        if not self.should_apply(spec):
+            return spec
+        x = spec["encoding"]["x"]
+        x.setdefault("axis", {})
+        x["axis"]["labelAngle"] = 0
         return spec
 
 
@@ -1634,6 +1760,7 @@ POST_PROCESSING_RULES: list[PostProcessingRule] = [
     ApplyTimeUnitRule(),
     FixValueAxisEncodingRule(),
     TemporalAxisCleanupRule(),
+    DiscreteYearBarXAxisRule(),
     ValueAxisLabelFormatRule(),
     LineChartPointHoverRule(),
     ZeroLineRule(),

--- a/src/data360/viz_config.py
+++ b/src/data360/viz_config.py
@@ -12,6 +12,7 @@ Design principles:
 
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
 from numbers import Integral
@@ -1917,6 +1918,285 @@ class ValueAxisLabelFormatRule(PostProcessingRule):
         return spec
 
 
+# Internal columns for year-gap dashed line segments (unlikely to collide with WDI columns).
+_LINE_GAP_SEG_DETAIL = "_d360_lseg"
+_LINE_GAP_STROKE_FLAG = "_d360_ygap"
+
+
+class LineYearGapStrokeDashRule(PostProcessingRule):
+    """Temporal / discrete-year line charts: dashed stroke across multi-year gaps.
+
+    Vega-Lite draws one continuous polyline per color series. We split each
+    consecutive observation pair into its own ``detail`` group and use
+    ``strokeDash`` so segments that skip one or more calendar years render dashed.
+    """
+
+    def __init__(self):
+        super().__init__(
+            "line_year_gap_stroke_dash",
+            ["line"],
+            "Dashed line segments where consecutive points differ by >1 calendar year",
+        )
+
+    def apply(self, spec, data_frequency=None, unit_measure=None):
+        if not isinstance(spec, dict):
+            return spec
+        if "layer" in spec and isinstance(spec["layer"], list):
+            self._apply_to_layer_root(spec)
+            return spec
+        if "spec" in spec and isinstance(spec.get("spec"), dict):
+            inner = spec["spec"]
+            # Facet + inner layer (e.g. line + point from interactive) — data often on facet root
+            if "layer" in inner and isinstance(inner["layer"], list):
+                self._apply_to_layer_root(inner, data_root=spec)
+                return spec
+            if self._is_candidate_line_spec(inner):
+                self._maybe_transform_line_spec(inner, spec)
+            return spec
+        if self._is_candidate_line_spec(spec):
+            self._maybe_transform_line_spec(spec, spec)
+        return spec
+
+    def _apply_to_layer_root(
+        self, layer_parent: dict, data_root: dict | None = None
+    ) -> None:
+        root = data_root if data_root is not None else layer_parent
+        line_layers = [
+            layer
+            for layer in layer_parent["layer"]
+            if isinstance(layer, dict) and self._is_candidate_line_spec(layer)
+        ]
+        if len(line_layers) != 1:
+            return
+        self._maybe_transform_line_spec(line_layers[0], root)
+
+    def _mark_type(self, enc_spec: dict) -> str | None:
+        m = enc_spec.get("mark")
+        if isinstance(m, str):
+            return m
+        if isinstance(m, dict):
+            return m.get("type")
+        return None
+
+    def _is_candidate_line_spec(self, enc_spec: dict) -> bool:
+        if self._mark_type(enc_spec) != "line":
+            return False
+        enc = enc_spec.get("encoding")
+        if not isinstance(enc, dict):
+            return False
+        x = enc.get("x", {})
+        if not isinstance(x, dict):
+            return False
+        xf = x.get("field")
+        if xf not in ("year", "time_period"):
+            return False
+        # ApplyTimeUnitRule sets ``timeUnit: "year"`` for annual (A) data; still one value
+        # per calendar year — allow dashed segments across missing years. Reject finer
+        # units (month, quarter) where calendar-year gap logic does not apply.
+        if not self._x_timeunit_allows_year_gap_segments(x):
+            return False
+        if x.get("type") not in ("temporal", "ordinal", "nominal"):
+            return False
+        y = enc.get("y", {})
+        if not isinstance(y, dict) or y.get("type") != "quantitative":
+            return False
+        if not y.get("field"):
+            return False
+        if enc.get("detail") is not None:
+            return False
+        if enc.get("strokeDash") is not None:
+            return False
+        return True
+
+    @staticmethod
+    def _x_timeunit_allows_year_gap_segments(x: dict) -> bool:
+        tu = x.get("timeUnit")
+        if tu is None:
+            return True
+        if isinstance(tu, str):
+            return tu == "year"
+        if isinstance(tu, dict):
+            return tu.get("unit") == "year"
+        return False
+
+    def _find_inline_values_holder(self, line_spec: dict, data_root: dict) -> dict | None:
+        for candidate in (line_spec, data_root):
+            data = candidate.get("data")
+            if isinstance(data, dict) and isinstance(data.get("values"), list):
+                return candidate
+        return None
+
+    def _write_inline_values(self, holder: dict, rows: list[dict]) -> None:
+        data = holder.get("data")
+        if isinstance(data, dict) and "values" in data:
+            data["values"] = rows
+
+    def _named_dataset_rows(
+        self, line_spec: dict, data_root: dict
+    ) -> tuple[str, list] | None:
+        for candidate in (line_spec, data_root):
+            data = candidate.get("data")
+            if not isinstance(data, dict):
+                continue
+            name = data.get("name")
+            if (
+                isinstance(name, str)
+                and isinstance(data_root.get("datasets"), dict)
+                and isinstance(data_root["datasets"].get(name), list)
+            ):
+                return name, data_root["datasets"][name]
+        return None
+
+    def _set_named_dataset_rows(self, data_root: dict, name: str, rows: list[dict]) -> None:
+        data_root.setdefault("datasets", {})[name] = rows
+
+    def _series_keys(self, encoding: dict) -> list[str]:
+        c = encoding.get("color")
+        if isinstance(c, dict) and isinstance(c.get("field"), str):
+            return [c["field"]]
+        return []
+
+    def _facet_field_keys(self, data_root: dict) -> list[str]:
+        """Facet / row / column fields so multi-panel specs split series per panel."""
+        keys: list[str] = []
+        for name in ("facet", "row", "column"):
+            node = data_root.get(name)
+            if not isinstance(node, dict):
+                continue
+            f = node.get("field")
+            if isinstance(f, str):
+                keys.append(f)
+        return keys
+
+    def _dedupe_sort_group(
+        self, rows: list[dict], x_field: str
+    ) -> list[tuple[int, dict]]:
+        by_year: dict[int, dict] = {}
+        order: list[int] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            yi = _single_obs_year_to_int(row.get(x_field))
+            if yi is None:
+                continue
+            if yi not in by_year:
+                order.append(yi)
+            by_year[yi] = dict(row)
+        order.sort()
+        return [(y, by_year[y]) for y in order]
+
+    def _group_rows_by_series(
+        self, rows: list[dict], series_keys: list[str]
+    ) -> dict[tuple, list[dict]]:
+        groups: defaultdict[tuple, list[dict]] = defaultdict(list)
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            key = tuple(row.get(k) for k in series_keys) if series_keys else (None,)
+            groups[key].append(dict(row))
+        return dict(groups)
+
+    def _any_calendar_year_gap(
+        self, groups: dict[tuple, list[dict]], x_field: str
+    ) -> bool:
+        for grp_rows in groups.values():
+            chain = self._dedupe_sort_group(grp_rows, x_field)
+            if len(chain) < 2:
+                continue
+            for i in range(len(chain) - 1):
+                y0 = chain[i][0]
+                y1 = chain[i + 1][0]
+                if y1 - y0 > 1:
+                    return True
+        return False
+
+    def _build_segment_rows(
+        self, groups: dict[tuple, list[dict]], x_field: str, series_keys: list[str]
+    ) -> list[dict]:
+        out: list[dict] = []
+        seg_i = 0
+        for key, grp_rows in groups.items():
+            chain = self._dedupe_sort_group(grp_rows, x_field)
+            if len(chain) < 2:
+                continue
+            prefix = "_".join("" if v is None else str(v) for v in key)
+            for i in range(len(chain) - 1):
+                y0, r0 = chain[i]
+                y1, r1 = chain[i + 1]
+                gap = 1 if (y1 - y0) > 1 else 0
+                sid = f"{prefix}_{seg_i}" if prefix else str(seg_i)
+                seg_i += 1
+                a = {**r0, _LINE_GAP_SEG_DETAIL: sid, _LINE_GAP_STROKE_FLAG: gap}
+                b = {**r1, _LINE_GAP_SEG_DETAIL: sid, _LINE_GAP_STROKE_FLAG: gap}
+                out.append(a)
+                out.append(b)
+        return out
+
+    def _strip_internal_tooltip_channels(self, encoding: dict) -> None:
+        tips = encoding.get("tooltip")
+        if not isinstance(tips, list):
+            return
+        internal = {_LINE_GAP_SEG_DETAIL, _LINE_GAP_STROKE_FLAG}
+        encoding["tooltip"] = [
+            t
+            for t in tips
+            if not (isinstance(t, dict) and t.get("field") in internal)
+        ]
+
+    def _maybe_transform_line_spec(self, line_spec: dict, data_root: dict) -> None:
+        enc = line_spec.get("encoding")
+        if not isinstance(enc, dict):
+            return
+        x = enc.get("x", {})
+        x_field = x.get("field") if isinstance(x, dict) else None
+        if x_field not in ("year", "time_period"):
+            return
+
+        holder = self._find_inline_values_holder(line_spec, data_root)
+        rows: list[dict] | None = None
+        if holder is not None:
+            v = holder["data"]["values"]
+            rows = v if isinstance(v, list) else None
+        else:
+            named = self._named_dataset_rows(line_spec, data_root)
+            if named is not None:
+                _, rows_list = named
+                rows = rows_list if isinstance(rows_list, list) else None
+        if not rows or len(rows) < 2:
+            return
+
+        facet_keys = self._facet_field_keys(data_root)
+        series_keys = list(
+            dict.fromkeys([*self._series_keys(enc), *facet_keys]),
+        )
+        groups = self._group_rows_by_series(rows, series_keys)
+        if not self._any_calendar_year_gap(groups, x_field):
+            return
+
+        new_rows = self._build_segment_rows(groups, x_field, series_keys)
+        if len(new_rows) < 2:
+            return
+
+        if holder is not None:
+            self._write_inline_values(holder, new_rows)
+        else:
+            named = self._named_dataset_rows(line_spec, data_root)
+            if named is None:
+                return
+            name, _ = named
+            self._set_named_dataset_rows(data_root, name, new_rows)
+
+        enc["detail"] = {"field": _LINE_GAP_SEG_DETAIL, "type": "nominal"}
+        enc["strokeDash"] = {
+            "condition": {
+                "test": f"datum.{_LINE_GAP_STROKE_FLAG} == 1",
+                "value": [6, 4],
+            },
+            "value": [],
+        }
+        self._strip_internal_tooltip_channels(enc)
+
+
 class LineChartPointHoverRule(PostProcessingRule):
     """Add / enlarge line points so tooltips are easier to trigger (thin line geometry)."""
 
@@ -2004,6 +2284,7 @@ POST_PROCESSING_RULES: list[PostProcessingRule] = [
     TemporalAxisCleanupRule(),
     DiscreteYearBarXAxisRule(),
     ValueAxisLabelFormatRule(),
+    LineYearGapStrokeDashRule(),
     LineChartPointHoverRule(),
     ZeroLineRule(),
     ApplyWBStyleRule(),

--- a/src/data360/viz_config.py
+++ b/src/data360/viz_config.py
@@ -14,7 +14,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Literal
+from numbers import Integral
+from typing import Any, Literal
 
 import pandas as pd
 
@@ -1467,6 +1468,108 @@ def get_data_preparation_action(
     return "datetime"
 
 
+_YEAR_GAP_FILL_MAX_SPAN = 400
+
+
+def frequency_allows_annual_year_gap_fill(data_frequency: str | None) -> bool:
+    """True when data are treated as annual so missing calendar years can be inserted."""
+    if data_frequency is None or not str(data_frequency).strip():
+        return True
+    code = str(data_frequency).strip().upper()
+    if code in FREQUENCY_TO_TIMEUNIT and code != "A":
+        return False
+    return code in ("A", "ANNUAL", "Y", "YEAR", "YA")
+
+
+def _clone_year_field(y_int: int, sample: Any) -> Any:
+    """Match ``year`` dtype/shape used in the source group (string, datetime, int)."""
+    if isinstance(sample, str):
+        stripped = sample.strip()
+        if len(stripped) == 4 and stripped.isdigit():
+            return str(y_int)
+        return pd.Timestamp(year=y_int, month=1, day=1)
+    if isinstance(sample, pd.Timestamp):
+        return pd.Timestamp(year=y_int, month=1, day=1)
+    if isinstance(sample, Integral) and not isinstance(sample, bool):
+        return int(y_int)
+    if isinstance(sample, float) and not pd.isna(sample) and sample == int(sample):
+        return int(y_int)
+    return pd.Timestamp(year=y_int, month=1, day=1)
+
+
+def _coerce_year_column_to_int(series: pd.Series) -> pd.Series:
+    if pd.api.types.is_datetime64_any_dtype(series):
+        return series.dt.year.astype("Int64")
+    parsed = pd.to_datetime(series, errors="coerce")
+    if parsed.notna().mean() >= 0.99 and parsed.notna().any():
+        return parsed.dt.year.astype("Int64")
+    num = pd.to_numeric(series, errors="coerce")
+    return num.round().astype("Int64")
+
+
+def fill_missing_calendar_years_annual(
+    df: pd.DataFrame,
+    data_frequency: str | None,
+) -> pd.DataFrame:
+    """Insert NaN rows for missing integer calendar years within each series' span.
+
+    Each *series* is defined by every column except ``year`` and ``value`` (e.g. one
+    country). For that series, all calendar years from min(year) to max(year) appear
+    exactly once; gaps in the source (e.g. no 2010) become explicit rows with null
+    ``value``. Skipped when frequency is not annual, years cannot be coerced, any
+    (series, year) duplicates exist, or the span exceeds ``_YEAR_GAP_FILL_MAX_SPAN``.
+    """
+    if df.empty or "year" not in df.columns or "value" not in df.columns:
+        return df
+    if not frequency_allows_annual_year_gap_fill(data_frequency):
+        return df
+
+    y_int = _coerce_year_column_to_int(df["year"])
+    if y_int.isna().all():
+        return df
+
+    work = df.copy()
+    work["_yi"] = y_int
+    work = work.loc[~work["_yi"].isna()].copy()
+    work["_yi"] = work["_yi"].astype(int)
+
+    gcols = [c for c in work.columns if c not in ("year", "value", "_yi")]
+    dup_check = work.groupby(gcols + ["_yi"], dropna=False).size()
+    if (dup_check > 1).any():
+        return df
+
+    out_rows: list[pd.Series] = []
+    grouped = (
+        work.groupby(gcols, dropna=False)
+        if gcols
+        else [(tuple(), work)]
+    )
+    for _gkey, g in grouped:
+        lo = int(g["_yi"].min())
+        hi = int(g["_yi"].max())
+        if hi - lo > _YEAR_GAP_FILL_MAX_SPAN:
+            return df
+        sample_year = g["year"].iloc[0]
+        existing = set(int(x) for x in g["_yi"].tolist())
+        for yi in range(lo, hi + 1):
+            match = g[g["_yi"] == yi]
+            if len(match) > 0:
+                out_rows.append(match.iloc[0].drop(labels=["_yi"]))
+            else:
+                proto = g.iloc[0].drop(labels=["_yi"]).to_dict()
+                proto["year"] = _clone_year_field(yi, sample_year)
+                proto["value"] = float("nan")
+                out_rows.append(pd.Series(proto))
+
+    out = pd.DataFrame(out_rows)
+    out = out.reindex(columns=df.columns)
+    meta_cols = [c for c in df.columns if c not in ("year", "value")]
+    out["_sy"] = _coerce_year_column_to_int(out["year"])
+    sort_keys = [k for k in (*meta_cols, "_sy") if k in out.columns]
+    out = out.sort_values(by=sort_keys, na_position="last").drop(columns=["_sy"])
+    return out
+
+
 def should_prepare_as_datetime(
     viz_data: pd.DataFrame, chart_type: str, frequency: str | None
 ) -> bool:
@@ -1521,6 +1624,106 @@ def _year_ordinal_value_needs_temporal_encoding(value: object) -> bool:
         # Altair often serializes datetimes as milliseconds in embedded datasets
         return abs(fv) >= _YEAR_ORDINAL_EPOCH_MS_THRESHOLD
     return False
+
+
+def _extract_spec_dataset_rows(spec: dict) -> list[dict] | None:
+    """Return embedded chart rows from ``data.values`` or ``datasets[name]``."""
+    data = spec.get("data")
+    if isinstance(data, dict) and "values" in data:
+        v = data.get("values")
+        return v if isinstance(v, list) else None
+    ds_name = data.get("name") if isinstance(data, dict) else None
+    if ds_name and isinstance(spec.get("datasets"), dict):
+        rows = spec["datasets"].get(ds_name)
+        return rows if isinstance(rows, list) else None
+    return None
+
+
+def _single_obs_year_to_int(value: object) -> int | None:
+    """Parse one observation's year field to a calendar year, or None."""
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, Integral):
+        return int(value)
+    if isinstance(value, float) and value == int(value):
+        return int(value)
+    if isinstance(value, str):
+        s = value.strip()
+        if len(s) >= 4 and s[:4].isdigit():
+            return int(s[:4])
+        ts = pd.to_datetime(s, errors="coerce")
+        if pd.notna(ts):
+            return int(ts.year)
+        return None
+    if isinstance(value, pd.Timestamp):
+        return int(value.year)
+    return None
+
+
+class ContiguousCalendarYearDomainRule(PostProcessingRule):
+    """Ordinal/nominal ``year`` / ``time_period`` on x: full calendar year range on the scale.
+
+    Applies to marks that commonly use a discrete year axis (bar, line, area, point, tick).
+    Does **not** apply when ``x`` is ``temporal`` (handled separately; continuous time ≠ discrete domain).
+    """
+
+    def __init__(self):
+        super().__init__(
+            "contiguous_calendar_year_domain",
+            ["bar", "line", "area", "point", "tick"],
+            "Ordinal/nominal year x: explicit scale.domain for every calendar year in min–max span",
+        )
+
+    def apply(self, spec, data_frequency=None, unit_measure=None):
+        if not frequency_allows_annual_year_gap_fill(data_frequency):
+            return spec
+        if "encoding" not in spec or "x" not in spec["encoding"]:
+            return spec
+        mark_type = (
+            spec.get("mark", {}).get("type")
+            if isinstance(spec.get("mark"), dict)
+            else spec.get("mark")
+        )
+        if mark_type not in self.applies_to_mark_types:
+            return spec
+        x = spec["encoding"]["x"]
+        xf = x.get("field")
+        if xf not in ("year", "time_period"):
+            return spec
+        if x.get("type") not in ("ordinal", "nominal"):
+            return spec
+        if x.get("scale", {}).get("domain") is not None:
+            return spec
+        rows = _extract_spec_dataset_rows(spec)
+        if not rows or len(rows) < 2:
+            return spec
+        years: list[int] = []
+        template: object | None = None
+        for row in rows:
+            if not isinstance(row, dict) or xf not in row:
+                continue
+            raw = row.get(xf)
+            if raw is None:
+                continue
+            if template is None:
+                template = raw
+            yi = _single_obs_year_to_int(raw)
+            if yi is not None:
+                years.append(yi)
+        if len(years) < 2:
+            return spec
+        lo, hi = min(years), max(years)
+        if hi - lo > _YEAR_GAP_FILL_MAX_SPAN:
+            return spec
+        if template is None:
+            return spec
+        domain = [_clone_year_field(y, template) for y in range(lo, hi + 1)]
+        x.setdefault("scale", {})["domain"] = domain
+        # Explicit sort matches domain order (helps Vega-Lite / Vega compile stability).
+        x["sort"] = domain
+        return spec
 
 
 class OrdinalToTemporalRule(PostProcessingRule):
@@ -1797,6 +2000,7 @@ POST_PROCESSING_RULES: list[PostProcessingRule] = [
     OrdinalToTemporalRule(),
     ApplyTimeUnitRule(),
     FixValueAxisEncodingRule(),
+    ContiguousCalendarYearDomainRule(),
     TemporalAxisCleanupRule(),
     DiscreteYearBarXAxisRule(),
     ValueAxisLabelFormatRule(),

--- a/src/data360/viz_config.py
+++ b/src/data360/viz_config.py
@@ -531,15 +531,16 @@ def select_strategy(
 
     # Multi-year time series
     if year_count > 1:
+        phrase = chart_type_phrase_for_reason(hint)
         return StrategyResult(
             ChartStrategy.TEMPORAL_SINGLE,
-            f"Single indicator, {year_count} years, {country_count} countries → line chart",
+            f"Single indicator, {year_count} years, {country_count} countries → {phrase}",
             color_dim="country" if country_count > 0 else None,
         )
 
     return StrategyResult(
         ChartStrategy.FALLBACK_LINE,
-        "Default fallback → line chart",
+        f"Default fallback → {chart_type_phrase_for_reason(hint)}",
         color_dim="country" if country_count > 0 else None,
     )
 
@@ -1353,6 +1354,43 @@ def parse_chart_type_hint(chart_type: str | None) -> str:
         if any(keyword in hint for keyword in keywords):
             return mark_type
     return DEFAULT_CHART_TYPE
+
+
+_REASON_CHART_PHRASES: dict[str, str] = {
+    "line": "line chart",
+    "bar": "bar chart",
+    "area": "area chart",
+    "point": "point chart",
+    "tick": "strip chart",
+}
+
+
+def chart_type_phrase_for_reason(mark_type: str | None) -> str:
+    """Human phrase for strategy / tool ``reason`` (aligned with mark type hint or render)."""
+    if not mark_type:
+        return _REASON_CHART_PHRASES["line"]
+    normalized = mark_type.lower().strip()
+    return _REASON_CHART_PHRASES.get(normalized, f"{normalized} chart")
+
+
+def patch_strategy_reason_chart_phrase(reason: str, mark_type: str) -> str:
+    """Replace the trailing ``→ …`` segment so it reflects the given mark type."""
+    sep = " → "
+    if sep not in reason:
+        return reason
+    prefix, _old = reason.rsplit(sep, 1)
+    return f"{prefix}{sep}{chart_type_phrase_for_reason(mark_type)}"
+
+
+def extract_top_level_mark_type(vl_spec: dict) -> str | None:
+    """Best-effort mark ``type`` from a single-view Vega-Lite spec."""
+    mark = vl_spec.get("mark")
+    if isinstance(mark, str):
+        return mark
+    if isinstance(mark, dict):
+        t = mark.get("type")
+        return t if isinstance(t, str) else None
+    return None
 
 
 def infer_frequency_from_periodicity(periodicity: str) -> str | None:

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -271,8 +271,26 @@ class TestStructuredTooltips:
         assert value_tip["format"] == ",.2f", "Value tooltip must use number formatting"
         assert value_tip["type"] == "quantitative"
 
-    def test_year_tooltip_has_temporal_type(self):
-        tips = viz_config.build_structured_tooltips(["year", "value"], "line")
+    def test_year_tooltip_nominal_for_string_years_avoids_vl_date_parse(self):
+        """Temporal tooltips on string years make Vega-Lite parse year as date for all encodings."""
+        df = pd.DataFrame({"year": ["2018", "2019"], "value": [1.0, 2.0]})
+        tips = viz_config.build_structured_tooltips(
+            ["year", "value"], "line", viz_data=df
+        )
+        year_tip = next(t for t in tips if t["field"] == "year")
+        assert year_tip["type"] == "nominal"
+        assert "format" not in year_tip
+
+    def test_year_tooltip_temporal_when_column_is_datetime(self):
+        df = pd.DataFrame(
+            {
+                "year": pd.to_datetime(["2018-01-01", "2019-01-01"]),
+                "value": [1.0, 2.0],
+            }
+        )
+        tips = viz_config.build_structured_tooltips(
+            ["year", "value"], "line", viz_data=df
+        )
         year_tip = next(t for t in tips if t["field"] == "year")
         assert year_tip["type"] == "temporal"
         assert year_tip["format"] == "%Y"

--- a/tests/test_viz_complex.py
+++ b/tests/test_viz_complex.py
@@ -156,6 +156,13 @@ class TestStrategyRouter:
         assert r.strategy == ChartStrategy.TEMPORAL_SINGLE
         assert r.color_dim == "country"
 
+    def test_temporal_single_reason_reflects_chart_type_hint(self):
+        df = _ts_df(n_countries=1, n_years=5)
+        r_bar = select_strategy(df, chart_type_hint="bar chart")
+        assert "→ bar chart" in r_bar.reason
+        r_line = select_strategy(df, chart_type_hint="line")
+        assert "→ line chart" in r_line.reason
+
     def test_cross_sectional_single_year_few_countries(self):
         df = _cs_df(n_countries=5)
         r = select_strategy(df)

--- a/tests/test_viz_year_axis.py
+++ b/tests/test_viz_year_axis.py
@@ -1,12 +1,17 @@
 """Bar / ordinal year axis: confirm data-prep and post-processing avoid raw epoch ms labels."""
 
+import pandas as pd
+
 from data360.viz_config import (
     DiscreteYearBarXAxisRule,
     OrdinalToTemporalRule,
     TemporalAxisCleanupRule,
     _first_non_null_dataset_value,
     _year_ordinal_value_needs_temporal_encoding,
+    fill_missing_calendar_years_annual,
+    frequency_allows_annual_year_gap_fill,
     get_data_preparation_action,
+    wb_altair_config,
 )
 
 # 2014-01-01T00:00:00.000Z as milliseconds (example Altair dataset serialization)
@@ -87,3 +92,62 @@ def test_discrete_year_bar_x_axis_skips_temporal_x() -> None:
         "encoding": {"x": {"field": "year", "type": "temporal", "axis": {}}},
     }
     assert rule.should_apply(spec) is False
+
+
+def test_wb_altair_config_has_no_mark_invalid_override() -> None:
+    cfg = wb_altair_config()
+    assert "invalid" not in cfg.get("mark", {})
+
+
+def test_contiguous_year_domain_rule_sets_ordinal_domain() -> None:
+    from data360.viz_config import ContiguousCalendarYearDomainRule
+
+    rule = ContiguousCalendarYearDomainRule()
+    spec = {
+        "mark": {"type": "bar"},
+        "data": {
+            "values": [
+                {"year": "2007", "value": 10.0, "country": "Brazil"},
+                {"year": "2009", "value": 9.0, "country": "Brazil"},
+            ]
+        },
+        "encoding": {
+            "x": {"field": "year", "type": "ordinal"},
+            "y": {"field": "value", "type": "quantitative"},
+        },
+    }
+    out = rule.apply(spec, data_frequency="A")
+    assert out["encoding"]["x"]["scale"]["domain"] == ["2007", "2008", "2009"]
+    assert out["encoding"]["x"]["sort"] == ["2007", "2008", "2009"]
+
+
+def test_frequency_allows_annual_year_gap_fill() -> None:
+    assert frequency_allows_annual_year_gap_fill(None) is True
+    assert frequency_allows_annual_year_gap_fill("A") is True
+    assert frequency_allows_annual_year_gap_fill("M") is False
+    assert frequency_allows_annual_year_gap_fill("Q") is False
+
+
+def test_fill_missing_calendar_years_inserts_gap_year() -> None:
+    df = pd.DataFrame(
+        {
+            "year": ["2007", "2008", "2009", "2011"],
+            "value": [40.0, 39.0, 38.0, 36.0],
+            "country": ["Brazil"] * 4,
+        }
+    )
+    out = fill_missing_calendar_years_annual(df, "A")
+    assert len(out) == 5
+    years = sorted(int(str(y)[:4]) for y in out["year"])
+    assert years == [2007, 2008, 2009, 2010, 2011]
+    y2010 = out[out["year"].astype(str).str.startswith("2010")]
+    assert len(y2010) == 1
+    assert y2010["value"].isna().all()
+
+
+def test_fill_missing_calendar_years_skips_duplicate_year_rows() -> None:
+    df = pd.DataFrame(
+        {"year": ["2007", "2007"], "value": [1.0, 2.0], "country": ["x", "x"]}
+    )
+    out = fill_missing_calendar_years_annual(df, "A")
+    assert len(out) == len(df)

--- a/tests/test_viz_year_axis.py
+++ b/tests/test_viz_year_axis.py
@@ -1,0 +1,89 @@
+"""Bar / ordinal year axis: confirm data-prep and post-processing avoid raw epoch ms labels."""
+
+from data360.viz_config import (
+    DiscreteYearBarXAxisRule,
+    OrdinalToTemporalRule,
+    TemporalAxisCleanupRule,
+    _first_non_null_dataset_value,
+    _year_ordinal_value_needs_temporal_encoding,
+    get_data_preparation_action,
+)
+
+# 2014-01-01T00:00:00.000Z as milliseconds (example Altair dataset serialization)
+YEAR_2014_JAN1_UTC_MS = 1_388_534_400_000
+
+
+def test_get_data_preparation_action_bar_unknown_frequency_uses_year_strings() -> None:
+    assert get_data_preparation_action("bar", None) == "year_strings"
+    assert get_data_preparation_action("bar", "A") == "year_strings"
+
+
+def test_get_data_preparation_action_line_unknown_frequency_stays_datetime() -> None:
+    assert get_data_preparation_action("line", None) == "datetime"
+
+
+def test_year_ordinal_value_needs_temporal_encoding() -> None:
+    assert _year_ordinal_value_needs_temporal_encoding(YEAR_2014_JAN1_UTC_MS) is True
+    assert _year_ordinal_value_needs_temporal_encoding("2014-01-01T00:00:00") is True
+    assert _year_ordinal_value_needs_temporal_encoding("2014") is False
+    assert _year_ordinal_value_needs_temporal_encoding(2014) is False
+
+
+def test_first_non_null_dataset_value() -> None:
+    rows = [{"year": None, "v": 1}, {"year": YEAR_2014_JAN1_UTC_MS, "v": 2}]
+    assert _first_non_null_dataset_value(rows, "year") == YEAR_2014_JAN1_UTC_MS
+
+
+def test_ordinal_to_temporal_rule_bar_ms_dataset_updates_encoding() -> None:
+    rule = OrdinalToTemporalRule()
+    spec = {
+        "mark": {"type": "bar"},
+        "data": {"name": "ds0"},
+        "datasets": {
+            "ds0": [
+                {"year": YEAR_2014_JAN1_UTC_MS, "value": 41.7, "country": "Brazil"},
+            ]
+        },
+        "encoding": {
+            "x": {"field": "year", "type": "ordinal"},
+            "y": {"field": "value", "type": "quantitative"},
+        },
+    }
+    out = rule.apply(spec)
+    assert out["encoding"]["x"]["type"] == "temporal"
+
+
+def test_temporal_axis_cleanup_applies_to_bar_with_temporal_x() -> None:
+    rule = TemporalAxisCleanupRule()
+    spec = {
+        "mark": {"type": "bar"},
+        "encoding": {
+            "x": {"field": "year", "type": "temporal", "axis": {}},
+        },
+    }
+    assert rule.should_apply(spec) is True
+    out = rule.apply(spec)
+    assert out["encoding"]["x"]["axis"]["format"] == "%Y"
+
+
+def test_discrete_year_bar_x_axis_sets_label_angle() -> None:
+    rule = DiscreteYearBarXAxisRule()
+    spec = {
+        "mark": {"type": "bar"},
+        "encoding": {
+            "x": {"field": "year", "type": "ordinal"},
+            "y": {"field": "value", "type": "quantitative"},
+        },
+    }
+    assert rule.should_apply(spec) is True
+    out = rule.apply(spec)
+    assert out["encoding"]["x"]["axis"]["labelAngle"] == 0
+
+
+def test_discrete_year_bar_x_axis_skips_temporal_x() -> None:
+    rule = DiscreteYearBarXAxisRule()
+    spec = {
+        "mark": {"type": "bar"},
+        "encoding": {"x": {"field": "year", "type": "temporal", "axis": {}}},
+    }
+    assert rule.should_apply(spec) is False

--- a/tests/test_viz_year_axis.py
+++ b/tests/test_viz_year_axis.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from data360.viz_config import (
     DiscreteYearBarXAxisRule,
+    LineYearGapStrokeDashRule,
     OrdinalToTemporalRule,
     TemporalAxisCleanupRule,
     _first_non_null_dataset_value,
@@ -151,3 +152,170 @@ def test_fill_missing_calendar_years_skips_duplicate_year_rows() -> None:
     )
     out = fill_missing_calendar_years_annual(df, "A")
     assert len(out) == len(df)
+
+
+def test_line_year_gap_stroke_dash_splits_when_calendar_gap() -> None:
+    rule = LineYearGapStrokeDashRule()
+    spec = {
+        "data": {
+            "values": [
+                {"year": "2020-01-01", "country": "A", "value": 1.0},
+                {"year": "2021-01-01", "country": "A", "value": 2.0},
+                {"year": "2024-01-01", "country": "A", "value": 3.0},
+            ]
+        },
+        "mark": {"type": "line"},
+        "encoding": {
+            "x": {"field": "year", "type": "temporal"},
+            "y": {"field": "value", "type": "quantitative"},
+            "color": {"field": "country", "type": "nominal"},
+        },
+    }
+    out = rule.apply(spec)
+    assert len(out["data"]["values"]) == 4
+    assert out["encoding"]["detail"]["field"] == "_d360_lseg"
+    assert "strokeDash" in out["encoding"]
+    cond = out["encoding"]["strokeDash"]["condition"]
+    assert cond["value"] == [6, 4]
+
+
+def test_line_year_gap_stroke_dash_applies_when_x_has_annual_timeunit() -> None:
+    """WDI annual pipeline sets ``timeUnit: \"year\"`` on x before this rule — must still dash gaps."""
+    rule = LineYearGapStrokeDashRule()
+    spec = {
+        "data": {
+            "values": [
+                {"year": "2009-01-01", "value": 8.4},
+                {"year": "2011-01-01", "value": 7.1},
+            ]
+        },
+        "mark": {"type": "line"},
+        "encoding": {
+            "x": {"field": "year", "type": "temporal", "timeUnit": "year"},
+            "y": {"field": "value", "type": "quantitative"},
+        },
+    }
+    out = rule.apply(spec)
+    assert out["encoding"]["detail"]["field"] == "_d360_lseg"
+    assert len(out["data"]["values"]) == 2
+
+
+def test_line_year_gap_stroke_dash_skips_monthly_timeunit() -> None:
+    rule = LineYearGapStrokeDashRule()
+    spec = {
+        "data": {
+            "values": [
+                {"year": "2009-01-01", "value": 8.4},
+                {"year": "2011-01-01", "value": 7.1},
+            ]
+        },
+        "mark": {"type": "line"},
+        "encoding": {
+            "x": {"field": "year", "type": "temporal", "timeUnit": "yearmonth"},
+            "y": {"field": "value", "type": "quantitative"},
+        },
+    }
+    out = rule.apply(spec)
+    assert "detail" not in out["encoding"]
+    assert len(out["data"]["values"]) == 2
+
+
+def test_line_year_gap_stroke_dash_skips_monthly_timeunit() -> None:
+    rule = LineYearGapStrokeDashRule()
+    spec = {
+        "data": {
+            "values": [
+                {"year": "2009-01-01", "value": 8.4},
+                {"year": "2011-01-01", "value": 7.1},
+            ]
+        },
+        "mark": {"type": "line"},
+        "encoding": {
+            "x": {"field": "year", "type": "temporal", "timeUnit": "yearmonth"},
+            "y": {"field": "value", "type": "quantitative"},
+        },
+    }
+    out = rule.apply(spec)
+    assert "detail" not in out["encoding"]
+    assert len(out["data"]["values"]) == 2
+
+
+def test_line_year_gap_facet_with_inner_layer_reads_outer_data() -> None:
+    rule = LineYearGapStrokeDashRule()
+    spec = {
+        "data": {
+            "values": [
+                {"country": "Brazil", "year": "2009-01-01", "value": 8.4},
+                {"country": "Brazil", "year": "2011-01-01", "value": 7.1},
+            ]
+        },
+        "facet": {"field": "country", "type": "nominal"},
+        "spec": {
+            "layer": [
+                {
+                    "mark": {"type": "line"},
+                    "encoding": {
+                        "x": {"field": "year", "type": "temporal"},
+                        "y": {"field": "value", "type": "quantitative"},
+                    },
+                },
+                {
+                    "mark": {"type": "point"},
+                    "encoding": {
+                        "x": {"field": "year", "type": "temporal"},
+                        "y": {"field": "value", "type": "quantitative"},
+                    },
+                },
+            ]
+        },
+    }
+    out = rule.apply(spec)
+    line0 = out["spec"]["layer"][0]
+    assert line0["encoding"]["detail"]["field"] == "_d360_lseg"
+    assert len(out["data"]["values"]) == 2
+
+
+def test_line_year_gap_stroke_dash_skips_consecutive_years() -> None:
+    rule = LineYearGapStrokeDashRule()
+    spec = {
+        "data": {
+            "values": [
+                {"year": "2020-01-01", "value": 1.0},
+                {"year": "2021-01-01", "value": 2.0},
+            ]
+        },
+        "mark": {"type": "line"},
+        "encoding": {
+            "x": {"field": "year", "type": "temporal"},
+            "y": {"field": "value", "type": "quantitative"},
+        },
+    }
+    out = rule.apply(spec)
+    assert len(out["data"]["values"]) == 2
+    assert "detail" not in out["encoding"]
+
+
+def test_line_year_gap_stroke_dash_respects_facet_field() -> None:
+    """Each facet series is split separately (no merging countries into one line)."""
+    rule = LineYearGapStrokeDashRule()
+    spec = {
+        "data": {
+            "values": [
+                {"country": "A", "year": "2020-01-01", "value": 1.0},
+                {"country": "A", "year": "2024-01-01", "value": 2.0},
+                {"country": "B", "year": "2020-01-01", "value": 3.0},
+                {"country": "B", "year": "2021-01-01", "value": 4.0},
+            ]
+        },
+        "facet": {"field": "country", "type": "nominal"},
+        "spec": {
+            "mark": {"type": "line"},
+            "encoding": {
+                "x": {"field": "year", "type": "temporal"},
+                "y": {"field": "value", "type": "quantitative"},
+            },
+        },
+    }
+    out = rule.apply(spec)
+    assert len(out["data"]["values"]) == 4
+    assert out["spec"]["encoding"]["detail"]["field"] == "_d360_lseg"


### PR DESCRIPTION
## Summary

Improves **year / time handling** for Vega-Lite specs so **bar charts** use discrete, readable year axes (no raw epoch-style labels), **line charts** keep appropriate temporal encoding, and **gaps in annual time series** render as **broken segments** instead of misleading continuous lines. Also aligns **strategy “reason”** text with the chart type actually emitted (including `temporal_single`), and enriches **structured tooltips** with year/period context from the dataframe.

## Motivation

- Ordinal year encodings paired with **milliseconds or ISO datetime strings** in the dataset produced poor or inconsistent axes; bars especially needed **string years** or targeted **ordinal → temporal** fixes plus axis cleanup (`%Y` formatting where appropriate).
- Multi-year **line** series with missing calendar years should not imply continuity across gaps.
- User-facing **reason** strings could mention a chart type that did not match the resolved mark after post-processing.

## What changed

- **`src/data360/viz_config.py`**: Data-prep hooks (`get_data_preparation_action`, `fill_missing_calendar_years_annual`, frequency helpers), post-processing rules (`OrdinalToTemporalRule`, `TemporalAxisCleanupRule`, `DiscreteYearBarXAxisRule`, `LineYearGapStrokeDashRule`), subtitle/title helpers for geography + year range, and **`build_structured_tooltips`** updates so `year` / `time_period` tooltips choose **temporal vs ordinal** based on real column dtypes (avoids breaking ordinal bar x-axes).
- **`src/data360/visualization.py`**: Passes **`viz_data`** into structured tooltip building; for **`ChartStrategy.TEMPORAL_SINGLE`**, patches **`reason`** via **`patch_strategy_reason_chart_phrase`** using the resolved top-level mark.
- **Tests**: New **`tests/test_viz_year_axis.py`** covering bar vs line prep, ordinal/temporal edge cases, rule applications, and gap styling; incremental updates in **`tests/test_visualization.py`** and **`tests/test_viz_complex.py`**.
