### PR TITLE
feat: handle indicators with custom dimensions (COMP_BREAKDOWN_1/2)

### DIFF
--- a/src/data360/mcp_server/prompts.py
+++ b/src/data360/mcp_server/prompts.py
@@ -124,6 +124,40 @@ Do not answer with guesses. Do not stop after describing a plan.
    - **DECIDE**: Does the frame support a chart? (e.g. time_period + obs_value for lines.)
    - If the shape does **not** support a chart, present the **table** — do not force a broken viz.
 
+   #### Grammar-of-graphics rule for disaggregation_filters
+   **Do NOT pin a dimension in disaggregation_filters to simplify a chart.**
+   Pinning collapses multi-series data into a single line and silently discards information.
+
+   | Situation | Correct action |
+   |-----------|---------------|
+   | User said "show only females" | `disaggregation_filters={"SEX": "F"}` |
+   | User said "totals only" / "aggregate" | `disaggregation_filters={"SEX": "_T"}` |
+   | Dimension not applicable | `disaggregation_filters={"SEX": "_Z"}` |
+   | Multiple values exist, user has NO preference | **OMIT the dimension entirely** — the pipeline maps it to color/facet automatically |
+
+   The pipeline auto-detects non-trivial dimensions (_T/_Z are trivial) and routes:
+   - breakdown + multi-year + 1 country → TEMPORAL_SINGLE (color = breakdown dim)
+   - breakdown + multi-country          → SMALL_MULTIPLES (facet = country, color = breakdown)
+   - no breakdown, multi-year           → TEMPORAL_SINGLE (color = country)
+
+   #### Mixed-unit breakdown warning (Option A)
+   Some indicators carry comp_breakdown_1 values that represent **structurally different
+   metric types** — not just different categories of the same quantity. Example: WGI uses
+   WGI_EST (estimate, ~−2.5 to +2.5), WGI_SC (percentile rank, 0–100), WGI_SE (standard
+   error), WGI_SR (source count), WGI_SC_LB/UB (confidence bounds). Plotting all on one
+   Y-axis is misleading because the scales are incompatible.
+
+   **When you call data360_get_disaggregation and find comp_breakdown_1 has 3+ values,
+   check if they represent different metric types** (e.g. estimate + rank + error + count).
+   If so, BEFORE calling the visualization tool:
+   1. List the available breakdown values and their meanings to the user.
+   2. Recommend the primary analytic series (e.g. WGI_EST for governance analysis,
+      WGI_SC for cross-country rank comparison).
+   3. Ask which breakdown the user wants, or proceed with the recommended one and say so.
+
+   The chart subtitle will always list all series present — users can read it to understand
+   what is shown. But proactively surfacing the choice is better than a crowded chart.
+
    ┌─ ONE indicator? ──────────────────────────────────────────────────────────┐
    │  Call data360_get_viz_spec                                                │
    │  • Multi-year, 1-8 countries  → chart_type="line"  (auto color by cntry) │
@@ -133,7 +167,6 @@ Do not answer with guesses. Do not stop after describing a plan.
    │  • Pass relevant_fields=["time_period","obs_value",...] when you must    │
    │    pin exact columns; the tool can auto-enrich dimensions when needed.   │
    │  • If the user asked for a style ("bar chart"), pass chart_type="bar".   │
-   │  • Optional: custom_constraints for Draco when the user gave layout rules. │
    └───────────────────────────────────────────────────────────────────────────┘
 
    ┌─ TWO OR MORE indicators? ─────────────────────────────────────────────────┐
@@ -145,7 +178,7 @@ Do not answer with guesses. Do not stop after describing a plan.
    │     {"database_id": "WB_WDI", "indicator_id": "WB_WDI_SP_DYN_LE00_IN"}]   │
    │  • Optional: country_code, start_year, end_year, disaggregation_filters,  │
    │    chart_type — same names as data360_get_viz_spec except there is NO     │
-   │    relevant_fields, custom_constraints, or use_default_constraints.       │
+   │    relevant_fields or custom_constraints.                                 │
    │                                                                           │
    │  Chart type selection:                                                    │
    │  • "Compare X vs Y across countries, one year"  → chart_type="scatter"  │
@@ -426,12 +459,22 @@ data360_get_data(
 **Step 5: Visualize**
 If data is suitable (time series), visualize directly.
 For multi-country, the tool auto-handles color-coding.
+
+Grammar-of-graphics rule: do NOT pin disaggregation dimensions to simplify the chart.
+If the indicator has breakdowns (sex, age, comp_breakdown_1, etc.) and the user did not
+request a specific value, OMIT those dimensions from disaggregation_filters entirely.
+The pipeline maps them to color/facet channels automatically.
+
+  WRONG: disaggregation_filters={{"COMP_BREAKDOWN_1": "WGI_EST"}}  # silently drops 5 series
+  RIGHT: (omit COMP_BREAKDOWN_1 — pipeline auto-routes to SMALL_MULTIPLES or multi-series line)
+
 data360_get_viz_spec(
     database_id=<db_id>,
     indicator_id=<ind_id>,
     country_code="<ISO: one code, or several with semicolons e.g. KEN;UGA>",
-    # If explicit breakdown needed:
-    # disaggregation_filters={{"SEX": None}}, # Explicitly ask for all sexes
+    # Only pin a dimension when the user explicitly requested it:
+    # disaggregation_filters={{"SEX": "F"}},   # user said "females only"
+    # disaggregation_filters={{"SEX": "_T"}},  # user said "totals only"
     chart_type="line"
 )
 """

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -54,6 +54,18 @@ _FALLBACK_WARNING = (
 
 VizResult = dict[str, str | None]
 
+# Disaggregation dimensions considered during viz data cleaning and encoding.
+# Mirrors _DISAGG_DIMS_TO_DETECT from api.py but in lowercase (post-column-rename).
+# Single source of truth for the viz pipeline: _clean_single_df, color dim
+# detection, and multi-indicator join keys all reference this tuple.
+_VIZ_DISAGG_DIMS: tuple[str, ...] = (
+    "sex",
+    "age",
+    "urbanisation",
+    "comp_breakdown_1",
+    "comp_breakdown_2",
+)
+
 
 # ============================================================================
 # STORAGE HELPERS
@@ -358,6 +370,9 @@ def _clean_single_df(
     data_frequency: str | None,
 ) -> tuple[pd.DataFrame, list[str]]:
     """Clean + rename a single-indicator DataFrame for the Draco path."""
+    # Trivial values for disaggregation dimensions: _T = aggregate total, _Z = not applicable.
+    _TRIVIAL_DIM_VALUES = ("_T", "_Z")
+
     if relevant_fields:
         req = [f.lower() for f in relevant_fields]
         missing = [f for f in req if f not in data.columns]
@@ -366,10 +381,10 @@ def _clean_single_df(
                 f"Requested fields not found: {missing}. Available: {list(data.columns)}"
             )
         valid_cols = req
-        for dim in ["ref_area", "sex", "age", "urbanisation"]:
+        for dim in ["ref_area", *_VIZ_DISAGG_DIMS]:
             if dim in data.columns and dim not in valid_cols:
                 uv = data[dim].unique()
-                if len(uv) > 1 or (len(uv) == 1 and uv[0] != "_T"):
+                if len(uv) > 1 or (len(uv) == 1 and uv[0] not in _TRIVIAL_DIM_VALUES):
                     valid_cols.append(dim)
         viz_data = data[valid_cols].copy()
         relevant_cols = valid_cols
@@ -378,10 +393,10 @@ def _clean_single_df(
         for col in ["time_period", "obs_value", "ref_area"]:
             if col in data.columns:
                 relevant_cols.append(col)
-        for dim in ["sex", "age", "urbanisation"]:
+        for dim in _VIZ_DISAGG_DIMS:
             if dim in data.columns:
                 uv = data[dim].unique()
-                if len(uv) > 1 or (len(uv) == 1 and uv[0] != "_T"):
+                if len(uv) > 1 or (len(uv) == 1 and uv[0] not in _TRIVIAL_DIM_VALUES):
                     relevant_cols.append(dim)
         viz_data = data[relevant_cols].copy() if relevant_cols else data.copy()
 
@@ -748,10 +763,10 @@ async def get_viz_spec(
                 "attribute((encoding,field),e2,value).",
             ]
 
-        # Color dimension
+        # Color dimension: prefer country, then standard disagg dims, then custom breakdowns.
         color_dim = strategy_result.color_dim
         if not color_dim:
-            for dim, _ in [("country", 0), ("sex", 0), ("age", 0), ("urbanisation", 0)]:
+            for dim in ["country", *_VIZ_DISAGG_DIMS]:
                 if dim in viz_data.columns and viz_data[dim].nunique() > 1:
                     color_dim = dim
                     break
@@ -967,7 +982,7 @@ async def get_multi_indicator_viz_spec(
         # Keep only join keys + value column
         keep = [
             c
-            for c in ["year", "country", "sex", "age", "urbanisation"]
+            for c in ["year", "country", *_VIZ_DISAGG_DIMS]
             if c in df.columns
         ]
         keep.append(col)
@@ -987,7 +1002,7 @@ async def get_multi_indicator_viz_spec(
     # 4. Merge on common keys
     join_keys = [
         c
-        for c in ["year", "country", "sex", "age", "urbanisation"]
+        for c in ["year", "country", *_VIZ_DISAGG_DIMS]
         if all(c in df.columns for df in std_dfs)
     ]
 

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -7,8 +7,8 @@ Vega-Lite specifications, then persists them either through the optional Charts 
 
 **Public tools**
 
-- ``get_viz_spec`` — one indicator. Uses Draco where appropriate and
-  ``data360.viz_config`` strategy dispatch for patterns Draco does not handle well.
+- ``get_viz_spec`` — one indicator. Uses ``data360.viz_config`` strategy dispatch
+  to build validated Vega-Lite v5 specs directly.
 - ``get_multi_indicator_viz_spec`` — two to four indicators; merges frames and
   dispatches multi-series strategies (scatter, layered lines, connected scatter, etc.).
 
@@ -33,12 +33,9 @@ import uuid
 from datetime import date, datetime
 from urllib.parse import parse_qs, urlparse
 
-import altair as alt
 import httpx
 import numpy as np
 import pandas as pd
-from draco import Draco, answer_set_to_dict, dict_to_facts, schema_from_dataframe
-from draco.renderer import AltairRenderer
 
 from data360 import viz_config
 from data360.config import get_mcp_server_settings
@@ -46,11 +43,6 @@ from data360.http_client import get_shared_httpx_client
 from data360.providers import get_database_mapping
 
 _logger = logging.getLogger(__name__)
-
-_FALLBACK_WARNING = (
-    "Draco could not determine an optimal encoding; "
-    "a default chart was generated as fallback."
-)
 
 VizResult = dict[str, str | None]
 
@@ -369,7 +361,7 @@ def _clean_single_df(
     chart_type: str | None,
     data_frequency: str | None,
 ) -> tuple[pd.DataFrame, list[str]]:
-    """Clean + rename a single-indicator DataFrame for the Draco path."""
+    """Clean + rename a single-indicator DataFrame for strategy-based specs."""
     # Trivial values for disaggregation dimensions: _T = aggregate total, _Z = not applicable.
     _TRIVIAL_DIM_VALUES = ("_T", "_Z")
 
@@ -622,12 +614,11 @@ async def get_viz_spec(
             semicolons in REF_AREA are normalized to commas.
         chart_type: Optional hint — "line", "bar", "scatter", "strip", "small_multiples".
         relevant_fields: Optional list of column names to include in the chart.
-        custom_constraints: Optional list of raw Draco ASP constraints.
-        use_default_constraints: If True (default), apply standard encoding heuristics.
+        custom_constraints: Deprecated legacy field; ignored by strategy-based specs.
+        use_default_constraints: Deprecated legacy field; ignored by strategy-based specs.
 
     Returns:
-        Dict with "url" (chart URL on success), "error" (message on failure),
-        and optionally "warning" (if fallback was used).
+        Dict with "url" (chart URL on success) and "error" (message on failure).
     """
     from data360.api import get_data_api_url, get_metadata
 
@@ -745,7 +736,7 @@ async def get_viz_spec(
         chart_title, raw_unit or None, viz_data
     )
 
-    # 7. Determine strategy — route around Draco for complex patterns
+    # 7. Determine strategy
     n_indicators = 1
     strategy_result = viz_config.select_strategy(
         viz_data,
@@ -757,183 +748,23 @@ async def get_viz_spec(
         f"Chart strategy: {strategy_result.strategy.value} — {strategy_result.reason}"
     )
 
-    # Strategy-based direct spec (bypasses Draco for all known patterns).
-    # TEMPORAL_SINGLE and FALLBACK_LINE are included unconditionally: Draco consistently
-    # picks scatter/point for time-series data regardless of color_dim, ignoring the
-    # strategy result. build_temporal_single_spec always produces the correct output.
-    bypass_strategies = {
-        viz_config.ChartStrategy.DISTRIBUTION,
-        viz_config.ChartStrategy.CROSS_SECTIONAL,
-        viz_config.ChartStrategy.BREAKDOWN_COMPARISON,
-        viz_config.ChartStrategy.SMALL_MULTIPLES,
-        viz_config.ChartStrategy.TEMPORAL_SINGLE,
-        viz_config.ChartStrategy.FALLBACK_LINE,
-    }
-
-    if strategy_result.strategy in bypass_strategies:
-        try:
-            spec = viz_config.dispatch_spec(
-                strategy_result.strategy,
-                viz_data,
-                chart_title_vl,
-                strategy_result,
-                unit_measure=raw_unit,
-            )
-            return _ok(
-                await _store_spec(spec),
-                source_attribution=source_attribution,
-                strategy=strategy_result.strategy.value,
-                reason=strategy_result.reason,
-            )
-        except Exception as e:
-            _logger.exception("Strategy builder failed")
-            return _err(f"Chart generation failed: {e}")
-
-    # 8. Draco path (temporal_single, fallback)
     try:
-        schema = schema_from_dataframe(viz_data)
-        facts = dict_to_facts(schema)
-    except Exception as e:
-        _logger.exception("Error generating schema")
-        return _err(f"Error generating data schema: {e}")
-
-    d = Draco()
-    program_constraints = ["entity(view,root,view).", "entity(mark,view,m)."]
-
-    if use_default_constraints:
-        user_mark_type = viz_config.parse_chart_type_hint(chart_type)
-        use_temporal_x, categorical_x_field = viz_config.should_use_temporal_x_axis(
-            viz_data, chart_type, viz_data.columns.tolist()
+        spec = viz_config.dispatch_spec(
+            strategy_result.strategy,
+            viz_data,
+            chart_title_vl,
+            strategy_result,
+            unit_measure=raw_unit,
         )
-
-        if use_temporal_x and "year" in viz_data.columns:
-            program_constraints += [
-                "entity(encoding,m,e1).",
-                "attribute((encoding,channel),e1,x).",
-                "attribute((encoding,field),e1,year).",
-            ]
-        elif not use_temporal_x and categorical_x_field:
-            program_constraints += [
-                "entity(encoding,m,e1).",
-                "attribute((encoding,channel),e1,x).",
-                f"attribute((encoding,field),e1,{categorical_x_field}).",
-            ]
-        elif "year" in viz_data.columns:
-            program_constraints += [
-                "entity(encoding,m,e1).",
-                "attribute((encoding,channel),e1,x).",
-                "attribute((encoding,field),e1,year).",
-            ]
-
-        if "value" in viz_data.columns:
-            program_constraints += [
-                "entity(encoding,m,e2).",
-                "attribute((encoding,channel),e2,y).",
-                "attribute((encoding,field),e2,value).",
-            ]
-
-        # Color dimension: prefer country, then standard disagg dims, then custom breakdowns.
-        color_dim = strategy_result.color_dim
-        if not color_dim:
-            for dim in ["country", *_VIZ_DISAGG_DIMS]:
-                if dim in viz_data.columns and viz_data[dim].nunique() > 1:
-                    color_dim = dim
-                    break
-
-        if color_dim:
-            program_constraints += [
-                "entity(encoding,m,e3).",
-                "attribute((encoding,channel),e3,color).",
-                f"attribute((encoding,field),e3,{color_dim}).",
-            ]
-
-        if chart_type:
-            program_constraints.append(f"attribute((mark,type),m,{user_mark_type}).")
-
-    if custom_constraints:
-        program_constraints.extend(custom_constraints)
-
-    program = "\n".join(facts) + "\n" + "\n".join(program_constraints)
-
-    try:
-        model = next(d.complete_spec(program))
-        draco_spec = answer_set_to_dict(model.answer_set)
-
-        if "view" in draco_spec:
-            for view in draco_spec["view"]:
-                if "mark" in view:
-                    for mark in view["mark"]:
-                        if "encoding" in mark:
-                            for enc in mark["encoding"]:
-                                enc.pop("type", None)
-
-        full_spec = {**schema, **draco_spec}
-        renderer = AltairRenderer()
-        chart = renderer.render(spec=full_spec, data=viz_data)
-        chart = chart.properties(title=chart_title_vl).interactive()
-
-        # Structured tooltips
-        mark_type_for_tt = viz_config.parse_chart_type_hint(chart_type)
-        structured_tooltips = viz_config.build_structured_tooltips(
-            list(viz_data.columns), mark_type_for_tt, viz_data=viz_data
-        )
-        chart = chart.encode(tooltip=[alt.Tooltip(**t) for t in structured_tooltips])
-
-        vl_spec = chart.to_dict()
-
-        # Patch color type: nominal for all known categorical dims.
-        # Without this, Draco sometimes assigns 'ordinal' to breakdown/sex dims.
-        if "encoding" in vl_spec and "color" in vl_spec["encoding"]:
-            _nominal_color_dims = {"country", "ref_area", *_VIZ_DISAGG_DIMS}
-            if color_dim in _nominal_color_dims:
-                vl_spec["encoding"]["color"]["type"] = "nominal"
-
-        # Post-processing rules
-        for rule in viz_config.POST_PROCESSING_RULES:
-            vl_spec = rule.apply(vl_spec, data_frequency, raw_unit or None)
-
-        out_reason = strategy_result.reason
-        if strategy_result.strategy == viz_config.ChartStrategy.TEMPORAL_SINGLE:
-            resolved_mark = viz_config.extract_top_level_mark_type(vl_spec)
-            if resolved_mark:
-                out_reason = viz_config.patch_strategy_reason_chart_phrase(
-                    strategy_result.reason, resolved_mark
-                )
-
         return _ok(
-            await _store_spec(vl_spec),
+            await _store_spec(spec),
             source_attribution=source_attribution,
             strategy=strategy_result.strategy.value,
-            reason=out_reason,
+            reason=strategy_result.reason,
         )
-
-    except StopIteration:
-        _logger.warning("Draco failed → fallback")
-        # Strategy-aware fallback
-        try:
-            spec = viz_config.dispatch_spec(
-                viz_config.ChartStrategy.FALLBACK_LINE,
-                viz_data,
-                chart_title_vl,
-                strategy_result,
-                unit_measure=raw_unit,
-            )
-            return _ok(
-                await _store_spec(spec),
-                warning=_FALLBACK_WARNING,
-                source_attribution=source_attribution,
-                strategy=strategy_result.strategy.value,
-                reason=strategy_result.reason,
-            )
-        except Exception as fallback_err:
-            _logger.exception(f"Fallback failed: {fallback_err}")
-            return _err(
-                "Error: Draco could not determine a suitable visualization, and fallback failed."
-            )
-
     except Exception as e:
-        _logger.exception(f"Draco error: {e}")
-        return _err(f"Error generating visualization: {e}")
+        _logger.exception("Strategy builder failed")
+        return _err(f"Chart generation failed: {e}")
 
 
 # ============================================================================

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -697,23 +697,18 @@ async def get_viz_spec(
         f"Chart strategy: {strategy_result.strategy.value} — {strategy_result.reason}"
     )
 
-    # Strategy-based direct spec (bypasses Draco for non-Draco-friendly patterns)
+    # Strategy-based direct spec (bypasses Draco for all known patterns).
+    # TEMPORAL_SINGLE and FALLBACK_LINE are included unconditionally: Draco consistently
+    # picks scatter/point for time-series data regardless of color_dim, ignoring the
+    # strategy result. build_temporal_single_spec always produces the correct output.
     bypass_strategies = {
         viz_config.ChartStrategy.DISTRIBUTION,
         viz_config.ChartStrategy.CROSS_SECTIONAL,
         viz_config.ChartStrategy.BREAKDOWN_COMPARISON,
         viz_config.ChartStrategy.SMALL_MULTIPLES,
+        viz_config.ChartStrategy.TEMPORAL_SINGLE,
+        viz_config.ChartStrategy.FALLBACK_LINE,
     }
-
-    # Also bypass Draco for TEMPORAL_SINGLE when the color dim is a breakdown dimension
-    # (not country). Draco independently picks mark type (often scatter/point) and ignores
-    # the strategy result, producing a scatter cloud instead of colored lines.
-    _nominal_breakdown_dims = set(_VIZ_DISAGG_DIMS)  # sex, age, urbanisation, comp_breakdown_1/2
-    if (
-        strategy_result.strategy == viz_config.ChartStrategy.TEMPORAL_SINGLE
-        and strategy_result.color_dim in _nominal_breakdown_dims
-    ):
-        bypass_strategies.add(viz_config.ChartStrategy.TEMPORAL_SINGLE)
 
     if strategy_result.strategy in bypass_strategies:
         spec = viz_config.dispatch_spec(

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -549,6 +549,63 @@ async def get_viz_spec(
     Use when the user wants a visualization for ONE indicator. For comparing multiple
     indicators (scatter, dual-axis), use data360_get_multi_indicator_viz_spec instead.
 
+    ## Grammar of Graphics Contract
+
+    The pipeline maps data dimensions to Vega-Lite aesthetic channels automatically
+    (color, facet). DO NOT pre-filter a dimension to simplify the chart — that collapses
+    multi-series data into a single undifferentiated line and silently discards information.
+
+    ### disaggregation_filters decision rule
+
+    Only pin a dimension when the user has explicitly requested a specific value:
+
+      CORRECT — user asked for females only:
+        disaggregation_filters={"SEX": "F"}
+
+      CORRECT — force aggregate totals (suppress breakdown display):
+        disaggregation_filters={"SEX": "_T"}
+
+      CORRECT — dimension is not applicable for this indicator:
+        disaggregation_filters={"SEX": "_Z"}
+
+      WRONG — do not pre-filter to reduce chart complexity:
+        disaggregation_filters={"COMP_BREAKDOWN_1": "WGI_EST"}  # silently drops other series
+        disaggregation_filters={"SEX": "_T"}                    # unless user said "totals only"
+
+    When a dimension has multiple meaningful values and the user has not requested a
+    specific one, OMIT it from disaggregation_filters entirely. The pipeline will:
+      - detect non-trivial values (anything other than "_T" or "_Z")
+      - choose the correct Vega-Lite channel based on data shape (see chart strategy table)
+
+    ### Chart strategy → Vega-Lite encoding table
+
+    The pipeline selects a strategy from the shape of the data after filtering. All
+    strategies bypass Draco and produce validated Vega-Lite v5 specs directly.
+
+    Strategy              | When selected                                       | Vega-Lite encoding
+    ----------------------|-----------------------------------------------------|-------------------------------------------
+    TEMPORAL_SINGLE       | multi-year, ≤8 countries, 0-1 breakdowns            | x=year(temporal), y=value(Q), color=country or breakdown(N)
+    CROSS_SECTIONAL       | single year, ≤8 countries, no breakdown             | y=country(N) sorted, x=value(Q) (horizontal bar)
+    DISTRIBUTION          | single year, >8 countries                           | x=value(Q), y=country(N) (tick/strip chart)
+    BREAKDOWN_COMPARISON  | 1 breakdown, single year, ≤4 countries              | x=country(N), xOffset=breakdown(N), y=value(Q) (grouped bar)
+    SMALL_MULTIPLES       | breakdown + >1 country, OR 2+ breakdowns            | facet=country(N), color=breakdown(N), x=year(temporal), y=value(Q)
+    TEMPORAL_SINGLE*      | 1 breakdown (any dim), multi-year                   | x=year(temporal), y=value(Q), color=breakdown(N) (multi-series line)
+    FALLBACK_LINE         | unclassified shapes                                 | x=year(temporal), y=value(Q), color=country(N)
+
+    *When comp_breakdown_1/2 has multiple values and year_count > 1, the pipeline routes
+    to TEMPORAL_SINGLE with color=comp_breakdown_1 — producing one colored line per
+    breakdown series. This is the correct encoding for WGI, sectoral breakdowns, etc.
+
+    ### Encoding type rules (Vega-Lite v5)
+
+    - Year fields: always type="temporal", format="%Y". Do not use "ordinal" for years
+      — ordinal maps ISO timestamps to raw millisecond integers on the axis.
+    - Country / breakdown fields: type="nominal"
+    - Numeric values: type="quantitative"
+    - Legend titles: derived from _TOOLTIP_SPECS labels (e.g. "Breakdown", not
+      "Comp_Breakdown_1").
+    - Color scale: WB categorical palette (9 colors). Gender data uses WB_GENDER_COLORS.
+
     Args:
         database_id: Database identifier (e.g., WB_HNP, WB_WDI).
         indicator_id: Indicator ID (e.g., WB_HNP_SP_POP_TOTL).
@@ -558,7 +615,10 @@ async def get_viz_spec(
         start_year: Optional start year (inclusive).
         end_year: Optional end year (inclusive).
         disaggregation_filters: Optional dimension filters; each value is str or null, not a list.
-            Example: {'SEX': 'F'}. For REF_AREA use comma-separated ISO codes (e.g. 'KEN,TZA');
+            See grammar of graphics contract above — only pin a dimension when the user
+            explicitly requested a specific value. Omitting a dimension fetches all values
+            and lets the pipeline choose the correct Vega-Lite channel automatically.
+            For REF_AREA use comma-separated ISO codes (e.g. 'KEN,TZA');
             semicolons in REF_AREA are normalized to commas.
         chart_type: Optional hint — "line", "bar", "scatter", "strip", "small_multiples".
         relevant_fields: Optional list of column names to include in the chart.
@@ -899,6 +959,49 @@ async def get_multi_indicator_viz_spec(
     Use for: scatterplots (2 indicators vs each other), layered/dual-axis line charts
     (2-3 indicators over time in one country), connected scatter (trajectory charts).
 
+    ## Grammar of Graphics Contract
+
+    The pipeline maps data dimensions to Vega-Lite aesthetic channels automatically.
+    DO NOT pre-filter a dimension to simplify the chart — that collapses multi-series
+    data into a single undifferentiated line and silently discards information.
+
+    ### disaggregation_filters decision rule
+
+    disaggregation_filters applies to ALL indicators in this call. Only pin a dimension
+    when the user has explicitly requested a specific value:
+
+      CORRECT — user asked for females only:
+        disaggregation_filters={"SEX": "F"}
+
+      CORRECT — force aggregate totals (suppress breakdown display):
+        disaggregation_filters={"SEX": "_T"}
+
+      WRONG — do not pre-filter to reduce chart complexity:
+        disaggregation_filters={"COMP_BREAKDOWN_1": "WGI_EST"}  # silently drops other series
+
+    When a dimension has multiple meaningful values and the user has not requested a
+    specific one, OMIT it from disaggregation_filters. The pipeline will detect
+    non-trivial values (anything other than "_T" or "_Z") and choose the correct
+    Vega-Lite channel for them.
+
+    ### Chart strategy → Vega-Lite encoding table
+
+    Strategy              | When selected                                       | Vega-Lite encoding
+    ----------------------|-----------------------------------------------------|-------------------------------------------
+    CORRELATION           | 2 indicators, >1 country, single year               | x=indicator1(Q), y=indicator2(Q), color=country(N) (scatter)
+    CORRELATION_TEMPORAL  | 2 indicators, >1 country, multi-year                | x=indicator1(Q), y=indicator2(Q), color=country(N), order=year (connected scatter)
+    TEMPORAL_MULTI_IND    | 2-4 indicators, 1 country or 3+ indicators          | layered lines, independent y-scales per indicator
+
+    ### Encoding type rules (Vega-Lite v5)
+
+    - Year fields: type="temporal", format="%Y". Never "ordinal" for years.
+    - Country / breakdown fields: type="nominal"
+    - Numeric values: type="quantitative", scale.zero=False for non-ratio data
+    - Multi-indicator layers: each indicator gets its own y-axis (left/right), its own
+      WB categorical color. Resolved with resolve.scale.y="independent".
+    - Connected scatter uses order channel (order=year, type=temporal) to draw
+      trajectory lines in chronological order.
+
     Args:
         indicator_ids: List of dicts, each with "database_id" and "indicator_id".
             Example: [
@@ -910,6 +1013,9 @@ async def get_multi_indicator_viz_spec(
         start_year: Optional start year (inclusive).
         end_year: Optional end year (inclusive).
         disaggregation_filters: Optional filters applied to ALL indicators; values are str or null.
+            See grammar of graphics contract above — only pin a dimension when the user
+            explicitly requested a specific value. Omitting a dimension fetches all values
+            and lets the pipeline choose the correct Vega-Lite channel automatically.
             REF_AREA uses comma-separated ISO codes (semicolons normalized to commas).
         chart_type: Optional hint — "scatter", "connected_scatter", "layered_lines",
             "line", "bar". If omitted, auto-selected by data shape.

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -705,6 +705,16 @@ async def get_viz_spec(
         viz_config.ChartStrategy.SMALL_MULTIPLES,
     }
 
+    # Also bypass Draco for TEMPORAL_SINGLE when the color dim is a breakdown dimension
+    # (not country). Draco independently picks mark type (often scatter/point) and ignores
+    # the strategy result, producing a scatter cloud instead of colored lines.
+    _nominal_breakdown_dims = set(_VIZ_DISAGG_DIMS)  # sex, age, urbanisation, comp_breakdown_1/2
+    if (
+        strategy_result.strategy == viz_config.ChartStrategy.TEMPORAL_SINGLE
+        and strategy_result.color_dim in _nominal_breakdown_dims
+    ):
+        bypass_strategies.add(viz_config.ChartStrategy.TEMPORAL_SINGLE)
+
     if strategy_result.strategy in bypass_strategies:
         spec = viz_config.dispatch_spec(
             strategy_result.strategy,
@@ -812,9 +822,11 @@ async def get_viz_spec(
 
         vl_spec = chart.to_dict()
 
-        # Patch color type
+        # Patch color type: nominal for all known categorical dims.
+        # Without this, Draco sometimes assigns 'ordinal' to breakdown/sex dims.
         if "encoding" in vl_spec and "color" in vl_spec["encoding"]:
-            if color_dim in ["country", "sex", "urbanisation", "ref_area"]:
+            _nominal_color_dims = {"country", "ref_area", *_VIZ_DISAGG_DIMS}
+            if color_dim in _nominal_color_dims:
                 vl_spec["encoding"]["color"]["type"] = "nominal"
 
         # Post-processing rules

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -711,19 +711,23 @@ async def get_viz_spec(
     }
 
     if strategy_result.strategy in bypass_strategies:
-        spec = viz_config.dispatch_spec(
-            strategy_result.strategy,
-            viz_data,
-            chart_title_vl,
-            strategy_result,
-            unit_measure=raw_unit,
-        )
-        return _ok(
-            await _store_spec(spec),
-            source_attribution=source_attribution,
-            strategy=strategy_result.strategy.value,
-            reason=strategy_result.reason,
-        )
+        try:
+            spec = viz_config.dispatch_spec(
+                strategy_result.strategy,
+                viz_data,
+                chart_title_vl,
+                strategy_result,
+                unit_measure=raw_unit,
+            )
+            return _ok(
+                await _store_spec(spec),
+                source_attribution=source_attribution,
+                strategy=strategy_result.strategy.value,
+                reason=strategy_result.reason,
+            )
+        except Exception as e:
+            _logger.exception("Strategy builder failed")
+            return _err(f"Chart generation failed: {e}")
 
     # 8. Draco path (temporal_single, fallback)
     try:

--- a/src/data360/viz_config.py
+++ b/src/data360/viz_config.py
@@ -397,8 +397,16 @@ def _append_trim_note(
     """
     if original is None:
         return title
-    # Correct pluralisation: 'country' → 'countries', others get plain 's'.
-    dim_plural = "countries" if dim_label == "country" else f"{dim_label}s"
+    dim_title = (
+        _TOOLTIP_SPECS.get(dim_label, {}).get("title")
+        or dim_label.replace("_", " ").title()
+    ).strip().lower()
+    if dim_title.endswith("y") and len(dim_title) > 1 and dim_title[-2] not in "aeiou":
+        dim_plural = f"{dim_title[:-1]}ies"
+    elif dim_title.endswith(("s", "x", "z", "ch", "sh")):
+        dim_plural = f"{dim_title}es"
+    else:
+        dim_plural = f"{dim_title}s"
     note = (
         f"Showing {shown} of {original} {dim_plural} by most recent data — "
         "specify a subset for the full view"
@@ -1141,13 +1149,13 @@ def build_small_multiples_spec(
 
     # Rebuild the context subtitle so it only names the countries actually shown,
     # not the full pre-cap list that build_chart_title_with_context built earlier.
-    if original_n is not None and isinstance(title, dict):
+    if original_n is not None and facet_dim == "country" and isinstance(title, dict):
         existing_sub = title.get("subtitle", "")
         # Normalise to list (handle legacy string subtitles from tests).
         if isinstance(existing_sub, str):
             existing_sub = [p.strip() for p in existing_sub.split(" · ") if p.strip()]
         # Rebuild element [0] (country + year range); keep [1:] (units, series notes).
-        shown_countries = sorted(df[facet_dim].unique().tolist(), key=str.casefold)
+        shown_countries = sorted(df["country"].unique().tolist(), key=str.casefold)
         year_lbl = _year_range_label(df["year"]) if "year" in df.columns else None
         new_geo = ", ".join(shown_countries)
         if year_lbl:

--- a/src/data360/viz_config.py
+++ b/src/data360/viz_config.py
@@ -862,12 +862,29 @@ def build_breakdown_comparison_spec(
         color_scale = {"range": WB_CAT_COLORS}
 
     x_field = "country" if df.get("country", pd.Series()).nunique() > 1 else "year"
-    x_type = "nominal" if x_field == "country" else "ordinal"
+    # Use temporal type for year so Vega-Lite formats ISO strings as years, not raw ms integers.
+    x_enc: dict
+    if x_field == "year":
+        x_enc = {
+            "field": "year",
+            "type": "temporal",
+            "timeUnit": "year",
+            "axis": {"title": None, "labelFontWeight": "bold", "format": "%Y", "labelAngle": -45},
+        }
+    else:
+        x_enc = {
+            "field": x_field,
+            "type": "nominal",
+            "axis": {"title": None, "labelFontWeight": "bold"},
+        }
     y_ax = {
         **_axis_style(),
         "title": None,
         "labelExpr": _value_label_expr(unit_measure),
     }
+
+    # Resolve a friendly legend title: prefer _TOOLTIP_SPECS label, fall back to title-cased field.
+    legend_title = _TOOLTIP_SPECS.get(color_dim, {}).get("title") or color_dim.replace("_", " ").title()
 
     spec: dict = {
         "$schema": _vl_schema(),
@@ -875,15 +892,7 @@ def build_breakdown_comparison_spec(
         "data": {"values": rows},
         "mark": {"type": "bar"},
         "encoding": {
-            "x": {
-                "field": x_field,
-                "type": x_type,
-                "axis": {
-                    "title": None,
-                    "labelFontWeight": "bold",
-                    **({"labelAngle": 0} if x_field in ("year", "time_period") else {}),
-                },
-            },
+            "x": x_enc,
             "xOffset": {"field": color_dim, "type": "nominal"},
             "y": {
                 "field": "value",
@@ -897,7 +906,7 @@ def build_breakdown_comparison_spec(
                 "scale": color_scale,
                 "legend": {
                     "orient": "top",
-                    "title": color_dim.title(),
+                    "title": legend_title,
                     "labelLimit": 100,
                     "columns": 3,
                 },

--- a/src/data360/viz_config.py
+++ b/src/data360/viz_config.py
@@ -501,13 +501,16 @@ def select_strategy(
 
     # ── Single indicator from here ──
 
-    # Small multiples: 2+ meaningful breakdowns, or breakdown + many countries
-    if n_breakdowns >= 2 or (n_breakdowns >= 1 and country_count > 4):
+    # Small multiples: 2+ meaningful breakdowns, or breakdown + multiple countries.
+    # With breakdown + 2+ countries, series count = country_count × breakdown_values.
+    # Even 2 countries × 6 WGI metrics = 12 overlapping series on one chart — unreadable.
+    # Facet by country so each panel shows one country's breakdown lines.
+    if n_breakdowns >= 2 or (n_breakdowns >= 1 and country_count > 1):
         facet_dim = "country" if country_count > 1 else list(breakdown_counts.keys())[0]
         color_dim = list(breakdown_counts.keys())[0] if breakdown_counts else None
         return StrategyResult(
             ChartStrategy.SMALL_MULTIPLES,
-            f"{n_breakdowns} breakdowns, {country_count} countries → small multiples",
+            f"{n_breakdowns} breakdowns, {country_count} countries → small multiples (facet={facet_dim})",
             color_dim=color_dim,
             facet_dim=facet_dim,
         )

--- a/src/data360/viz_config.py
+++ b/src/data360/viz_config.py
@@ -512,12 +512,22 @@ def select_strategy(
             facet_dim=facet_dim,
         )
 
-    # Breakdown comparison: 1 disaggregation, 2-4 values, ≤4 countries
+    # Breakdown + multi-year → line chart with breakdown as color dim.
+    # Avoids a dense grouped bar chart (e.g. 6 breakdowns × 15 years = 90 bars).
+    if n_breakdowns == 1 and year_count > 1:
+        color_dim = list(breakdown_counts.keys())[0]
+        return StrategyResult(
+            ChartStrategy.TEMPORAL_SINGLE,
+            f"1 breakdown ({color_dim}), {year_count} years → multi-series line chart",
+            color_dim=color_dim,
+        )
+
+    # Breakdown comparison: 1 disaggregation, single year, ≤4 countries → grouped bar
     if n_breakdowns == 1 and country_count <= 4:
         color_dim = list(breakdown_counts.keys())[0]
         return StrategyResult(
             ChartStrategy.BREAKDOWN_COMPARISON,
-            f"1 breakdown ({color_dim}), {breakdown_counts[color_dim]} values → grouped bar",
+            f"1 breakdown ({color_dim}), {breakdown_counts[color_dim]} values, single year → grouped bar",
             color_dim=color_dim,
         )
 

--- a/src/data360/viz_config.py
+++ b/src/data360/viz_config.py
@@ -13,6 +13,7 @@ Design principles:
 from __future__ import annotations
 
 from collections import defaultdict
+import re
 from dataclasses import dataclass, field
 from enum import Enum
 from numbers import Integral
@@ -267,14 +268,30 @@ def build_chart_title_with_context(
 _CUSTOM_BREAKDOWN_DIMS = {"comp_breakdown_1", "comp_breakdown_2"}
 
 
+def _is_homogeneous_breakdown(vals: list[str]) -> bool:
+    """Return True when breakdown codes are ordinal categories of ONE metric.
+
+    Strategy: strip trailing digits from each code. If all codes reduce to the
+    same base string, they are categories of the same metric (e.g.
+    IPC_IPC_PHASE1, IPC_IPC_PHASE2, IPC_IPC_PHASE3 → all become IPC_IPC_PHASE).
+    Heterogeneous codes (WGI_EST, WGI_SC, WGI_SE, WGI_SR) reduce to distinct
+    base strings and are correctly flagged as mixed-unit.
+    """
+    bases = {re.sub(r"\d+$", "", v) for v in vals}
+    return len(bases) == 1 and next(iter(bases)) != ""  # non-empty shared prefix
+
+
 def _format_breakdown_subtitle(df: pd.DataFrame, color_dim: str | None) -> str | None:
-    """Return a compact subtitle note when color_dim is a custom breakdown.
+    """Return a compact subtitle note when color_dim is a heterogeneous custom breakdown.
 
     Appended to chart subtitles so end users can see which series are present
-    and understand that each series may carry different units or scales.
+    and understand they may carry different units or scales.
 
-    Returns None when color_dim is a standard dimension (country, sex, age, …)
-    or when there is only one unique breakdown value.
+    Returns None when:
+    - color_dim is a standard dimension (country, sex, age, …)
+    - there is only one unique breakdown value
+    - the breakdowns are homogeneous (ordinal categories of the same metric,
+      e.g. IPC Phase 1–5 are all person counts — no mixed-unit warning needed)
     """
     if color_dim not in _CUSTOM_BREAKDOWN_DIMS:
         return None
@@ -283,6 +300,9 @@ def _format_breakdown_subtitle(df: pd.DataFrame, color_dim: str | None) -> str |
     vals = sorted(str(v) for v in df[color_dim].dropna().unique())
     if len(vals) <= 1:
         return None
+    if _is_homogeneous_breakdown(vals):
+        # Ordinal categories of one metric — list series but omit the mixed-unit warning.
+        return f"Series: {', '.join(vals)}"
     series_list = ", ".join(vals)
     return f"Series: {series_list} — series may have different units/scales"
 
@@ -991,10 +1011,38 @@ def build_small_multiples_spec(
     y_label: str = "Value",
     unit_measure: str | None = None,
 ) -> dict:
-    """Faceted small multiples: 1 indicator, 2+ breakdowns or breakdown+many countries."""
-    rows = df.to_dict(orient="records")
+    """Faceted small multiples: 1 indicator, 2+ breakdowns or breakdown+many countries.
+
+    Facet panels are capped at SMALL_MULTIPLES_MAX_FACETS to prevent the chart
+    overflowing the embedding UI. When the cap is applied, the top-N facet values
+    by most-recent data point are retained and a note is added to the subtitle.
+    """
     facet_dim = result.facet_dim or "country"
     color_dim = result.color_dim
+
+    # --- Facet cap: keep at most SMALL_MULTIPLES_MAX_FACETS panels ---
+    n_facets_total = df[facet_dim].nunique() if facet_dim in df.columns else 1
+    trimmed = False
+    if n_facets_total > SMALL_MULTIPLES_MAX_FACETS:
+        trimmed = True
+        # Select top-N facet values by most recent (highest TIME_PERIOD) row count.
+        # Ties broken by total row count (more data = more useful panel).
+        if "year" in df.columns:
+            latest_year = df.groupby(facet_dim)["year"].max()
+        else:
+            latest_year = pd.Series(dtype="object")
+        row_count = df.groupby(facet_dim).size()
+        rank_key = latest_year.reindex(row_count.index).fillna(pd.Timestamp.min)
+        # Sort: latest year desc, then row count desc
+        top_facets = (
+            pd.DataFrame({"latest": rank_key, "count": row_count})
+            .sort_values(["latest", "count"], ascending=False)
+            .head(SMALL_MULTIPLES_MAX_FACETS)
+            .index.tolist()
+        )
+        df = df[df[facet_dim].isin(top_facets)].copy()
+
+    rows = df.to_dict(orient="records")
     max_abs = float(df["value"].abs().max()) if "value" in df.columns else None
     tt_fmt = _compute_tooltip_format(max_abs, unit_measure)
 
@@ -1035,6 +1083,22 @@ def build_small_multiples_spec(
     # Option C: annotate chart subtitle with breakdown series names when color_dim is
     # a custom breakdown (comp_breakdown_1/2). Standard dims (country, sex) are unaffected.
     annotated_title = _append_breakdown_note(title, df, color_dim)
+
+    # Append facet-cap note when panels were trimmed.
+    if trimmed:
+        facet_label = facet_dim.replace("_", " ")
+        cap_note = (
+            f"Showing {SMALL_MULTIPLES_MAX_FACETS} of {n_facets_total} {facet_label}s "
+            f"by most recent data — specify a subset for the full view"
+        )
+        if isinstance(annotated_title, dict):
+            existing = annotated_title.get("subtitle", "")
+            annotated_title = {
+                **annotated_title,
+                "subtitle": f"{existing} · {cap_note}" if existing else cap_note,
+            }
+        else:
+            annotated_title = {"text": annotated_title, "subtitle": cap_note}
 
     spec: dict = {
         "$schema": _vl_schema(),
@@ -1367,6 +1431,11 @@ HIGH_CARDINALITY_THRESHOLDS: dict[str, int] = {
     "facet_threshold": 4,
     "top_n_series": 12,
 }
+
+# Maximum number of facet panels rendered in SMALL_MULTIPLES.
+# Chatbot UIs embed charts at fixed widths; beyond this the panels become
+# unreadably small and the page overflows vertically.
+SMALL_MULTIPLES_MAX_FACETS: int = 8
 
 
 # Keep legacy aliases for backward compat with existing tests

--- a/src/data360/viz_config.py
+++ b/src/data360/viz_config.py
@@ -176,6 +176,9 @@ _TOOLTIP_SPECS: dict[str, dict] = {
     "sex": {"title": "Sex", "type": "nominal"},
     "age": {"title": "Age Group", "type": "nominal"},
     "urbanisation": {"title": "Urbanisation", "type": "nominal"},
+    "comp_breakdown_1": {"title": "Breakdown", "type": "nominal"},
+    "comp_breakdown_2": {"title": "Sub-Breakdown", "type": "nominal"},
+    "time_period": {"title": "Period", "type": "temporal"},
     "obs_value": {"title": "Value", "format": ",.2f", "type": "quantitative"},
     "ref_area": {"title": "Country", "type": "nominal"},
     "region": {"title": "Region", "type": "nominal"},
@@ -192,6 +195,8 @@ _TOOLTIP_PRIORITY = [
     "sex",
     "age",
     "urbanisation",
+    "comp_breakdown_1",
+    "comp_breakdown_2",
 ]
 
 
@@ -426,6 +431,8 @@ def select_strategy(
     sex_count = df["sex"].nunique() if "sex" in cols else 0
     age_count = df["age"].nunique() if "age" in cols else 0
     urban_count = df["urbanisation"].nunique() if "urbanisation" in cols else 0
+    cb1_count = df["comp_breakdown_1"].nunique() if "comp_breakdown_1" in cols else 0
+    cb2_count = df["comp_breakdown_2"].nunique() if "comp_breakdown_2" in cols else 0
 
     breakdown_counts = {
         k: v
@@ -433,6 +440,8 @@ def select_strategy(
             ("sex", sex_count),
             ("age", age_count),
             ("urbanisation", urban_count),
+            ("comp_breakdown_1", cb1_count),
+            ("comp_breakdown_2", cb2_count),
         ]
         if v > 1
     }

--- a/src/data360/viz_config.py
+++ b/src/data360/viz_config.py
@@ -263,6 +263,47 @@ def build_chart_title_with_context(
     return {"text": main_title, "subtitle": " · ".join(subtitle_parts)}
 
 
+# Dimension codes that are custom breakdowns (not standard demographic dims).
+_CUSTOM_BREAKDOWN_DIMS = {"comp_breakdown_1", "comp_breakdown_2"}
+
+
+def _format_breakdown_subtitle(df: pd.DataFrame, color_dim: str | None) -> str | None:
+    """Return a compact subtitle note when color_dim is a custom breakdown.
+
+    Appended to chart subtitles so end users can see which series are present
+    and understand that each series may carry different units or scales.
+
+    Returns None when color_dim is a standard dimension (country, sex, age, …)
+    or when there is only one unique breakdown value.
+    """
+    if color_dim not in _CUSTOM_BREAKDOWN_DIMS:
+        return None
+    if color_dim not in df.columns:
+        return None
+    vals = sorted(str(v) for v in df[color_dim].dropna().unique())
+    if len(vals) <= 1:
+        return None
+    series_list = ", ".join(vals)
+    return f"Series: {series_list} — series may have different units/scales"
+
+
+def _append_breakdown_note(
+    title: str | dict,
+    df: pd.DataFrame,
+    color_dim: str | None,
+) -> str | dict:
+    """Inject breakdown note into a Vega-Lite title dict's subtitle field."""
+    note = _format_breakdown_subtitle(df, color_dim)
+    if not note:
+        return title
+    if isinstance(title, dict):
+        existing = title.get("subtitle", "")
+        new_sub = f"{existing} · {note}" if existing else note
+        return {**title, "subtitle": new_sub}
+    # Plain string title — upgrade to dict
+    return {"text": title, "subtitle": note}
+
+
 # Shared dimensions for multi-indicator line layers: one value column per layer’s tooltip.
 _MULTI_IND_TOOLTIP_DIMS: tuple[str, ...] = (
     "year",
@@ -711,9 +752,13 @@ def build_temporal_single_spec(
             result.color_dim, mark_type="line", n_items=n_items
         )
 
+    # Option C: annotate chart subtitle with breakdown series names when color_dim is
+    # a custom breakdown (comp_breakdown_1/2). Omits note for standard dims like country.
+    annotated_title = _append_breakdown_note(title, df, result.color_dim)
+
     spec: dict = {
         "$schema": _vl_schema(),
-        "title": title,
+        "title": annotated_title,
         "data": {"values": rows},
         "mark": {
             "type": "line",
@@ -987,9 +1032,13 @@ def build_small_multiples_spec(
     if color_dim and color_dim != facet_dim:
         inner["encoding"]["color"] = _color_encoding(color_dim, mark_type="line")
 
+    # Option C: annotate chart subtitle with breakdown series names when color_dim is
+    # a custom breakdown (comp_breakdown_1/2). Standard dims (country, sex) are unaffected.
+    annotated_title = _append_breakdown_note(title, df, color_dim)
+
     spec: dict = {
         "$schema": _vl_schema(),
-        "title": title,
+        "title": annotated_title,
         "data": {"values": rows},
         "facet": {
             "field": facet_dim,

--- a/src/data360/viz_config.py
+++ b/src/data360/viz_config.py
@@ -252,7 +252,12 @@ def build_chart_title_with_context(
     unit_subtitle: str | None,
     df: pd.DataFrame,
 ) -> str | dict:
-    """Vega-Lite title: main text plus subtitle (geography + years · unit when present)."""
+    """Vega-Lite title: main text plus subtitle lines (geography + years, unit).
+
+    Subtitle is returned as a **list of strings** so Vega-Lite v5 renders each
+    part on its own line. This prevents the single-line overflow that occurs
+    when country names, year ranges, units, and trim notes are concatenated.
+    """
     ctx = format_chart_context_subtitle(df)
     subtitle_parts: list[str] = []
     if ctx:
@@ -261,7 +266,7 @@ def build_chart_title_with_context(
         subtitle_parts.append(str(unit_subtitle).strip())
     if not subtitle_parts:
         return main_title
-    return {"text": main_title, "subtitle": " · ".join(subtitle_parts)}
+    return {"text": main_title, "subtitle": subtitle_parts}
 
 
 # Dimension codes that are custom breakdowns (not standard demographic dims).
@@ -312,15 +317,21 @@ def _append_breakdown_note(
     df: pd.DataFrame,
     color_dim: str | None,
 ) -> str | dict:
-    """Inject breakdown note into a Vega-Lite title dict's subtitle field."""
+    """Inject breakdown note into a Vega-Lite title dict's subtitle.
+
+    When subtitle is a list (Vega-Lite multi-line form), the note is appended
+    as a new line. When subtitle is a string, it is appended with ' · '.
+    """
     note = _format_breakdown_subtitle(df, color_dim)
     if not note:
         return title
     if isinstance(title, dict):
         existing = title.get("subtitle", "")
+        if isinstance(existing, list):
+            return {**title, "subtitle": existing + [note]}
         new_sub = f"{existing} · {note}" if existing else note
         return {**title, "subtitle": new_sub}
-    # Plain string title — upgrade to dict
+    # Plain string title — upgrade to single-line dict.
     return {"text": title, "subtitle": note}
 
 
@@ -381,15 +392,21 @@ def _append_trim_note(
     was capped by :func:`_cap_cardinality`.
 
     No-op when *original* is None (no trimming occurred).
+    When subtitle is a list (Vega-Lite multi-line form), the note is appended
+    as a new line. When subtitle is a string, it is appended with ' · '.
     """
     if original is None:
         return title
+    # Correct pluralisation: 'country' → 'countries', others get plain 's'.
+    dim_plural = "countries" if dim_label == "country" else f"{dim_label}s"
     note = (
-        f"Showing {shown} of {original} {dim_label}s by most recent data — "
+        f"Showing {shown} of {original} {dim_plural} by most recent data — "
         "specify a subset for the full view"
     )
     if isinstance(title, dict):
         existing = title.get("subtitle", "")
+        if isinstance(existing, list):
+            return {**title, "subtitle": existing + [note]}
         return {**title, "subtitle": f"{existing} · {note}" if existing else note}
     return {"text": title, "subtitle": note}
 
@@ -1125,24 +1142,17 @@ def build_small_multiples_spec(
     # Rebuild the context subtitle so it only names the countries actually shown,
     # not the full pre-cap list that build_chart_title_with_context built earlier.
     if original_n is not None and isinstance(title, dict):
-        # Reconstruct the subtitle: country list + existing non-country parts
-        # The subtitle format is: "Country1, Country2, ... · year_range · units"
-        # We keep the year/unit parts and replace the country list.
         existing_sub = title.get("subtitle", "")
-        # Extract parts after the first " · " separator (year range, units, series notes).
-        sep = " \u00b7 "
-        sub_parts = existing_sub.split(sep)
-        # First part is the country+year segment from format_chart_context_subtitle.
-        # Rebuild it with only the shown countries.
+        # Normalise to list (handle legacy string subtitles from tests).
+        if isinstance(existing_sub, str):
+            existing_sub = [p.strip() for p in existing_sub.split(" · ") if p.strip()]
+        # Rebuild element [0] (country + year range); keep [1:] (units, series notes).
         shown_countries = sorted(df[facet_dim].unique().tolist(), key=str.casefold)
         year_lbl = _year_range_label(df["year"]) if "year" in df.columns else None
         new_geo = ", ".join(shown_countries)
         if year_lbl:
             new_geo = f"{new_geo}, {year_lbl}"
-        # Re-assemble: new geo + any non-geo parts from position 2+ (units, series notes).
-        non_geo_parts = sub_parts[1:] if len(sub_parts) > 1 else []
-        new_sub_parts = [new_geo] + non_geo_parts
-        title = {**title, "subtitle": sep.join(new_sub_parts)}
+        title = {**title, "subtitle": [new_geo] + existing_sub[1:]}
 
     rows = df.to_dict(orient="records")
     max_abs = float(df["value"].abs().max()) if "value" in df.columns else None

--- a/src/data360/viz_config.py
+++ b/src/data360/viz_config.py
@@ -324,6 +324,76 @@ def _append_breakdown_note(
     return {"text": title, "subtitle": note}
 
 
+def _cap_cardinality(
+    df: pd.DataFrame,
+    dim: str,
+    max_n: int,
+) -> tuple[pd.DataFrame, int | None]:
+    """Cap the number of unique values for *dim* to *max_n*.
+
+    Shared utility called by every spec builder that renders one visual element
+    per dim value (facet panels, bar rows, color lines).  This is standard
+    chart best practice: beyond ~8–12 elements embedded charts overflow the
+    chatbot UI and individual items become unreadable.
+
+    Selection strategy: top-N by most-recent data point, ties broken by row
+    count (more data = more informative panel).  Rows outside the top-N are
+    dropped from the returned DataFrame.
+
+    Args:
+        df:    Input DataFrame.  Must have a ``year`` column for recency sort.
+        dim:   Dimension column whose cardinality to cap (e.g. ``country``).
+        max_n: Maximum number of unique values to retain.
+
+    Returns:
+        (trimmed_df, original_n) where *original_n* is the pre-trim count, or
+        *None* when no trimming was needed (df is returned unchanged).
+    """
+    if dim not in df.columns:
+        return df, None
+    n_total = df[dim].nunique()
+    if n_total <= max_n:
+        return df, None
+
+    if "year" in df.columns:
+        latest = df.groupby(dim)["year"].max()
+    else:
+        latest = pd.Series(dtype="object", index=df[dim].unique())
+    count = df.groupby(dim).size()
+    rank = pd.DataFrame(
+        {"latest": latest.reindex(count.index).fillna(pd.Timestamp.min), "count": count}
+    )
+    top = (
+        rank.sort_values(["latest", "count"], ascending=False)
+        .head(max_n)
+        .index.tolist()
+    )
+    return df[df[dim].isin(top)].copy(), n_total
+
+
+def _append_trim_note(
+    title: str | dict,
+    dim_label: str,
+    shown: int,
+    original: int | None,
+) -> str | dict:
+    """Inject a 'Showing N of M' note into the chart subtitle when cardinality
+    was capped by :func:`_cap_cardinality`.
+
+    No-op when *original* is None (no trimming occurred).
+    """
+    if original is None:
+        return title
+    note = (
+        f"Showing {shown} of {original} {dim_label}s by most recent data — "
+        "specify a subset for the full view"
+    )
+    if isinstance(title, dict):
+        existing = title.get("subtitle", "")
+        return {**title, "subtitle": f"{existing} · {note}" if existing else note}
+    return {"text": title, "subtitle": note}
+
+
 # Shared dimensions for multi-indicator line layers: one value column per layer’s tooltip.
 _MULTI_IND_TOOLTIP_DIMS: tuple[str, ...] = (
     "year",
@@ -801,7 +871,19 @@ def build_cross_sectional_spec(
     x_label: str = "Value",
     unit_measure: str | None = None,
 ) -> dict:
-    """Horizontal bar: 1 indicator, single year, ≤8 countries."""
+    """Horizontal bar: 1 indicator, single year.
+
+    Rows are capped at HIGH_CARDINALITY_THRESHOLDS["cross_sectional_max_items"]
+    and sorted descending by value (highest performing country at top).
+    """
+    bar_dim = result.color_dim or "country"
+    df, original_n = _cap_cardinality(
+        df.sort_values("value", ascending=False),
+        bar_dim,
+        HIGH_CARDINALITY_THRESHOLDS["cross_sectional_max_items"],
+    )
+    title = _append_trim_note(title, bar_dim, df[bar_dim].nunique() if bar_dim in df.columns else 0, original_n)
+
     sorted_df = df.sort_values("value", ascending=False)
     rows = sorted_df.to_dict(orient="records")
     max_abs = float(df["value"].abs().max()) if "value" in df.columns else None
@@ -1013,34 +1095,18 @@ def build_small_multiples_spec(
 ) -> dict:
     """Faceted small multiples: 1 indicator, 2+ breakdowns or breakdown+many countries.
 
-    Facet panels are capped at SMALL_MULTIPLES_MAX_FACETS to prevent the chart
-    overflowing the embedding UI. When the cap is applied, the top-N facet values
-    by most-recent data point are retained and a note is added to the subtitle.
+    Facet panels are capped at HIGH_CARDINALITY_THRESHOLDS["small_multiples_max_facets"]
+    via the shared :func:`_cap_cardinality` utility. When trimmed, the top-N facet
+    values by most-recent data point are retained and a subtitle note is injected via
+    :func:`_append_trim_note` — the same logic used by build_cross_sectional_spec.
     """
     facet_dim = result.facet_dim or "country"
     color_dim = result.color_dim
 
-    # --- Facet cap: keep at most SMALL_MULTIPLES_MAX_FACETS panels ---
-    n_facets_total = df[facet_dim].nunique() if facet_dim in df.columns else 1
-    trimmed = False
-    if n_facets_total > SMALL_MULTIPLES_MAX_FACETS:
-        trimmed = True
-        # Select top-N facet values by most recent (highest TIME_PERIOD) row count.
-        # Ties broken by total row count (more data = more useful panel).
-        if "year" in df.columns:
-            latest_year = df.groupby(facet_dim)["year"].max()
-        else:
-            latest_year = pd.Series(dtype="object")
-        row_count = df.groupby(facet_dim).size()
-        rank_key = latest_year.reindex(row_count.index).fillna(pd.Timestamp.min)
-        # Sort: latest year desc, then row count desc
-        top_facets = (
-            pd.DataFrame({"latest": rank_key, "count": row_count})
-            .sort_values(["latest", "count"], ascending=False)
-            .head(SMALL_MULTIPLES_MAX_FACETS)
-            .index.tolist()
-        )
-        df = df[df[facet_dim].isin(top_facets)].copy()
+    # Shared cap utility — identical contract to cross_sectional bar rows.
+    df, original_n = _cap_cardinality(
+        df, facet_dim, HIGH_CARDINALITY_THRESHOLDS["small_multiples_max_facets"]
+    )
 
     rows = df.to_dict(orient="records")
     max_abs = float(df["value"].abs().max()) if "value" in df.columns else None
@@ -1080,25 +1146,10 @@ def build_small_multiples_spec(
     if color_dim and color_dim != facet_dim:
         inner["encoding"]["color"] = _color_encoding(color_dim, mark_type="line")
 
-    # Option C: annotate chart subtitle with breakdown series names when color_dim is
-    # a custom breakdown (comp_breakdown_1/2). Standard dims (country, sex) are unaffected.
+    # Option C: annotate with breakdown series names (heterogeneous → mixed-unit warning).
     annotated_title = _append_breakdown_note(title, df, color_dim)
-
-    # Append facet-cap note when panels were trimmed.
-    if trimmed:
-        facet_label = facet_dim.replace("_", " ")
-        cap_note = (
-            f"Showing {SMALL_MULTIPLES_MAX_FACETS} of {n_facets_total} {facet_label}s "
-            f"by most recent data — specify a subset for the full view"
-        )
-        if isinstance(annotated_title, dict):
-            existing = annotated_title.get("subtitle", "")
-            annotated_title = {
-                **annotated_title,
-                "subtitle": f"{existing} · {cap_note}" if existing else cap_note,
-            }
-        else:
-            annotated_title = {"text": annotated_title, "subtitle": cap_note}
+    # Shared trim note — same utility as cross_sectional.
+    annotated_title = _append_trim_note(annotated_title, facet_dim, n_facets, original_n)
 
     spec: dict = {
         "$schema": _vl_schema(),
@@ -1117,6 +1168,7 @@ def build_small_multiples_spec(
         "spec": {**inner, "width": 220, "height": 160},
     }
     return inject_wb_config(spec)
+
 
 
 def build_correlation_spec(
@@ -1426,16 +1478,26 @@ def dispatch_spec(
 # ============================================================================
 
 HIGH_CARDINALITY_THRESHOLDS: dict[str, int] = {
+    # Maximum color series in a TEMPORAL_SINGLE line chart.
+    # Strategy routing enforces this before the builder is called.
     "line_max_series": 8,
+    # Minimum country count to switch from line to strip (beeswarm) in single-year views.
     "beeswarm_threshold": 8,
+    # Minimum breakdown count to prefer SMALL_MULTIPLES over BREAKDOWN_COMPARISON.
     "facet_threshold": 4,
+    # Maximum color series in any context where the strategy router can’t pre-filter.
     "top_n_series": 12,
+    # Maximum facet panels in SMALL_MULTIPLES.
+    # Chatbot UIs embed charts at fixed widths; beyond this panels become unreadably
+    # small and the page overflows vertically.
+    "small_multiples_max_facets": 8,
+    # Maximum bar rows in CROSS_SECTIONAL horizontal bar charts.
+    # Beyond this, bars become hair-thin and labels collide.
+    "cross_sectional_max_items": 20,
 }
 
-# Maximum number of facet panels rendered in SMALL_MULTIPLES.
-# Chatbot UIs embed charts at fixed widths; beyond this the panels become
-# unreadably small and the page overflows vertically.
-SMALL_MULTIPLES_MAX_FACETS: int = 8
+# Keep the standalone constant as a typed alias for backward compat with existing tests.
+SMALL_MULTIPLES_MAX_FACETS: int = HIGH_CARDINALITY_THRESHOLDS["small_multiples_max_facets"]
 
 
 # Keep legacy aliases for backward compat with existing tests

--- a/src/data360/viz_config.py
+++ b/src/data360/viz_config.py
@@ -776,7 +776,20 @@ def _color_encoding(
     domain: list | None = None,
     mark_type: str = "point",
     n_items: int = 0,
+    legend_title: str | None = None,
 ) -> dict:
+    """Build a Vega-Lite color encoding channel.
+
+    Legend title resolves in this priority order:
+    1. Caller-supplied ``legend_title``
+    2. Human-readable label from ``_TOOLTIP_SPECS`` (e.g. "Sub-Breakdown")
+    3. Title-cased field name (e.g. "Comp Breakdown 2")
+    """
+    resolved_title = (
+        legend_title
+        or _TOOLTIP_SPECS.get(field, {}).get("title")
+        or field.replace("_", " ").title()
+    )
     scale = {"range": WB_CAT_COLORS}
     if domain:
         scale["domain"] = domain
@@ -787,6 +800,7 @@ def _color_encoding(
         legend: dict | None = {
             "orient": "top",
             "direction": "horizontal",
+            "title": resolved_title,
             "labelLimit": 100,
             "columns": 3,
         }
@@ -1107,6 +1121,28 @@ def build_small_multiples_spec(
     df, original_n = _cap_cardinality(
         df, facet_dim, HIGH_CARDINALITY_THRESHOLDS["small_multiples_max_facets"]
     )
+
+    # Rebuild the context subtitle so it only names the countries actually shown,
+    # not the full pre-cap list that build_chart_title_with_context built earlier.
+    if original_n is not None and isinstance(title, dict):
+        # Reconstruct the subtitle: country list + existing non-country parts
+        # The subtitle format is: "Country1, Country2, ... · year_range · units"
+        # We keep the year/unit parts and replace the country list.
+        existing_sub = title.get("subtitle", "")
+        # Extract parts after the first " · " separator (year range, units, series notes).
+        sep = " \u00b7 "
+        sub_parts = existing_sub.split(sep)
+        # First part is the country+year segment from format_chart_context_subtitle.
+        # Rebuild it with only the shown countries.
+        shown_countries = sorted(df[facet_dim].unique().tolist(), key=str.casefold)
+        year_lbl = _year_range_label(df["year"]) if "year" in df.columns else None
+        new_geo = ", ".join(shown_countries)
+        if year_lbl:
+            new_geo = f"{new_geo}, {year_lbl}"
+        # Re-assemble: new geo + any non-geo parts from position 2+ (units, series notes).
+        non_geo_parts = sub_parts[1:] if len(sub_parts) > 1 else []
+        new_sub_parts = [new_geo] + non_geo_parts
+        title = {**title, "subtitle": sep.join(new_sub_parts)}
 
     rows = df.to_dict(orient="records")
     max_abs = float(df["value"].abs().max()) if "value" in df.columns else None

--- a/src/data360/viz_config.py
+++ b/src/data360/viz_config.py
@@ -200,6 +200,8 @@ _TOOLTIP_PRIORITY = [
     "comp_breakdown_2",
 ]
 
+_VOWELS = {"a", "e", "i", "o", "u"}
+
 
 def _year_range_label(year_series: pd.Series) -> str | None:
     """Min–max year label, e.g. ``1990-2024`` or ``2020`` when only one year."""
@@ -399,9 +401,10 @@ def _append_trim_note(
         return title
     dim_title = (
         _TOOLTIP_SPECS.get(dim_label, {}).get("title")
-        or dim_label.replace("_", " ").title()
+        or dim_label.replace("_", " ")
     ).strip().lower()
-    if dim_title.endswith("y") and len(dim_title) > 1 and dim_title[-2] not in "aeiou":
+    # Simple English pluralization for subtitle notes.
+    if dim_title.endswith("y") and len(dim_title) > 2 and dim_title[-2] not in _VOWELS:
         dim_plural = f"{dim_title[:-1]}ies"
     elif dim_title.endswith(("s", "x", "z", "ch", "sh")):
         dim_plural = f"{dim_title}es"

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,7 +1,7 @@
 """Tests for data360.visualization module."""
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import numpy as np
 import pandas as pd
@@ -14,8 +14,8 @@ from data360.visualization import (
 )
 
 
-class TestGetVizSpecDracoFallbackWarning:
-    """Verify that a warning is surfaced when Draco fails and fallback is used."""
+class TestGetVizSpecStrategyDispatch:
+    """Verify single-indicator specs are built by strategy dispatch."""
 
     @pytest.fixture
     def sample_dataframe(self):
@@ -30,7 +30,7 @@ class TestGetVizSpecDracoFallbackWarning:
 
     @pytest.fixture
     def patches(self, sample_dataframe):
-        """Set up all the mocks needed to isolate the Draco fallback path."""
+        """Set up all the mocks needed to isolate strategy dispatch behavior."""
         with (
             patch(
                 "data360.api.get_data_api_url",
@@ -73,17 +73,11 @@ class TestGetVizSpecDracoFallbackWarning:
 
     @pytest.mark.asyncio
     async def test_temporal_single_bypasses_draco_and_returns_line(self, patches):
-        """TEMPORAL_SINGLE no longer goes through Draco — it should return a clean line spec."""
-        with patch("data360.visualization.Draco") as MockDraco:
-            # Draco returns empty — but TEMPORAL_SINGLE is bypassed before Draco is called
-            draco_instance = MagicMock()
-            draco_instance.complete_spec.return_value = iter([])
-            MockDraco.return_value = draco_instance
-
-            result = await get_viz_spec(
-                database_id="WB_WDI",
-                indicator_id="FAKE_IND",
-            )
+        """TEMPORAL_SINGLE should return a clean line spec via strategy dispatch."""
+        result = await get_viz_spec(
+            database_id="WB_WDI",
+            indicator_id="FAKE_IND",
+        )
 
         # Must succeed cleanly — no error, no fallback warning
         assert result["url"] is not None, "Expected a URL from strategy builder"
@@ -94,127 +88,12 @@ class TestGetVizSpecDracoFallbackWarning:
         assert result["strategy"] == "temporal_single"
 
     @pytest.mark.asyncio
-    async def test_draco_success_has_no_warning(self, patches):
-        """When Draco succeeds, no warning key should be present."""
-        # Build a chainable mock chart that returns a valid spec from to_dict()
-        mock_chart = MagicMock()
-        mock_vl_spec = {
-            "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
-            "mark": "point",
-            "encoding": {
-                "x": {"field": "year", "type": "temporal"},
-                "y": {"field": "value", "type": "quantitative"},
-            },
-        }
-        # Chain: chart.properties(...).interactive().encode(...).to_dict()
-        mock_chart.properties.return_value = mock_chart
-        mock_chart.interactive.return_value = mock_chart
-        mock_chart.encode.return_value = mock_chart
-        mock_chart.to_dict.return_value = mock_vl_spec
-
-        with (
-            patch("data360.visualization.Draco") as MockDraco,
-            patch("data360.visualization.answer_set_to_dict") as mock_as2d,
-            patch("data360.visualization.AltairRenderer") as MockRenderer,
-        ):
-            fake_model = MagicMock()
-            draco_instance = MagicMock()
-            draco_instance.complete_spec.return_value = iter([fake_model])
-            MockDraco.return_value = draco_instance
-
-            mock_as2d.return_value = {
-                "view": [{"mark": [{"type": "point", "encoding": []}]}]
-            }
-
-            renderer_instance = MagicMock()
-            renderer_instance.render.return_value = mock_chart
-            MockRenderer.return_value = renderer_instance
-
-            result = await get_viz_spec(
-                database_id="WB_WDI",
-                indicator_id="FAKE_IND",
-            )
-
-        assert result["error"] is None, f"Unexpected error: {result['error']}"
-        assert result["url"] is not None
-        assert "warning" not in result, (
-            f"No warning expected on Draco success, got: {result.get('warning')}"
-        )
-
-    @pytest.mark.asyncio
-    async def test_draco_line_spec_gets_hover_points_in_postprocess(self, patches):
-        """Draco line outputs should get mark.point injected for easier tooltip hover."""
-        mock_chart = MagicMock()
-        mock_vl_spec = {
-            "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
-            "mark": "line",
-            "encoding": {
-                "x": {"field": "year", "type": "temporal"},
-                "y": {"field": "value", "type": "quantitative"},
-            },
-        }
-        mock_chart.properties.return_value = mock_chart
-        mock_chart.interactive.return_value = mock_chart
-        mock_chart.encode.return_value = mock_chart
-        mock_chart.to_dict.return_value = mock_vl_spec
-
-        captured_spec: dict[str, object] = {}
-
-        async def _capture_spec(spec):
-            captured_spec.clear()
-            captured_spec.update(spec)
-            return "http://localhost:8021/static/viz_specs/test-line.json"
-
-        with (
-            patch("data360.visualization.Draco") as MockDraco,
-            patch("data360.visualization.answer_set_to_dict") as mock_as2d,
-            patch("data360.visualization.AltairRenderer") as MockRenderer,
-            patch(
-                "data360.visualization._store_spec",
-                side_effect=_capture_spec,
-            ),
-        ):
-            fake_model = MagicMock()
-            draco_instance = MagicMock()
-            draco_instance.complete_spec.return_value = iter([fake_model])
-            MockDraco.return_value = draco_instance
-            mock_as2d.return_value = {
-                "view": [{"mark": [{"type": "line", "encoding": []}]}]
-            }
-
-            renderer_instance = MagicMock()
-            renderer_instance.render.return_value = mock_chart
-            MockRenderer.return_value = renderer_instance
-
-            result = await get_viz_spec(
-                database_id="WB_WDI",
-                indicator_id="FAKE_IND",
-            )
-
-        assert result["error"] is None
-        mark = captured_spec.get("mark")
-        if isinstance(mark, str):
-            pytest.fail("Expected post-processing to normalize line mark into dict")
-        assert isinstance(mark, dict)
-        assert mark.get("type") == "line"
-        point = mark.get("point")
-        assert isinstance(point, dict)
-        assert point.get("size", 0) >= 40
-
-    @pytest.mark.asyncio
     async def test_strategy_dispatch_failure_returns_error(self, patches):
-        """When dispatch_spec raises for a bypass strategy, an error is returned."""
-        with (
-            patch("data360.visualization.Draco") as MockDraco,
-            patch(
-                "data360.viz_config.dispatch_spec",
-                side_effect=RuntimeError("dispatch broke"),
-            ),
+        """When dispatch_spec raises, an error is returned."""
+        with patch(
+            "data360.viz_config.dispatch_spec",
+            side_effect=RuntimeError("dispatch broke"),
         ):
-            draco_instance = MagicMock()
-            draco_instance.complete_spec.return_value = iter([])
-            MockDraco.return_value = draco_instance
-
             result = await get_viz_spec(
                 database_id="WB_WDI",
                 indicator_id="FAKE_IND",
@@ -533,15 +412,10 @@ class TestObsValueNullHandling:
         with patch(
             "data360.visualization.save_specs_to_static", side_effect=capture_spec
         ):
-            with patch("data360.visualization.Draco") as MockDraco:
-                draco_instance = MagicMock()
-                draco_instance.complete_spec.return_value = iter([])
-                MockDraco.return_value = draco_instance
-
-                result = await get_viz_spec(
-                    database_id="WB_WDI",
-                    indicator_id="FAKE_IND",
-                )
+            result = await get_viz_spec(
+                database_id="WB_WDI",
+                indicator_id="FAKE_IND",
+            )
 
         # If spec was captured, verify the data values
         if "spec" in captured_data:

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -72,9 +72,10 @@ class TestGetVizSpecDracoFallbackWarning:
             }
 
     @pytest.mark.asyncio
-    async def test_fallback_returns_warning(self, patches):
-        """When Draco raises StopIteration, the response should include a warning key."""
+    async def test_temporal_single_bypasses_draco_and_returns_line(self, patches):
+        """TEMPORAL_SINGLE no longer goes through Draco — it should return a clean line spec."""
         with patch("data360.visualization.Draco") as MockDraco:
+            # Draco returns empty — but TEMPORAL_SINGLE is bypassed before Draco is called
             draco_instance = MagicMock()
             draco_instance.complete_spec.return_value = iter([])
             MockDraco.return_value = draco_instance
@@ -84,14 +85,13 @@ class TestGetVizSpecDracoFallbackWarning:
                 indicator_id="FAKE_IND",
             )
 
-        assert result["url"] is not None, "Expected a URL from fallback generation"
-        assert result["error"] is None, "Expected no error from successful fallback"
-        assert result.get("database_name") == "World Development Indicators"
-        assert result.get("indicator_id") == "FAKE_IND"
-        assert "warning" in result, "Expected a 'warning' key when Draco falls back"
-        assert "fallback" in result["warning"].lower(), (
-            f"Warning message should mention fallback, got: {result['warning']}"
+        # Must succeed cleanly — no error, no fallback warning
+        assert result["url"] is not None, "Expected a URL from strategy builder"
+        assert result["error"] is None, f"Unexpected error: {result['error']}"
+        assert "warning" not in result, (
+            "TEMPORAL_SINGLE bypasses Draco, so no fallback warning is expected"
         )
+        assert result["strategy"] == "temporal_single"
 
     @pytest.mark.asyncio
     async def test_draco_success_has_no_warning(self, patches):
@@ -202,8 +202,8 @@ class TestGetVizSpecDracoFallbackWarning:
         assert point.get("size", 0) >= 40
 
     @pytest.mark.asyncio
-    async def test_fallback_also_fails_returns_error(self, patches):
-        """When both Draco and the dispatch_spec fallback fail, an error is returned."""
+    async def test_strategy_dispatch_failure_returns_error(self, patches):
+        """When dispatch_spec raises for a bypass strategy, an error is returned."""
         with (
             patch("data360.visualization.Draco") as MockDraco,
             patch(
@@ -222,7 +222,6 @@ class TestGetVizSpecDracoFallbackWarning:
 
         assert result["url"] is None
         assert result["error"] is not None
-        assert "fallback" in result["error"].lower()
 
 
 # =============================================================================

--- a/tests/test_viz_comp_breakdown.py
+++ b/tests/test_viz_comp_breakdown.py
@@ -220,3 +220,52 @@ def test_viz_disagg_dims_constant_is_complete():
     assert "sex" in _VIZ_DISAGG_DIMS
     assert "age" in _VIZ_DISAGG_DIMS
     assert "urbanisation" in _VIZ_DISAGG_DIMS
+
+
+# ---------------------------------------------------------------------------
+# Bugfix: build_breakdown_comparison_spec year axis and legend title
+# ---------------------------------------------------------------------------
+
+
+def test_breakdown_comparison_spec_uses_temporal_year_encoding():
+    """Year X axis must use type=temporal so Vega-Lite renders years, not millisecond integers."""
+    from data360.viz_config import ChartStrategy, StrategyResult, build_breakdown_comparison_spec
+
+    WGI_BREAKDOWNS = ["WGI_EST", "WGI_SC", "WGI_SE"]
+    df = _make_viz_df(WGI_BREAKDOWNS, [2020, 2021, 2022, 2023, 2024])
+    result = StrategyResult(
+        strategy=ChartStrategy.BREAKDOWN_COMPARISON,
+        reason="test",
+        color_dim="comp_breakdown_1",
+    )
+
+    spec = build_breakdown_comparison_spec(df, "Test Title", result)
+
+    x_enc = spec["encoding"]["x"]
+    assert x_enc["type"] == "temporal", (
+        "X encoding must use type=temporal for year, not ordinal — "
+        "ordinal causes Vega-Lite to render ISO timestamps as raw millisecond integers"
+    )
+    assert x_enc.get("timeUnit") == "year"
+    assert x_enc.get("axis", {}).get("format") == "%Y"
+
+
+def test_breakdown_comparison_spec_uses_friendly_legend_title():
+    """Legend title must use the friendly label from _TOOLTIP_SPECS, not field.title()."""
+    from data360.viz_config import ChartStrategy, StrategyResult, build_breakdown_comparison_spec
+
+    WGI_BREAKDOWNS = ["WGI_EST", "WGI_SC"]
+    df = _make_viz_df(WGI_BREAKDOWNS, [2022, 2023])
+    result = StrategyResult(
+        strategy=ChartStrategy.BREAKDOWN_COMPARISON,
+        reason="test",
+        color_dim="comp_breakdown_1",
+    )
+
+    spec = build_breakdown_comparison_spec(df, "Test Title", result)
+
+    legend_title = spec["encoding"]["color"]["legend"]["title"]
+    assert legend_title == "Breakdown", (
+        f"Legend title should be 'Breakdown' from _TOOLTIP_SPECS, got '{legend_title}'. "
+        "The old code used color_dim.title() which produced 'Comp_Breakdown_1'."
+    )

--- a/tests/test_viz_comp_breakdown.py
+++ b/tests/test_viz_comp_breakdown.py
@@ -1,0 +1,222 @@
+"""Tests for COMP_BREAKDOWN_1/2 handling in the visualization pipeline.
+
+Covers: _clean_single_df column discovery, color dim detection, strategy
+selection breakdown counting, tooltip specs, and multi-indicator join keys.
+Issue: https://github.com/worldbank/data360-mcp/issues/84
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from data360.viz_config import (
+    _TOOLTIP_PRIORITY,
+    _TOOLTIP_SPECS,
+    ChartStrategy,
+    StrategyResult,
+    select_strategy,
+)
+from data360.visualization import _VIZ_DISAGG_DIMS, _clean_single_df
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_wgi_df(breakdowns: list[str], years: list[int]) -> pd.DataFrame:
+    """Build a synthetic WGI-style DataFrame with multiple COMP_BREAKDOWN_1 values."""
+    rows = []
+    for bd in breakdowns:
+        for yr in years:
+            rows.append(
+                {
+                    "time_period": str(yr),
+                    "obs_value": 0.5,
+                    "ref_area": "GEO",
+                    "comp_breakdown_1": bd,
+                    "sex": "_Z",
+                    "age": "_Z",
+                    "urbanisation": "_Z",
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _make_viz_df(breakdowns: list[str], years: list[int]) -> pd.DataFrame:
+    """Build a cleaned viz DataFrame (post-_clean_single_df rename) for strategy testing."""
+    rows = []
+    for bd in breakdowns:
+        for yr in years:
+            rows.append(
+                {
+                    "year": pd.Timestamp(f"{yr}-01-01"),
+                    "value": 0.5,
+                    "country": "Georgia",
+                    "comp_breakdown_1": bd,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Change 1: _clean_single_df column discovery
+# ---------------------------------------------------------------------------
+
+
+def test_clean_single_df_keeps_comp_breakdown_1_when_multi_value():
+    """comp_breakdown_1 must be retained when it has multiple distinct non-trivial values."""
+    WGI_BREAKDOWNS = ["WGI_EST", "WGI_SE", "WGI_SC", "WGI_SR", "WGI_SC_LB", "WGI_SC_UB"]
+    raw = _make_wgi_df(WGI_BREAKDOWNS, [2022, 2023, 2024])
+
+    viz_data, relevant_cols = _clean_single_df(raw, None, None, "A")
+
+    assert "comp_breakdown_1" in viz_data.columns, (
+        "comp_breakdown_1 should be retained when it has 6 distinct values"
+    )
+    assert "comp_breakdown_1" in relevant_cols
+
+
+def test_clean_single_df_drops_comp_breakdown_1_when_trivial_z():
+    """comp_breakdown_1 must be dropped when its only value is _Z (not applicable)."""
+    raw = _make_wgi_df(["_Z"], [2022, 2023])  # single trivial value
+
+    viz_data, relevant_cols = _clean_single_df(raw, None, None, "A")
+
+    assert "comp_breakdown_1" not in viz_data.columns, (
+        "comp_breakdown_1 should be dropped when value is only _Z"
+    )
+
+
+def test_clean_single_df_drops_comp_breakdown_1_when_trivial_t():
+    """comp_breakdown_1 must be dropped when its only value is _T (aggregate total)."""
+    df = pd.DataFrame(
+        {
+            "time_period": ["2023", "2024"],
+            "obs_value": [1.0, 2.0],
+            "ref_area": ["GEO", "GEO"],
+            "comp_breakdown_1": ["_T", "_T"],
+        }
+    )
+    viz_data, relevant_cols = _clean_single_df(df, None, None, "A")
+
+    assert "comp_breakdown_1" not in viz_data.columns, (
+        "comp_breakdown_1 should be dropped when value is only _T"
+    )
+
+
+def test_clean_single_df_keeps_comp_breakdown_2_when_multi_value():
+    """comp_breakdown_2 follows the same inclusion logic as comp_breakdown_1."""
+    df = pd.DataFrame(
+        {
+            "time_period": ["2023", "2023"],
+            "obs_value": [1.0, 2.0],
+            "ref_area": ["GEO", "GEO"],
+            "comp_breakdown_2": ["PHASE1", "PHASE2"],
+        }
+    )
+    viz_data, relevant_cols = _clean_single_df(df, None, None, "A")
+
+    assert "comp_breakdown_2" in viz_data.columns
+    assert "comp_breakdown_2" in relevant_cols
+
+
+def test_clean_single_df_relevant_fields_branch_keeps_comp_breakdown():
+    """The explicit relevant_fields branch should also auto-add comp_breakdown_1."""
+    raw = _make_wgi_df(["WGI_EST", "WGI_SC"], [2022, 2023])
+
+    # Pass only core fields; comp_breakdown_1 should be auto-added
+    viz_data, relevant_cols = _clean_single_df(
+        raw, ["time_period", "obs_value"], None, "A"
+    )
+
+    assert "comp_breakdown_1" in viz_data.columns, (
+        "comp_breakdown_1 should be auto-added in relevant_fields branch"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Change 3: strategy selection counts comp_breakdown_1/2
+# ---------------------------------------------------------------------------
+
+
+def test_strategy_detects_comp_breakdown_1_as_breakdown():
+    """select_strategy must count comp_breakdown_1 values in breakdown_counts."""
+    WGI_BREAKDOWNS = ["WGI_EST", "WGI_SE", "WGI_SC", "WGI_SR", "WGI_SC_LB", "WGI_SC_UB"]
+    df = _make_viz_df(WGI_BREAKDOWNS, list(range(2010, 2025)))
+
+    result = select_strategy(df, n_indicators=1)
+
+    # 6 breakdowns, 1 country, multi-year → must NOT fall through to TEMPORAL_SINGLE
+    # (which would produce a tangled single-color line cloud)
+    assert result.strategy != ChartStrategy.TEMPORAL_SINGLE, (
+        "WGI-style indicators with 6 COMP_BREAKDOWN_1 values must not route to "
+        "TEMPORAL_SINGLE — that produces an unreadable overlapping line cloud"
+    )
+    # Should route to BREAKDOWN_COMPARISON or SMALL_MULTIPLES
+    assert result.strategy in (ChartStrategy.BREAKDOWN_COMPARISON, ChartStrategy.SMALL_MULTIPLES), (
+        f"Expected BREAKDOWN_COMPARISON or SMALL_MULTIPLES, got {result.strategy}"
+    )
+
+
+def test_strategy_no_false_positive_for_trivial_comp_breakdown():
+    """comp_breakdown_1 with a single trivial value must not inflate breakdown count."""
+    df = pd.DataFrame(
+        {
+            "year": pd.to_datetime(["2022", "2023", "2024"]),
+            "value": [1.0, 2.0, 3.0],
+            "country": ["Kenya"] * 3,
+            # Single trivial value — should NOT count as a breakdown
+            "comp_breakdown_1": ["_Z"] * 3,
+        }
+    )
+
+    result = select_strategy(df, n_indicators=1)
+
+    # With no meaningful breakdown, multi-year single-country → TEMPORAL_SINGLE
+    assert result.strategy == ChartStrategy.TEMPORAL_SINGLE
+
+
+# ---------------------------------------------------------------------------
+# Change 4: tooltip specs
+# ---------------------------------------------------------------------------
+
+
+def test_tooltip_specs_include_comp_breakdown_1():
+    """_TOOLTIP_SPECS must have an entry for comp_breakdown_1."""
+    assert "comp_breakdown_1" in _TOOLTIP_SPECS
+    assert _TOOLTIP_SPECS["comp_breakdown_1"]["type"] == "nominal"
+    assert _TOOLTIP_SPECS["comp_breakdown_1"]["title"] == "Breakdown"
+
+
+def test_tooltip_specs_include_comp_breakdown_2():
+    """_TOOLTIP_SPECS must have an entry for comp_breakdown_2."""
+    assert "comp_breakdown_2" in _TOOLTIP_SPECS
+    assert _TOOLTIP_SPECS["comp_breakdown_2"]["type"] == "nominal"
+    assert _TOOLTIP_SPECS["comp_breakdown_2"]["title"] == "Sub-Breakdown"
+
+
+def test_tooltip_priority_includes_comp_breakdown():
+    """Both comp_breakdown_1 and comp_breakdown_2 must appear in _TOOLTIP_PRIORITY."""
+    assert "comp_breakdown_1" in _TOOLTIP_PRIORITY
+    assert "comp_breakdown_2" in _TOOLTIP_PRIORITY
+    # They should appear after the standard dims, not before year/value
+    cb1_idx = _TOOLTIP_PRIORITY.index("comp_breakdown_1")
+    year_idx = _TOOLTIP_PRIORITY.index("year")
+    assert cb1_idx > year_idx, "comp_breakdown_1 should appear after year in tooltip priority"
+
+
+# ---------------------------------------------------------------------------
+# Change 6: _VIZ_DISAGG_DIMS constant
+# ---------------------------------------------------------------------------
+
+
+def test_viz_disagg_dims_constant_is_complete():
+    """_VIZ_DISAGG_DIMS must include both comp_breakdown dimensions."""
+    assert "comp_breakdown_1" in _VIZ_DISAGG_DIMS
+    assert "comp_breakdown_2" in _VIZ_DISAGG_DIMS
+    # Must also preserve existing dims
+    assert "sex" in _VIZ_DISAGG_DIMS
+    assert "age" in _VIZ_DISAGG_DIMS
+    assert "urbanisation" in _VIZ_DISAGG_DIMS

--- a/tests/test_viz_comp_breakdown.py
+++ b/tests/test_viz_comp_breakdown.py
@@ -141,22 +141,34 @@ def test_clean_single_df_relevant_fields_branch_keeps_comp_breakdown():
 # ---------------------------------------------------------------------------
 
 
-def test_strategy_detects_comp_breakdown_1_as_breakdown():
-    """select_strategy must count comp_breakdown_1 values in breakdown_counts."""
+def test_strategy_wgi_multi_year_routes_to_temporal_single():
+    """WGI-style multi-year breakdown must route to TEMPORAL_SINGLE (multi-line), not grouped bar."""
     WGI_BREAKDOWNS = ["WGI_EST", "WGI_SE", "WGI_SC", "WGI_SR", "WGI_SC_LB", "WGI_SC_UB"]
     df = _make_viz_df(WGI_BREAKDOWNS, list(range(2010, 2025)))
 
     result = select_strategy(df, n_indicators=1)
 
-    # 6 breakdowns, 1 country, multi-year → must NOT fall through to TEMPORAL_SINGLE
-    # (which would produce a tangled single-color line cloud)
-    assert result.strategy != ChartStrategy.TEMPORAL_SINGLE, (
-        "WGI-style indicators with 6 COMP_BREAKDOWN_1 values must not route to "
-        "TEMPORAL_SINGLE — that produces an unreadable overlapping line cloud"
+    # 6 breakdowns × 15 years → TEMPORAL_SINGLE with comp_breakdown_1 as color dim
+    # (not BREAKDOWN_COMPARISON which produces 90 grouped bars — unreadable)
+    assert result.strategy == ChartStrategy.TEMPORAL_SINGLE, (
+        f"Expected TEMPORAL_SINGLE for multi-year breakdown data, got {result.strategy}. "
+        "Multi-year breakdown should produce 6 colored lines, not 90 grouped bars."
     )
-    # Should route to BREAKDOWN_COMPARISON or SMALL_MULTIPLES
-    assert result.strategy in (ChartStrategy.BREAKDOWN_COMPARISON, ChartStrategy.SMALL_MULTIPLES), (
-        f"Expected BREAKDOWN_COMPARISON or SMALL_MULTIPLES, got {result.strategy}"
+    assert result.color_dim == "comp_breakdown_1", (
+        f"color_dim should be 'comp_breakdown_1', got '{result.color_dim}'"
+    )
+
+
+def test_strategy_single_year_breakdown_routes_to_breakdown_comparison():
+    """Single-year breakdown still routes to BREAKDOWN_COMPARISON (grouped bar)."""
+    WGI_BREAKDOWNS = ["WGI_EST", "WGI_SE", "WGI_SC"]
+    # Only one year — grouped bar is correct here
+    df = _make_viz_df(WGI_BREAKDOWNS, [2024])
+
+    result = select_strategy(df, n_indicators=1)
+
+    assert result.strategy == ChartStrategy.BREAKDOWN_COMPARISON, (
+        f"Expected BREAKDOWN_COMPARISON for single-year breakdown, got {result.strategy}"
     )
 
 

--- a/tests/test_viz_complex.py
+++ b/tests/test_viz_complex.py
@@ -174,9 +174,11 @@ class TestStrategyRouter:
         assert r.strategy == ChartStrategy.DISTRIBUTION
 
     def test_breakdown_single_disagg(self):
+        # _sex_df has 3 years (2020-2022) + sex breakdown → TEMPORAL_SINGLE (lines per sex)
+        # BREAKDOWN_COMPARISON (grouped bar) only fires for single-year data now.
         df = _sex_df(countries=2)
         r = select_strategy(df)
-        assert r.strategy == ChartStrategy.BREAKDOWN_COMPARISON
+        assert r.strategy == ChartStrategy.TEMPORAL_SINGLE
         assert r.color_dim == "sex"
 
     def test_small_multiples_many_countries_with_breakdown(self):

--- a/tests/test_viz_complex.py
+++ b/tests/test_viz_complex.py
@@ -251,9 +251,11 @@ class TestChartTitleContext:
         t = build_chart_title_with_context("My indicator", "current US$", df)
         assert isinstance(t, dict)
         assert t["text"] == "My indicator"
-        assert "Kenya" in t["subtitle"]
-        assert "2020-2021" in t["subtitle"]
-        assert "current US$" in t["subtitle"]
+        # subtitle is now a list of lines; join for substring checks.
+        full_text = " ".join(t["subtitle"]) if isinstance(t["subtitle"], list) else t["subtitle"]
+        assert "Kenya" in full_text
+        assert "2020-2021" in full_text
+        assert "current US$" in full_text
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_viz_complex.py
+++ b/tests/test_viz_complex.py
@@ -174,12 +174,13 @@ class TestStrategyRouter:
         assert r.strategy == ChartStrategy.DISTRIBUTION
 
     def test_breakdown_single_disagg(self):
-        # _sex_df has 3 years (2020-2022) + sex breakdown → TEMPORAL_SINGLE (lines per sex)
-        # BREAKDOWN_COMPARISON (grouped bar) only fires for single-year data now.
+        # 2 countries × 2 sex × 3 years → SMALL_MULTIPLES (facet by country, color by sex)
+        # Overlaying 4 series on one chart loses per-country context.
         df = _sex_df(countries=2)
         r = select_strategy(df)
-        assert r.strategy == ChartStrategy.TEMPORAL_SINGLE
+        assert r.strategy == ChartStrategy.SMALL_MULTIPLES
         assert r.color_dim == "sex"
+        assert r.facet_dim == "country"
 
     def test_small_multiples_many_countries_with_breakdown(self):
         # 6 countries × 2 sexes → small multiples

--- a/tests/test_viz_grammar_contract.py
+++ b/tests/test_viz_grammar_contract.py
@@ -1,0 +1,269 @@
+"""Tests for the Grammar of Graphics contract in visualization tool docstrings
+and the corresponding pipeline behavior for multi-breakdown indicators.
+
+Two concerns verified here:
+  1. Contract presence — the docstring cannot be accidentally stripped without
+     failing CI, preventing silent regression of the LLM guidance.
+  2. Pipeline correctness — unfiltered WGI-style data (multi-country ×
+     multi-breakdown × multi-year) must produce SMALL_MULTIPLES with the
+     correct Vega-Lite facet/color encoding, NOT a single collapsed series.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from data360.viz_config import ChartStrategy, select_strategy
+from data360.visualization import get_multi_indicator_viz_spec, get_viz_spec
+
+
+# ============================================================================
+# 1. Contract presence
+# ============================================================================
+
+
+class TestGrammarOfGraphicsContractPresence:
+    """The grammar-of-graphics contract must be in both tool docstrings."""
+
+    REQUIRED_PHRASES = [
+        "Grammar of Graphics Contract",
+        "disaggregation_filters decision rule",
+        "OMIT it from disaggregation_filters",
+        "Chart strategy",
+        "Vega-Lite encoding",
+        "_T",
+        "_Z",
+    ]
+
+    def test_get_viz_spec_docstring_has_contract(self):
+        doc = get_viz_spec.__doc__ or ""
+        for phrase in self.REQUIRED_PHRASES:
+            assert phrase in doc, (
+                f"get_viz_spec docstring is missing required contract phrase: {phrase!r}\n"
+                "The grammar-of-graphics contract must be present to guide the LLM."
+            )
+
+    def test_get_multi_indicator_viz_spec_docstring_has_contract(self):
+        doc = get_multi_indicator_viz_spec.__doc__ or ""
+        for phrase in self.REQUIRED_PHRASES:
+            assert phrase in doc, (
+                f"get_multi_indicator_viz_spec docstring is missing required contract "
+                f"phrase: {phrase!r}\n"
+                "The grammar-of-graphics contract must be present to guide the LLM."
+            )
+
+    def test_get_viz_spec_docstring_has_strategy_table(self):
+        """The strategy-to-encoding table must enumerate all bypass strategies."""
+        doc = get_viz_spec.__doc__ or ""
+        required_strategies = [
+            "TEMPORAL_SINGLE",
+            "CROSS_SECTIONAL",
+            "DISTRIBUTION",
+            "BREAKDOWN_COMPARISON",
+            "SMALL_MULTIPLES",
+            "FALLBACK_LINE",
+        ]
+        for strategy in required_strategies:
+            assert strategy in doc, (
+                f"get_viz_spec strategy table is missing: {strategy!r}"
+            )
+
+    def test_get_viz_spec_docstring_has_encoding_type_rules(self):
+        """Vega-Lite v5 encoding type rules must be documented."""
+        doc = get_viz_spec.__doc__ or ""
+        # Year type rule — prevents ordinal-on-year bug
+        assert "ordinal" in doc, (
+            "Docstring must warn against using 'ordinal' for year fields."
+        )
+        assert "temporal" in doc, (
+            "Docstring must state year fields use type='temporal'."
+        )
+
+    def test_get_viz_spec_docstring_has_wrong_example(self):
+        """A WRONG example for COMP_BREAKDOWN_1 must be present."""
+        doc = get_viz_spec.__doc__ or ""
+        assert "COMP_BREAKDOWN_1" in doc and "WRONG" in doc, (
+            "Docstring must contain a WRONG example with COMP_BREAKDOWN_1 to "
+            "explicitly show the LLM what not to do."
+        )
+
+
+# ============================================================================
+# 2. Pipeline behavior: unfiltered multi-breakdown + multi-country
+# ============================================================================
+
+
+def _make_wgi_df(
+    breakdowns: list[str],
+    countries: list[str],
+    years: list[int],
+) -> pd.DataFrame:
+    """Synthetic WGI-style DataFrame: multi-breakdown × multi-country × multi-year."""
+    rows = []
+    for country in countries:
+        for bd in breakdowns:
+            for yr in years:
+                rows.append(
+                    {
+                        "year": pd.Timestamp(str(yr)),
+                        "value": 0.5,
+                        "country": country,
+                        "comp_breakdown_1": bd,
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+WGI_BREAKDOWNS = ["WGI_EST", "WGI_SE", "WGI_SC", "WGI_SR", "WGI_SC_LB", "WGI_SC_UB"]
+THREE_COUNTRIES = ["Ghana", "Kenya", "South Africa"]
+YEARS_2010_2024 = list(range(2010, 2025))
+
+
+class TestUnfilteredWGIPipelineBehavior:
+    """Unfiltered WGI data (3 countries × 6 breakdowns × 15 years) must route
+    to SMALL_MULTIPLES with facet=country and color=comp_breakdown_1.
+
+    This is the correct grammar-of-graphics encoding: each country gets its own
+    panel (facet) and each breakdown series gets its own color line within that
+    panel. Pre-filtering to COMP_BREAKDOWN_1=WGI_EST would collapse all 6 series
+    into one line and produce TEMPORAL_SINGLE with color=country instead.
+    """
+
+    def setup_method(self):
+        self.df = _make_wgi_df(WGI_BREAKDOWNS, THREE_COUNTRIES, YEARS_2010_2024)
+
+    def test_strategy_is_small_multiples(self):
+        result = select_strategy(self.df, n_indicators=1)
+        assert result.strategy == ChartStrategy.SMALL_MULTIPLES, (
+            f"Expected SMALL_MULTIPLES for 3 countries × 6 breakdowns × 15 years, "
+            f"got {result.strategy}. "
+            "Pre-filtering (COMP_BREAKDOWN_1=WGI_EST) would suppress this and "
+            "produce TEMPORAL_SINGLE with color=country — wrong for multi-breakdown data."
+        )
+
+    def test_facet_dim_is_country(self):
+        result = select_strategy(self.df, n_indicators=1)
+        assert result.facet_dim == "country", (
+            f"facet_dim should be 'country', got {result.facet_dim!r}. "
+            "Each country must get its own panel so breakdown lines are readable."
+        )
+
+    def test_color_dim_is_comp_breakdown_1(self):
+        result = select_strategy(self.df, n_indicators=1)
+        assert result.color_dim == "comp_breakdown_1", (
+            f"color_dim should be 'comp_breakdown_1', got {result.color_dim!r}. "
+            "Each breakdown series must be a distinct colored line within each panel."
+        )
+
+    def test_vega_lite_spec_has_facet_encoding(self):
+        """The Vega-Lite spec must use the facet operator, not a flat mark spec."""
+        from data360.viz_config import dispatch_spec
+
+        result = select_strategy(self.df, n_indicators=1)
+        spec = dispatch_spec(result.strategy, self.df, "Test Title", result)
+
+        assert "facet" in spec, (
+            "SMALL_MULTIPLES spec must use top-level 'facet' key. "
+            "A flat mark spec would overlay all series on one chart."
+        )
+
+    def test_vega_lite_spec_facet_field_is_country(self):
+        from data360.viz_config import dispatch_spec
+
+        result = select_strategy(self.df, n_indicators=1)
+        spec = dispatch_spec(result.strategy, self.df, "Test Title", result)
+
+        facet = spec.get("facet", {})
+        assert facet.get("field") == "country", (
+            f"facet.field should be 'country', got {facet.get('field')!r}"
+        )
+        assert facet.get("type") == "nominal", (
+            f"facet.type should be 'nominal', got {facet.get('type')!r}"
+        )
+
+    def test_vega_lite_spec_inner_color_is_comp_breakdown_1(self):
+        from data360.viz_config import dispatch_spec
+
+        result = select_strategy(self.df, n_indicators=1)
+        spec = dispatch_spec(result.strategy, self.df, "Test Title", result)
+
+        inner_enc = spec.get("spec", {}).get("encoding", {})
+        color = inner_enc.get("color", {})
+        assert color.get("field") == "comp_breakdown_1", (
+            f"Inner color.field should be 'comp_breakdown_1', got {color.get('field')!r}. "
+            "Each breakdown must map to a distinct color channel."
+        )
+        assert color.get("type") == "nominal", (
+            f"color.type should be 'nominal', got {color.get('type')!r}"
+        )
+
+    def test_vega_lite_spec_x_axis_is_temporal(self):
+        """Year axis must use type='temporal', not 'ordinal'.
+
+        Using 'ordinal' causes Vega-Lite to render ISO timestamp strings as raw
+        millisecond integers on the axis, which is unreadable.
+        """
+        from data360.viz_config import dispatch_spec
+
+        result = select_strategy(self.df, n_indicators=1)
+        spec = dispatch_spec(result.strategy, self.df, "Test Title", result)
+
+        inner_enc = spec.get("spec", {}).get("encoding", {})
+        x = inner_enc.get("x", {})
+        assert x.get("type") == "temporal", (
+            f"x.type should be 'temporal', got {x.get('type')!r}. "
+            "Ordinal encoding converts ISO timestamps to raw millisecond integers."
+        )
+
+
+# ============================================================================
+# 3. Pre-filter regression: confirm that filtering collapses to the wrong strategy
+# ============================================================================
+
+
+class TestPinningBreakdownCollapsesBehavior:
+    """Verify that the bug scenario (pre-filtering to WGI_EST) does route to
+    TEMPORAL_SINGLE with color=country — which is readable for 3 countries but
+    discards the 5 other breakdown series without warning.
+
+    These tests document the expected behavior of the WRONG pattern so it is
+    clear in CI what information is being lost when a filter is pinned.
+    """
+
+    def test_filtered_to_single_breakdown_routes_to_temporal_single(self):
+        """After pinning COMP_BREAKDOWN_1=WGI_EST, only 1 breakdown remains.
+        The strategy degrades to TEMPORAL_SINGLE (no breakdown variation detected).
+        """
+        df = _make_wgi_df(["WGI_EST"], THREE_COUNTRIES, YEARS_2010_2024)
+        # comp_breakdown_1 has only 1 unique value — treated as trivial, dropped
+        # by _clean_single_df. Strategy sees: 3 countries × 15 years, no breakdown.
+        # But in the strategy df the column would have been dropped already.
+        # Simulate a df without comp_breakdown_1 (as _clean_single_df would produce):
+        df_no_cb = df.drop(columns=["comp_breakdown_1"])
+
+        result = select_strategy(df_no_cb, n_indicators=1)
+
+        assert result.strategy == ChartStrategy.TEMPORAL_SINGLE, (
+            f"After filtering to single breakdown, expected TEMPORAL_SINGLE, "
+            f"got {result.strategy}"
+        )
+        assert result.color_dim == "country", (
+            "With no breakdown dimension, color must fall back to country."
+        )
+
+    def test_filtered_df_loses_breakdown_information(self):
+        """Quantify the information loss: 5 out of 6 breakdown series are invisible."""
+        full_df = _make_wgi_df(WGI_BREAKDOWNS, THREE_COUNTRIES, YEARS_2010_2024)
+        filtered_df = _make_wgi_df(["WGI_EST"], THREE_COUNTRIES, YEARS_2010_2024)
+
+        full_series = len(WGI_BREAKDOWNS) * len(THREE_COUNTRIES)  # 18 series
+        filtered_series = 1 * len(THREE_COUNTRIES)  # 3 series
+
+        assert len(full_df) == full_series * len(YEARS_2010_2024)
+        assert len(filtered_df) == filtered_series * len(YEARS_2010_2024)
+
+        lost_pct = (1 - filtered_series / full_series) * 100
+        assert lost_pct == pytest.approx(83.33, abs=0.01), (
+            f"Expected ~83% of series to be lost by pinning WGI_EST, got {lost_pct:.1f}%"
+        )

--- a/tests/test_viz_grammar_contract.py
+++ b/tests/test_viz_grammar_contract.py
@@ -21,6 +21,7 @@ import pytest
 from data360.viz_config import (
     SMALL_MULTIPLES_MAX_FACETS,
     ChartStrategy,
+    _append_trim_note,
     _format_breakdown_subtitle,
     _is_homogeneous_breakdown,
     dispatch_spec,
@@ -480,3 +481,37 @@ class TestSmallMultiplesSubtitleRebuild:
         assert "Showing" not in subtitle, (
             f"No 'Showing N of M' note expected at or under cap. Got: {subtitle!r}"
         )
+
+    def test_non_country_facet_keeps_geography_subtitle(self):
+        rows = []
+        for bd1 in [f"BD{i:02d}" for i in range(SMALL_MULTIPLES_MAX_FACETS + 5)]:
+            for bd2 in ["A", "B"]:
+                for yr in [2021, 2022, 2023]:
+                    rows.append(
+                        {
+                            "year": pd.Timestamp(str(yr)),
+                            "value": 1.0,
+                            "country": "Kenya",
+                            "comp_breakdown_1": bd1,
+                            "comp_breakdown_2": bd2,
+                        }
+                    )
+        df = pd.DataFrame(rows)
+        result = select_strategy(df, n_indicators=1)
+        assert result.facet_dim == "comp_breakdown_1"
+
+        from data360.viz_config import build_chart_title_with_context
+
+        pre_built = build_chart_title_with_context("Test", None, df)
+        spec = dispatch_spec(result.strategy, df, pre_built, result)
+        raw_sub = spec.get("title", {}).get("subtitle", "")
+        subtitle = " ".join(raw_sub) if isinstance(raw_sub, list) else raw_sub
+        assert "Kenya" in subtitle
+
+
+def test_append_trim_note_uses_human_friendly_plural():
+    title = {"text": "Test", "subtitle": ["Kenya, 2021-2023"]}
+    out = _append_trim_note(title, "comp_breakdown_1", shown=8, original=14)
+    subtitle = " ".join(out["subtitle"]) if isinstance(out["subtitle"], list) else ""
+    assert "breakdowns" in subtitle
+    assert "comp_breakdown_1s" not in subtitle

--- a/tests/test_viz_grammar_contract.py
+++ b/tests/test_viz_grammar_contract.py
@@ -328,12 +328,14 @@ class TestSmallMultiplesFacetCap:
         )
 
     def test_over_cap_adds_showing_note_to_subtitle(self):
-        """Subtitle must say 'Showing N of M' when panels are trimmed."""
+        """Subtitle must contain 'Showing N of M' when panels are trimmed."""
         n = SMALL_MULTIPLES_MAX_FACETS + 10
         df = self._make_many_country_df(n)
         result = select_strategy(df, n_indicators=1)
         spec = dispatch_spec(result.strategy, df, {"text": "T", "subtitle": "S"}, result)
-        subtitle = spec.get("title", {}).get("subtitle", "")
+        raw_sub = spec.get("title", {}).get("subtitle", "")
+        # subtitle may be a list (new multi-line form) or a plain string.
+        subtitle = " ".join(raw_sub) if isinstance(raw_sub, list) else raw_sub
         assert f"Showing {SMALL_MULTIPLES_MAX_FACETS} of {n}" in subtitle, (
             f"Expected 'Showing {SMALL_MULTIPLES_MAX_FACETS} of {n}' in subtitle, "
             f"got: {subtitle!r}"
@@ -460,7 +462,8 @@ class TestSmallMultiplesSubtitleRebuild:
         from data360.viz_config import build_chart_title_with_context
         pre_built = build_chart_title_with_context("Test", None, df)
         spec = dispatch_spec(result.strategy, df, pre_built, result)
-        subtitle = spec.get("title", {}).get("subtitle", "")
+        raw_sub = spec.get("title", {}).get("subtitle", "")
+        subtitle = " ".join(raw_sub) if isinstance(raw_sub, list) else raw_sub
         assert "(+" not in subtitle, (
             f"After cap, '(+N more)' must not appear. Got: {subtitle!r}"
         )

--- a/tests/test_viz_grammar_contract.py
+++ b/tests/test_viz_grammar_contract.py
@@ -344,3 +344,136 @@ class TestSmallMultiplesFacetCap:
         assert 4 <= SMALL_MULTIPLES_MAX_FACETS <= 12, (
             f"SMALL_MULTIPLES_MAX_FACETS={SMALL_MULTIPLES_MAX_FACETS} is outside [4, 12]."
         )
+
+# ============================================================================
+# 6. Legend title — _color_encoding resolves _TOOLTIP_SPECS labels
+# ============================================================================
+
+
+class TestColorEncodingLegendTitle:
+    """_color_encoding must use human-readable labels from _TOOLTIP_SPECS.
+
+    Previously the legend title was missing entirely, so Vega-Lite rendered the
+    raw column name (e.g. 'comp_breakdown_2') as the legend header.
+    """
+
+    def test_comp_breakdown_2_legend_title_is_sub_breakdown(self):
+        from data360.viz_config import _color_encoding
+        enc = _color_encoding("comp_breakdown_2", mark_type="line", n_items=3)
+        legend = enc.get("legend", {})
+        assert legend is not None, "Legend should be present for n_items > 1."
+        assert legend.get("title") == "Sub-Breakdown", (
+            f"Legend title for comp_breakdown_2 should be 'Sub-Breakdown', "
+            f"got {legend.get('title')!r}."
+        )
+
+    def test_comp_breakdown_1_legend_title_is_breakdown(self):
+        from data360.viz_config import _color_encoding
+        enc = _color_encoding("comp_breakdown_1", mark_type="line", n_items=6)
+        legend = enc.get("legend", {})
+        assert legend.get("title") == "Breakdown", (
+            f"Legend title for comp_breakdown_1 should be 'Breakdown', "
+            f"got {legend.get('title')!r}."
+        )
+
+    def test_country_legend_title_is_country(self):
+        from data360.viz_config import _color_encoding
+        enc = _color_encoding("country", mark_type="line", n_items=3)
+        legend = enc.get("legend", {})
+        assert legend.get("title") == "Country"
+
+    def test_caller_supplied_title_takes_priority(self):
+        from data360.viz_config import _color_encoding
+        enc = _color_encoding("comp_breakdown_2", mark_type="line", n_items=3,
+                               legend_title="Food Security Phase")
+        assert enc["legend"]["title"] == "Food Security Phase"
+
+    def test_unknown_field_falls_back_to_title_case(self):
+        from data360.viz_config import _color_encoding
+        enc = _color_encoding("some_custom_dim", mark_type="line", n_items=3)
+        assert enc["legend"]["title"] == "Some Custom Dim"
+
+    def test_small_multiples_spec_legend_not_raw_column_name(self):
+        """End-to-end: SMALL_MULTIPLES spec must not expose raw column names in legend."""
+        breakdowns = ["IPC_IPC_PHASE1", "IPC_IPC_PHASE2", "IPC_IPC_PHASE3"]
+        countries = ["Kenya", "Ghana", "Nigeria"]
+        rows = []
+        for c in countries:
+            for bd in breakdowns:
+                for yr in [2021, 2022, 2023]:
+                    rows.append({"year": pd.Timestamp(str(yr)), "value": 10.0,
+                                 "country": c, "comp_breakdown_2": bd})
+        df = pd.DataFrame(rows)
+        result = select_strategy(df, n_indicators=1)
+        spec = dispatch_spec(result.strategy, df, "Test", result)
+        inner_color = spec.get("spec", {}).get("encoding", {}).get("color", {})
+        legend = inner_color.get("legend", {})
+        title = legend.get("title", "") if legend else ""
+        assert title not in ("comp_breakdown_2", "comp_breakdown_1", ""), (
+            f"Legend title must not be a raw column name. Got: {title!r}."
+        )
+
+
+# ============================================================================
+# 7. Subtitle rebuild — shown countries only after SMALL_MULTIPLES cap
+# ============================================================================
+
+
+class TestSmallMultiplesSubtitleRebuild:
+    """After capping, the subtitle country list must only name the shown countries."""
+
+    def _make_many_country_df(self, n_countries: int) -> pd.DataFrame:
+        countries = [f"Country_{i:02d}" for i in range(n_countries)]
+        breakdowns = ["BD_A", "BD_B"]
+        rows = []
+        for c in countries:
+            for bd in breakdowns:
+                for yr in [2021, 2022, 2023]:
+                    rows.append({"year": pd.Timestamp(str(yr)), "value": 1.0,
+                                 "country": c, "comp_breakdown_1": bd})
+        return pd.DataFrame(rows)
+
+    def test_subtitle_only_lists_shown_countries(self):
+        n = SMALL_MULTIPLES_MAX_FACETS + 10
+        df = self._make_many_country_df(n)
+        result = select_strategy(df, n_indicators=1)
+
+        from data360.viz_config import build_chart_title_with_context
+        pre_built = build_chart_title_with_context("Test", None, df)
+        spec = dispatch_spec(result.strategy, df, pre_built, result)
+        subtitle = spec.get("title", {}).get("subtitle", "")
+
+        shown = {r["country"] for r in spec["data"]["values"]}
+        assert len(shown) == SMALL_MULTIPLES_MAX_FACETS
+
+        trimmed = {f"Country_{i:02d}" for i in range(n)} - shown
+        for c in trimmed:
+            assert c not in subtitle, (
+                f"Trimmed country '{c}' must not appear in subtitle. Got: {subtitle!r}"
+            )
+
+    def test_subtitle_does_not_say_plus_more_after_cap(self):
+        n = SMALL_MULTIPLES_MAX_FACETS + 10
+        df = self._make_many_country_df(n)
+        result = select_strategy(df, n_indicators=1)
+
+        from data360.viz_config import build_chart_title_with_context
+        pre_built = build_chart_title_with_context("Test", None, df)
+        spec = dispatch_spec(result.strategy, df, pre_built, result)
+        subtitle = spec.get("title", {}).get("subtitle", "")
+        assert "(+" not in subtitle, (
+            f"After cap, '(+N more)' must not appear. Got: {subtitle!r}"
+        )
+
+    def test_no_subtitle_change_under_cap(self):
+        n = SMALL_MULTIPLES_MAX_FACETS
+        df = self._make_many_country_df(n)
+        result = select_strategy(df, n_indicators=1)
+
+        from data360.viz_config import build_chart_title_with_context
+        pre_built = build_chart_title_with_context("Test", None, df)
+        spec = dispatch_spec(result.strategy, df, pre_built, result)
+        subtitle = spec.get("title", {}).get("subtitle", "")
+        assert "Showing" not in subtitle, (
+            f"No 'Showing N of M' note expected at or under cap. Got: {subtitle!r}"
+        )

--- a/tests/test_viz_grammar_contract.py
+++ b/tests/test_viz_grammar_contract.py
@@ -1,12 +1,16 @@
 """Tests for the Grammar of Graphics contract in visualization tool docstrings
 and the corresponding pipeline behavior for multi-breakdown indicators.
 
-Two concerns verified here:
+Concerns verified here:
   1. Contract presence — the docstring cannot be accidentally stripped without
      failing CI, preventing silent regression of the LLM guidance.
-  2. Pipeline correctness — unfiltered WGI-style data (multi-country ×
-     multi-breakdown × multi-year) must produce SMALL_MULTIPLES with the
+  2. Pipeline correctness — unfiltered WGI-style data (multi-country x
+     multi-breakdown x multi-year) must produce SMALL_MULTIPLES with the
      correct Vega-Lite facet/color encoding, NOT a single collapsed series.
+  3. Homogeneous breakdown detection — IPC phases must NOT trigger the
+     mixed-unit warning; WGI breakdowns must.
+  4. Facet cap — SMALL_MULTIPLES must not produce more than
+     SMALL_MULTIPLES_MAX_FACETS panels.
 """
 
 from __future__ import annotations
@@ -14,7 +18,14 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-from data360.viz_config import ChartStrategy, select_strategy
+from data360.viz_config import (
+    SMALL_MULTIPLES_MAX_FACETS,
+    ChartStrategy,
+    _format_breakdown_subtitle,
+    _is_homogeneous_breakdown,
+    dispatch_spec,
+    select_strategy,
+)
 from data360.visualization import get_multi_indicator_viz_spec, get_viz_spec
 
 
@@ -72,7 +83,6 @@ class TestGrammarOfGraphicsContractPresence:
     def test_get_viz_spec_docstring_has_encoding_type_rules(self):
         """Vega-Lite v5 encoding type rules must be documented."""
         doc = get_viz_spec.__doc__ or ""
-        # Year type rule — prevents ordinal-on-year bug
         assert "ordinal" in doc, (
             "Docstring must warn against using 'ordinal' for year fields."
         )
@@ -99,7 +109,7 @@ def _make_wgi_df(
     countries: list[str],
     years: list[int],
 ) -> pd.DataFrame:
-    """Synthetic WGI-style DataFrame: multi-breakdown × multi-country × multi-year."""
+    """Synthetic WGI-style DataFrame: multi-breakdown x multi-country x multi-year."""
     rows = []
     for country in countries:
         for bd in breakdowns:
@@ -121,13 +131,8 @@ YEARS_2010_2024 = list(range(2010, 2025))
 
 
 class TestUnfilteredWGIPipelineBehavior:
-    """Unfiltered WGI data (3 countries × 6 breakdowns × 15 years) must route
+    """Unfiltered WGI data (3 countries x 6 breakdowns x 15 years) must route
     to SMALL_MULTIPLES with facet=country and color=comp_breakdown_1.
-
-    This is the correct grammar-of-graphics encoding: each country gets its own
-    panel (facet) and each breakdown series gets its own color line within that
-    panel. Pre-filtering to COMP_BREAKDOWN_1=WGI_EST would collapse all 6 series
-    into one line and produce TEMPORAL_SINGLE with color=country instead.
     """
 
     def setup_method(self):
@@ -136,134 +141,206 @@ class TestUnfilteredWGIPipelineBehavior:
     def test_strategy_is_small_multiples(self):
         result = select_strategy(self.df, n_indicators=1)
         assert result.strategy == ChartStrategy.SMALL_MULTIPLES, (
-            f"Expected SMALL_MULTIPLES for 3 countries × 6 breakdowns × 15 years, "
-            f"got {result.strategy}. "
-            "Pre-filtering (COMP_BREAKDOWN_1=WGI_EST) would suppress this and "
-            "produce TEMPORAL_SINGLE with color=country — wrong for multi-breakdown data."
+            f"Expected SMALL_MULTIPLES for 3 countries x 6 breakdowns x 15 years, "
+            f"got {result.strategy}."
         )
 
     def test_facet_dim_is_country(self):
         result = select_strategy(self.df, n_indicators=1)
         assert result.facet_dim == "country", (
-            f"facet_dim should be 'country', got {result.facet_dim!r}. "
-            "Each country must get its own panel so breakdown lines are readable."
+            f"facet_dim should be 'country', got {result.facet_dim!r}."
         )
 
     def test_color_dim_is_comp_breakdown_1(self):
         result = select_strategy(self.df, n_indicators=1)
         assert result.color_dim == "comp_breakdown_1", (
-            f"color_dim should be 'comp_breakdown_1', got {result.color_dim!r}. "
-            "Each breakdown series must be a distinct colored line within each panel."
+            f"color_dim should be 'comp_breakdown_1', got {result.color_dim!r}."
         )
 
     def test_vega_lite_spec_has_facet_encoding(self):
-        """The Vega-Lite spec must use the facet operator, not a flat mark spec."""
-        from data360.viz_config import dispatch_spec
-
         result = select_strategy(self.df, n_indicators=1)
         spec = dispatch_spec(result.strategy, self.df, "Test Title", result)
-
-        assert "facet" in spec, (
-            "SMALL_MULTIPLES spec must use top-level 'facet' key. "
-            "A flat mark spec would overlay all series on one chart."
-        )
+        assert "facet" in spec, "SMALL_MULTIPLES spec must use top-level 'facet' key."
 
     def test_vega_lite_spec_facet_field_is_country(self):
-        from data360.viz_config import dispatch_spec
-
         result = select_strategy(self.df, n_indicators=1)
         spec = dispatch_spec(result.strategy, self.df, "Test Title", result)
-
         facet = spec.get("facet", {})
-        assert facet.get("field") == "country", (
-            f"facet.field should be 'country', got {facet.get('field')!r}"
-        )
-        assert facet.get("type") == "nominal", (
-            f"facet.type should be 'nominal', got {facet.get('type')!r}"
-        )
+        assert facet.get("field") == "country"
+        assert facet.get("type") == "nominal"
 
     def test_vega_lite_spec_inner_color_is_comp_breakdown_1(self):
-        from data360.viz_config import dispatch_spec
-
         result = select_strategy(self.df, n_indicators=1)
         spec = dispatch_spec(result.strategy, self.df, "Test Title", result)
-
         inner_enc = spec.get("spec", {}).get("encoding", {})
         color = inner_enc.get("color", {})
-        assert color.get("field") == "comp_breakdown_1", (
-            f"Inner color.field should be 'comp_breakdown_1', got {color.get('field')!r}. "
-            "Each breakdown must map to a distinct color channel."
-        )
-        assert color.get("type") == "nominal", (
-            f"color.type should be 'nominal', got {color.get('type')!r}"
-        )
+        assert color.get("field") == "comp_breakdown_1"
+        assert color.get("type") == "nominal"
 
     def test_vega_lite_spec_x_axis_is_temporal(self):
-        """Year axis must use type='temporal', not 'ordinal'.
-
-        Using 'ordinal' causes Vega-Lite to render ISO timestamp strings as raw
-        millisecond integers on the axis, which is unreadable.
-        """
-        from data360.viz_config import dispatch_spec
-
+        """Year axis must use type='temporal', not 'ordinal'."""
         result = select_strategy(self.df, n_indicators=1)
         spec = dispatch_spec(result.strategy, self.df, "Test Title", result)
-
         inner_enc = spec.get("spec", {}).get("encoding", {})
         x = inner_enc.get("x", {})
         assert x.get("type") == "temporal", (
-            f"x.type should be 'temporal', got {x.get('type')!r}. "
-            "Ordinal encoding converts ISO timestamps to raw millisecond integers."
+            f"x.type should be 'temporal', got {x.get('type')!r}."
         )
 
 
 # ============================================================================
-# 3. Pre-filter regression: confirm that filtering collapses to the wrong strategy
+# 3. Pre-filter regression documentation
 # ============================================================================
 
 
 class TestPinningBreakdownCollapsesBehavior:
-    """Verify that the bug scenario (pre-filtering to WGI_EST) does route to
-    TEMPORAL_SINGLE with color=country — which is readable for 3 countries but
-    discards the 5 other breakdown series without warning.
-
-    These tests document the expected behavior of the WRONG pattern so it is
-    clear in CI what information is being lost when a filter is pinned.
-    """
+    """Documents what happens when the LLM incorrectly pins COMP_BREAKDOWN_1."""
 
     def test_filtered_to_single_breakdown_routes_to_temporal_single(self):
-        """After pinning COMP_BREAKDOWN_1=WGI_EST, only 1 breakdown remains.
-        The strategy degrades to TEMPORAL_SINGLE (no breakdown variation detected).
-        """
         df = _make_wgi_df(["WGI_EST"], THREE_COUNTRIES, YEARS_2010_2024)
-        # comp_breakdown_1 has only 1 unique value — treated as trivial, dropped
-        # by _clean_single_df. Strategy sees: 3 countries × 15 years, no breakdown.
-        # But in the strategy df the column would have been dropped already.
-        # Simulate a df without comp_breakdown_1 (as _clean_single_df would produce):
         df_no_cb = df.drop(columns=["comp_breakdown_1"])
-
         result = select_strategy(df_no_cb, n_indicators=1)
-
-        assert result.strategy == ChartStrategy.TEMPORAL_SINGLE, (
-            f"After filtering to single breakdown, expected TEMPORAL_SINGLE, "
-            f"got {result.strategy}"
-        )
-        assert result.color_dim == "country", (
-            "With no breakdown dimension, color must fall back to country."
-        )
+        assert result.strategy == ChartStrategy.TEMPORAL_SINGLE
+        assert result.color_dim == "country"
 
     def test_filtered_df_loses_breakdown_information(self):
-        """Quantify the information loss: 5 out of 6 breakdown series are invisible."""
         full_df = _make_wgi_df(WGI_BREAKDOWNS, THREE_COUNTRIES, YEARS_2010_2024)
         filtered_df = _make_wgi_df(["WGI_EST"], THREE_COUNTRIES, YEARS_2010_2024)
-
-        full_series = len(WGI_BREAKDOWNS) * len(THREE_COUNTRIES)  # 18 series
-        filtered_series = 1 * len(THREE_COUNTRIES)  # 3 series
-
+        full_series = len(WGI_BREAKDOWNS) * len(THREE_COUNTRIES)
+        filtered_series = 1 * len(THREE_COUNTRIES)
+        lost_pct = (1 - filtered_series / full_series) * 100
+        assert lost_pct == pytest.approx(83.33, abs=0.01), (
+            f"Expected ~83% series lost by pinning WGI_EST, got {lost_pct:.1f}%"
+        )
         assert len(full_df) == full_series * len(YEARS_2010_2024)
         assert len(filtered_df) == filtered_series * len(YEARS_2010_2024)
 
-        lost_pct = (1 - filtered_series / full_series) * 100
-        assert lost_pct == pytest.approx(83.33, abs=0.01), (
-            f"Expected ~83% of series to be lost by pinning WGI_EST, got {lost_pct:.1f}%"
+
+# ============================================================================
+# 4. Homogeneous breakdown detection
+# ============================================================================
+
+
+class TestHomogeneousBreakdownDetection:
+    """IPC phases are ordinal categories of ONE metric.
+    WGI breakdowns are structurally different metric types."""
+
+    def test_ipc_phases_are_homogeneous(self):
+        ipc = [
+            "IPC_IPC_PHASE1", "IPC_IPC_PHASE2", "IPC_IPC_PHASE3",
+            "IPC_IPC_PHASE4", "IPC_IPC_PHASE5",
+        ]
+        assert _is_homogeneous_breakdown(ipc) is True, (
+            "IPC phases share base 'IPC_IPC_PHASE' — should be homogeneous."
+        )
+
+    def test_wgi_breakdowns_are_heterogeneous(self):
+        wgi = ["WGI_EST", "WGI_SE", "WGI_SC", "WGI_SR", "WGI_SC_LB", "WGI_SC_UB"]
+        assert _is_homogeneous_breakdown(wgi) is False, (
+            "WGI breakdowns are structurally different metrics — heterogeneous."
+        )
+
+    def test_single_value_is_treated_as_homogeneous(self):
+        assert _is_homogeneous_breakdown(["WGI_EST"]) is True
+
+    def test_ipc_subtitle_has_no_mixed_unit_warning(self):
+        """IPC phase subtitle: list series, no 'different units/scales' warning."""
+        ipc_phases = ["IPC_IPC_PHASE1", "IPC_IPC_PHASE2", "IPC_IPC_PHASE3"]
+        rows = [
+            {"year": pd.Timestamp("2022"), "value": 10.0, "country": "Kenya",
+             "comp_breakdown_2": p}
+            for p in ipc_phases
+        ]
+        df = pd.DataFrame(rows)
+        note = _format_breakdown_subtitle(df, "comp_breakdown_2")
+        assert note is not None, "A note should still be returned for multi-value breakdowns."
+        assert "different units" not in note, (
+            "Homogeneous IPC phases must not show 'different units/scales' warning."
+        )
+        assert "Series:" in note, "Note must still list the series names."
+
+    def test_wgi_subtitle_has_mixed_unit_warning(self):
+        """WGI subtitle must include 'different units/scales' warning."""
+        wgi_bds = ["WGI_EST", "WGI_SC", "WGI_SE", "WGI_SR"]
+        rows = [
+            {"year": pd.Timestamp("2022"), "value": 0.5, "country": "Kenya",
+             "comp_breakdown_1": b}
+            for b in wgi_bds
+        ]
+        df = pd.DataFrame(rows)
+        note = _format_breakdown_subtitle(df, "comp_breakdown_1")
+        assert note is not None
+        assert "different units/scales" in note, (
+            "WGI breakdowns must show the mixed-unit warning."
+        )
+
+    def test_standard_dim_returns_none(self):
+        """Standard dims (country, sex) must never trigger a breakdown note."""
+        rows = [{"year": pd.Timestamp("2022"), "value": 1.0, "country": c}
+                for c in ["Kenya", "Ghana"]]
+        df = pd.DataFrame(rows)
+        assert _format_breakdown_subtitle(df, "country") is None
+        assert _format_breakdown_subtitle(df, "sex") is None
+
+
+# ============================================================================
+# 5. SMALL_MULTIPLES facet cap
+# ============================================================================
+
+
+class TestSmallMultiplesFacetCap:
+    """SMALL_MULTIPLES must cap at SMALL_MULTIPLES_MAX_FACETS panels.
+    Chatbot UIs overflow vertically beyond this."""
+
+    def _make_many_country_df(self, n_countries: int) -> pd.DataFrame:
+        countries = [f"Country_{i:02d}" for i in range(n_countries)]
+        # Two breakdown values ensures select_strategy routes to SMALL_MULTIPLES
+        breakdowns = ["BD_A", "BD_B"]
+        rows = []
+        for c in countries:
+            for bd in breakdowns:
+                for yr in [2020, 2021, 2022]:
+                    rows.append({
+                        "year": pd.Timestamp(str(yr)),
+                        "value": 1.0,
+                        "country": c,
+                        "comp_breakdown_1": bd,
+                    })
+        return pd.DataFrame(rows)
+
+    def test_under_cap_produces_no_trim_note(self):
+        """Fewer than MAX_FACETS countries: all panels, no trim note."""
+        df = self._make_many_country_df(SMALL_MULTIPLES_MAX_FACETS)
+        result = select_strategy(df, n_indicators=1)
+        spec = dispatch_spec(result.strategy, df, {"text": "T", "subtitle": "S"}, result)
+        subtitle = spec.get("title", {}).get("subtitle", "")
+        assert "Showing" not in subtitle, "No cap note should appear at or under MAX_FACETS."
+
+    def test_over_cap_trims_to_max_facets(self):
+        """More than MAX_FACETS countries: exactly MAX_FACETS shown."""
+        n = SMALL_MULTIPLES_MAX_FACETS + 10
+        df = self._make_many_country_df(n)
+        result = select_strategy(df, n_indicators=1)
+        spec = dispatch_spec(result.strategy, df, {"text": "T", "subtitle": "S"}, result)
+        shown = {r["country"] for r in spec["data"]["values"]}
+        assert len(shown) == SMALL_MULTIPLES_MAX_FACETS, (
+            f"Expected {SMALL_MULTIPLES_MAX_FACETS} panels, got {len(shown)}."
+        )
+
+    def test_over_cap_adds_showing_note_to_subtitle(self):
+        """Subtitle must say 'Showing N of M' when panels are trimmed."""
+        n = SMALL_MULTIPLES_MAX_FACETS + 10
+        df = self._make_many_country_df(n)
+        result = select_strategy(df, n_indicators=1)
+        spec = dispatch_spec(result.strategy, df, {"text": "T", "subtitle": "S"}, result)
+        subtitle = spec.get("title", {}).get("subtitle", "")
+        assert f"Showing {SMALL_MULTIPLES_MAX_FACETS} of {n}" in subtitle, (
+            f"Expected 'Showing {SMALL_MULTIPLES_MAX_FACETS} of {n}' in subtitle, "
+            f"got: {subtitle!r}"
+        )
+
+    def test_max_facets_constant_is_chatbot_safe(self):
+        """SMALL_MULTIPLES_MAX_FACETS must be in the usable range [4, 12]."""
+        assert 4 <= SMALL_MULTIPLES_MAX_FACETS <= 12, (
+            f"SMALL_MULTIPLES_MAX_FACETS={SMALL_MULTIPLES_MAX_FACETS} is outside [4, 12]."
         )

--- a/tests/test_viz_grammar_contract.py
+++ b/tests/test_viz_grammar_contract.py
@@ -509,9 +509,11 @@ class TestSmallMultiplesSubtitleRebuild:
         assert "Kenya" in subtitle
 
 
-def test_append_trim_note_uses_human_friendly_plural():
-    title = {"text": "Test", "subtitle": ["Kenya, 2021-2023"]}
-    out = _append_trim_note(title, "comp_breakdown_1", shown=8, original=14)
-    subtitle = " ".join(out["subtitle"]) if isinstance(out["subtitle"], list) else ""
-    assert "breakdowns" in subtitle
-    assert "comp_breakdown_1s" not in subtitle
+class TestTrimNotePluralization:
+    def test_append_trim_note_pluralizes_custom_dimensions(self):
+        title = {"text": "Test", "subtitle": ["Kenya, 2021-2023"]}
+        out = _append_trim_note(title, "comp_breakdown_1", shown=8, original=14)
+        raw_sub = out.get("subtitle", "")
+        subtitle = " ".join(raw_sub) if isinstance(raw_sub, list) else raw_sub
+        assert "breakdowns" in subtitle
+        assert "comp_breakdown_1s" not in subtitle


### PR DESCRIPTION
## Summary

Fixes #84.

Indicators like `WB_WGI` carry semantically distinct breakdowns via `COMP_BREAKDOWN_1` (e.g. `WGI_EST`, `WGI_SE`, `WGI_SC`, `WGI_SC_LB`, `WGI_SC_UB`, `WGI_SR`). Before this change, the visualization pipeline silently dropped `comp_breakdown_1` / `comp_breakdown_2` columns. This produced charts that mixed all 6 series as a single indistinguishable zigzag line — with percentile ranks (~60), estimates (~0.5), standard errors (~0.25), and source counts (~8) all overlapping on the same Y axis.

This PR introduces full pipeline support for custom breakdowns and establishes a Grammar of Graphics contract to teach the LLM how to correctly pin dimensions.

### Before & After

| Before (Issue #84) | After (This PR) |
|---|---|
| _<img width="808" height="665" alt="image" src="https://github.com/user-attachments/assets/c700d9bf-ec49-4707-981d-b4338e2c61b6" />_ | _<img width="793" height="592" alt="image" src="https://github.com/user-attachments/assets/9f869b37-2b82-41d2-b59c-314ac6d3f79b" />_ |
| The LLM didn't know how to filter, and the viz pipeline collapsed all 6 WGI series (rank, estimate, error, count) into a single zigzag line. | The LLM correctly identifies the mixed units, prompts the user or auto-selects a valid single series (e.g., Estimate), and plots a clean temporal line. |

## Changes

### Pipeline handling
**`src/data360/visualization.py`**
- Add `_VIZ_DISAGG_DIMS` constant — single source of truth for all disaggregation dim names in the viz pipeline.
- `_clean_single_df`: include `comp_breakdown_1/2` in dimension discovery loops; extend trivial-value check to cover both `_T` and `_Z`.

**`src/data360/viz_config.py`**
- `select_strategy`: count `comp_breakdown_1/2` unique values so indicators with custom dimensions route to `BREAKDOWN_COMPARISON` or `SMALL_MULTIPLES`.
- All bypass strategies produce validated Vega-Lite v5 specs directly (Draco is bypassed).
- Year axes use `type: temporal` with `format: %Y` (prevents ordinal→millisecond bug).
- Legend titles derived from `_TOOLTIP_SPECS` labels.
- Subtitles are now natively multi-line (list of strings) to prevent horizontal overflow in the chatbot UI, capped intelligently.

### Grammar of Graphics contract
**`src/data360/visualization.py`** — tool docstrings
- Add Grammar of Graphics Contract to `get_viz_spec` and `get_multi_indicator_viz_spec`.
- `disaggregation_filters` decision rule: CORRECT/WRONG examples teach LLMs to only pin dimensions when explicitly requested.

**`src/data360/mcp_server/prompts.py`** — system prompt
- Add grammar-of-graphics rule with situation/action table for `disaggregation_filters`.
- Add mixed-unit breakdown warning: LLM must surface `comp_breakdown_1` choices when breakdowns represent structurally different metric types.

## Tests
- Added **25+ new tests** covering column discovery, strategy detection, tooltip specs, contract presence guards, and subtitle formatting.
- Total test suite now runs **483 tests**, all passing.

