### PR TITLE
feat(tools): add data360_get_timeseries_v2 fallback to legacy Indicators v2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 DATA360_API_BASE_URL=https://data360api.worldbank.org
+# Optional override for the legacy Indicators v2 endpoint used by
+# data360_get_timeseries_v2 (default: https://api.worldbank.org/v2).
+# DATA360_INDICATORS_V2_BASE_URL=https://api.worldbank.org/v2
 # Optional base URL for static viz JSON URLs (defaults to http://localhost:MCP_PORT). Use a
 # browser-reachable origin, e.g. http://127.0.0.1:8000 — see visualization.save_specs_to_static.
 # WEBSITE_HOSTNAME=http://127.0.0.1:8000

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -27,6 +27,9 @@ from .models import (
     ComparisonSnapshot,
     ComparisonTimeSeries,
     CountryComparisonResponse,
+    DatasetDescription,
+    DatasetSearchRequest,
+    DatasetSearchResponse,
     DataSummaryResponse,
     DerivedDataResponse,
     DiagnosticSummaryResponse,
@@ -48,9 +51,6 @@ from .models import (
     SearchRequest,
     SearchResponse,
     SeriesDescription,
-    DatasetSearchRequest,
-    DatasetDescription,
-    DatasetSearchResponse,
 )
 from .providers import get_database_mapping
 
@@ -109,7 +109,15 @@ _ENRICHMENT_SELECT_FIELDS = [
 # Based on a 16-database survey (see payload_analysis.md for full documentation).
 # Always-keep fields: the core data the LLM needs.
 _CORE_FIELDS = frozenset(
-    {"OBS_VALUE", "TIME_PERIOD", "REF_AREA", "REF_AREA_NAME", "country_name", "UNIT_MEASURE", "claim_id"}
+    {
+        "OBS_VALUE",
+        "TIME_PERIOD",
+        "REF_AREA",
+        "REF_AREA_NAME",
+        "country_name",
+        "UNIT_MEASURE",
+        "claim_id",
+    }
 )
 # Conditional fields: kept only when their value is non-trivial (not _T or _Z).
 # SEX/AGE/URBANISATION carry real disaggregation in WB_HCP, WB_SSGD, OECD_IDD.
@@ -200,7 +208,8 @@ async def _fetch_dimensions_raw_uncached(
     _cache_key = (database_id, indicator_id)
     try:
         dimensions_url = (
-            data360_config.dimensions_url or f"{data360_config.api_url}/portal/v1/dimensions"
+            data360_config.dimensions_url
+            or f"{data360_config.api_url}/portal/v1/dimensions"
         )
         headers = {"accept": "*/*", "Content-Type": "application/json"}
         payload = {"database_id": database_id, "indicator_id": indicator_id}
@@ -502,7 +511,9 @@ def _get_items_from_response(response_data: dict[str, Any]) -> list[SeriesDescri
             databases = value.get("databases", [])
             db_id = None
             if databases and isinstance(databases, list) and len(databases) > 0:
-                db_id = databases[0].get("idno") if isinstance(databases[0], dict) else None
+                db_id = (
+                    databases[0].get("idno") if isinstance(databases[0], dict) else None
+                )
 
             tp = value.get("time_period")
             time_periods = None
@@ -528,13 +539,16 @@ def _get_items_from_response(response_data: dict[str, Any]) -> list[SeriesDescri
                 "idno": value.get("idno"),
                 "name": value.get("name"),
                 "database_id": db_id or value.get("database_id"),
-                "definition_long": value.get("description") or value.get("definition_long"),
+                "definition_long": value.get("description")
+                or value.get("definition_long"),
                 "periodicity": value.get("frequency") or value.get("periodicity"),
                 "time_periods": time_periods,
                 "ref_country": value.get("ref_country"),
                 "dimensions": dimensions,
                 "metadata_link": ml or [],
-                "connected_entities": value.get("connected_entities") if isinstance(value.get("connected_entities"), list) else None,
+                "connected_entities": value.get("connected_entities")
+                if isinstance(value.get("connected_entities"), list)
+                else None,
             }
 
         if (
@@ -558,7 +572,9 @@ def _process_search_response(
     """Process API response and build SearchResponse."""
     search_response_data = {
         "items": _get_items_from_response(response_data),
-        "total_count": response_data.get("count") if "count" in response_data else response_data.get("@odata.count"),
+        "total_count": response_data.get("count")
+        if "count" in response_data
+        else response_data.get("@odata.count"),
         "offset": request.offset,
     }
     search_response_data["count"] = len(search_response_data["items"])
@@ -605,7 +621,10 @@ async def _search_raw(
         count=count,
     )
 
-    url = data360_config.search_url or f"{data360_config.api_url}/portal/v1/public_data360_search"
+    url = (
+        data360_config.search_url
+        or f"{data360_config.api_url}/portal/v1/public_data360_search"
+    )
     payload = {
         "site": "data360",
         "query_string": request.query,
@@ -636,7 +655,6 @@ async def _search_raw(
     except Exception as e:
         # Convert unknown exceptions to Data360MCPError and raise
         raise classify_error(e, context="search")
-
 
 
 async def _resolve_country_code(country_query: str) -> str | None:
@@ -753,7 +771,9 @@ def _enrich_search_results(
                             ref_countries.add(rc["code"])
                         elif isinstance(rc, str):
                             ref_countries.add(rc)
-                covers_country = {code: (code in ref_countries) for code in requested_codes}
+                covers_country = {
+                    code: (code in ref_countries) for code in requested_codes
+                }
 
         # Extract dimension names
         dimensions = raw.get("dimensions", [])
@@ -794,7 +814,10 @@ def _enrich_search_results(
             # Check if query matches a connected entity (SearchV3 redirect direction is reversed)
             clean_query = query.strip().upper()
             for entity in raw["connected_entities"]:
-                if isinstance(entity, dict) and entity.get("idno", "").upper() == clean_query:
+                if (
+                    isinstance(entity, dict)
+                    and entity.get("idno", "").upper() == clean_query
+                ):
                     original_idno = entity.get("idno")
                     _logger.debug(
                         "Mapped primary source %s -> %s/%s via connected_entities for query %s",
@@ -1092,7 +1115,9 @@ async def search(  # noqa: PLR0911
                 query=q,
                 limit=limit,
                 offset=offset,
-                economy_codes=[c.strip() for c in country_code.split(";")] if country_code else None,
+                economy_codes=[c.strip() for c in country_code.split(";")]
+                if country_code
+                else None,
             )
             for q in clean_queries
         ]
@@ -1229,7 +1254,9 @@ async def search(  # noqa: PLR0911
             query=query,  # type: ignore[arg-type]  # validated non-None above
             limit=limit,
             offset=offset,
-            economy_codes=[c.strip() for c in country_code.split(";")] if country_code else None,
+            economy_codes=[c.strip() for c in country_code.split(";")]
+            if country_code
+            else None,
         )
     except PydanticValidationError as e:
         return EnrichedSearchResponse(error=str(e))
@@ -1350,7 +1377,11 @@ async def _build_multi_query_response(
     enriched_lists = []
     for i, (q, raw_result) in enumerate(zip(clean_queries, raw_results)):
         code_for_query = per_query_codes[i]
-        if isinstance(raw_result, Exception) or raw_result.error or not raw_result.items:
+        if (
+            isinstance(raw_result, Exception)
+            or raw_result.error
+            or not raw_result.items
+        ):
             enriched_lists.append((None, None))
             continue
 
@@ -1486,7 +1517,10 @@ async def search_datasets(
     except PydanticValidationError as e:
         return DatasetSearchResponse(error=str(e))
 
-    url = data360_config.search_url or f"{data360_config.api_url}/portal/v1/public_data360_search"
+    url = (
+        data360_config.search_url
+        or f"{data360_config.api_url}/portal/v1/public_data360_search"
+    )
     payload = {
         "site": "data360",
         "query_string": request.query,
@@ -1518,7 +1552,11 @@ async def search_datasets(
                 )
             )
 
-        total_count = response_data.get("count") or response_data.get("@odata.count") or len(items)
+        total_count = (
+            response_data.get("count")
+            or response_data.get("@odata.count")
+            or len(items)
+        )
 
         has_more = False
         next_offset = None
@@ -1740,9 +1778,7 @@ async def get_disaggregation(
     queried_countries = await _resolve_queried_countries(required_country)
 
     try:
-        dimensions_json = await _fetch_dimensions_with_cache(
-            database_id, indicator_id
-        )
+        dimensions_json = await _fetch_dimensions_with_cache(database_id, indicator_id)
         raw_data = _parse_dimensions_response(dimensions_json)
         # Filter out _Z values and format response
         valid_dimensions = _get_valid_disaggregations(raw_data)
@@ -2019,6 +2055,7 @@ async def get_data(
             raw_data = raw_data[:limit]
 
         from .providers import get_codelist_manager  # noqa: PLC0415
+
         _cm = get_codelist_manager()
         await _cm._ensure_extdataportal_loaded()
         for row in raw_data:
@@ -2266,6 +2303,132 @@ async def get_data_api_url(
 
     query_string = urlencode(params, safe=",")
     return f"{base}?{query_string}"
+
+
+# ---------------------------------------------------------------------------
+# Indicators v2 fallback (legacy World Bank Indicators API)
+# ---------------------------------------------------------------------------
+
+
+async def get_timeseries_v2(
+    indicator_id: str,
+    country_code: str,
+    start_year: int | None = None,
+    end_year: int | None = None,
+    per_page: int = 200,
+) -> IndicatorDataResponse:
+    """Fetch a time series from the legacy World Bank Indicators v2 API.
+
+    Use as a fallback when ``data360_get_data`` returns no observations,
+    errors out, or covers an indicator that has only the older v2 endpoint.
+    The v2 API has been stable for years and covers most WDI-classic series.
+
+    The v2 API uses a different indicator code format than Data360: dotted
+    codes like ``SP.POP.TOTL`` or ``NY.GDP.PCAP.CD``, **not** the Data360
+    underscored form ``WB_WDI_SP_POP_TOTL``. For most WDI indicators you can
+    derive the v2 code by stripping the ``WB_WDI_`` prefix and replacing
+    underscores with dots.
+
+    Args:
+        indicator_id: Classic WB indicator code in dotted form (e.g.
+            ``SP.POP.TOTL``).
+        country_code: ISO 3166-1 alpha-2 or alpha-3 country code (e.g. ``AR``
+            or ``ARG``). Multiple countries can be passed as a
+            semicolon-separated list (e.g. ``ARG;BRA``).
+        start_year: Optional start year (inclusive).
+        end_year: Optional end year (inclusive). If both years are omitted
+            the v2 API returns its full available range for the indicator.
+        per_page: Max records returned in one page (default 200).
+
+    Returns:
+        IndicatorDataResponse:
+            data: list of observation dicts with ``date``, ``value``,
+                ``country_code``, ``country_name``, ``indicator_id``,
+                ``unit``, ``decimal``.
+            metadata: ``source_id``, ``last_updated``, ``page``, ``pages``,
+                ``per_page``, ``total``.
+            count: number of records returned in this response.
+            total_count: total records reported by the v2 API.
+            has_more / next_offset: pagination cursors (v2 paginates by
+                ``page``; ``next_offset`` carries the next page number).
+            error: error message if the call failed, otherwise None.
+    """
+    from datetime import datetime  # noqa: PLC0415
+
+    settings = get_data360_settings()
+    base = settings.indicators_v2_base_url.rstrip("/")
+    url = f"{base}/country/{country_code}/indicator/{indicator_id}"
+
+    params: dict[str, Any] = {"format": "json", "per_page": per_page}
+    if start_year is not None and end_year is not None:
+        params["date"] = f"{start_year}:{end_year}"
+    elif start_year is not None:
+        params["date"] = f"{start_year}:{datetime.now().year}"
+    elif end_year is not None:
+        params["date"] = f"1960:{end_year}"
+
+    client = get_shared_httpx_client()
+    try:
+        response = await client.get(url, params=params)
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning("Indicators v2 fetch failed: %s", exc)
+        return IndicatorDataResponse(error=f"Indicators v2 API error: {exc}")
+
+    # The v2 API always returns a two-element list: [pagination_meta, observations].
+    _V2_PAYLOAD_LEN = 2
+    if not isinstance(payload, list) or len(payload) < _V2_PAYLOAD_LEN:
+        return IndicatorDataResponse(
+            error="Unexpected Indicators v2 response shape (expected [metadata, data]).",
+        )
+
+    meta_block, raw_points = payload[0], payload[1] or []
+    if not isinstance(meta_block, dict):
+        meta_block = {}
+    if not isinstance(raw_points, list):
+        raw_points = []
+
+    points: list[dict[str, Any]] = []
+    for row in raw_points:
+        if not isinstance(row, dict):
+            continue
+        indicator_obj = row.get("indicator") or {}
+        country_obj = row.get("country") or {}
+        points.append(
+            {
+                "date": row.get("date"),
+                "value": row.get("value"),
+                "country_code": row.get("countryiso3code") or country_obj.get("id"),
+                "country_name": country_obj.get("value"),
+                "indicator_id": indicator_obj.get("id"),
+                "unit": row.get("unit") or "",
+                "decimal": row.get("decimal"),
+            }
+        )
+
+    page = meta_block.get("page")
+    pages = meta_block.get("pages")
+    total = meta_block.get("total")
+    has_more = bool(page and pages and page < pages)
+    next_offset = (page + 1) if has_more else None
+
+    return IndicatorDataResponse(
+        data=points,
+        metadata={
+            "source_id": meta_block.get("sourceid"),
+            "last_updated": meta_block.get("lastupdated"),
+            "page": page,
+            "pages": pages,
+            "per_page": meta_block.get("per_page"),
+            "total": total,
+        },
+        count=len(points),
+        total_count=total if isinstance(total, int) else None,
+        offset=page,
+        has_more=has_more,
+        next_offset=next_offset,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/data360/config.py
+++ b/src/data360/config.py
@@ -78,6 +78,14 @@ class Data360Settings(BaseSettings):
         ...,
         description="Base URL for the Data360 API",
     )
+    indicators_v2_base_url: str = Field(
+        default="https://api.worldbank.org/v2",
+        description=(
+            "Base URL for the legacy World Bank Indicators v2 API. Used by "
+            "data360_get_timeseries_v2 as a stable fallback for WDI-family "
+            "indicators when the Data360 API returns an empty or 5xx response."
+        ),
+    )
     codelist_api_base_url: str = Field(
         default="https://extdataportal.worldbank.org/api/data360/metadata/codelist",
         description=(

--- a/src/data360/mcp_server/tools.py
+++ b/src/data360/mcp_server/tools.py
@@ -17,7 +17,6 @@ from data360 import visualization as data360_viz
 from ._server_definition import mcp
 from .tool_spans import instrument_mcp_tool
 
-
 # ---------------------------------------------------------------------------
 # Serializer for aggregation tools
 # ---------------------------------------------------------------------------
@@ -164,6 +163,40 @@ async def _get_data(
         limit=limit,
         offset=offset,
         ref_area_filter=ref_area_filter,
+    )
+
+
+async def _get_timeseries_v2(
+    indicator_id: str,
+    country_code: str,
+    start_year: int | None = None,
+    end_year: int | None = None,
+    per_page: int = 200,
+) -> Any:
+    """Fetch a time series from the legacy World Bank Indicators v2 API.
+
+    Use as a fallback when `data360_get_data` returns no observations or
+    errors out for an indicator the legacy API still serves. The v2 API has
+    been stable for years and covers most WDI-classic series.
+
+    The v2 API uses a different indicator code format than Data360: dotted
+    codes like "SP.POP.TOTL", NOT "WB_WDI_SP_POP_TOTL". For most WDI
+    indicators, strip the "WB_WDI_" prefix and replace underscores with dots.
+
+    Args:
+        indicator_id: Classic WB indicator code in dotted form (e.g. "SP.POP.TOTL").
+        country_code: ISO 3166-1 alpha-2 or alpha-3 code (e.g. "AR" or "ARG"),
+            or a semicolon-separated list for multiple countries.
+        start_year: Optional start year (inclusive).
+        end_year: Optional end year (inclusive).
+        per_page: Max records per page (default 200).
+    """
+    return await data360_api.get_timeseries_v2(
+        indicator_id=indicator_id,
+        country_code=country_code,
+        start_year=start_year,
+        end_year=end_year,
+        per_page=per_page,
     )
 
 
@@ -492,31 +525,28 @@ get_data = mcp.tool(
     name="data360_get_data",
 )
 
+get_timeseries_v2 = mcp.tool(
+    instrument_mcp_tool(_get_timeseries_v2, tool_name="data360_get_timeseries_v2"),
+    name="data360_get_timeseries_v2",
+)
+
 get_disaggregation = mcp.tool(
-    instrument_mcp_tool(
-        _get_disaggregation, tool_name="data360_get_disaggregation"
-    ),
+    instrument_mcp_tool(_get_disaggregation, tool_name="data360_get_disaggregation"),
     name="data360_get_disaggregation",
 )
 
 find_codelist_value = mcp.tool(
-    instrument_mcp_tool(
-        _find_codelist_value, tool_name="data360_find_codelist_value"
-    ),
+    instrument_mcp_tool(_find_codelist_value, tool_name="data360_find_codelist_value"),
     name="data360_find_codelist_value",
 )
 
 list_indicators = mcp.tool(
-    instrument_mcp_tool(
-        _list_indicators, tool_name="data360_list_indicators"
-    ),
+    instrument_mcp_tool(_list_indicators, tool_name="data360_list_indicators"),
     name="data360_list_indicators",
 )
 
 get_data_api_url = mcp.tool(
-    instrument_mcp_tool(
-        _get_data_api_url, tool_name="data360_get_data_api_url"
-    ),
+    instrument_mcp_tool(_get_data_api_url, tool_name="data360_get_data_api_url"),
     name="data360_get_data_api_url",
 )
 
@@ -554,9 +584,7 @@ expand_country_group = mcp.tool(
 
 summarize_data = mcp.add_tool(
     Tool.from_function(
-        instrument_mcp_tool(
-            _summarize_data, tool_name="data360_summarize_data"
-        ),
+        instrument_mcp_tool(_summarize_data, tool_name="data360_summarize_data"),
         name="data360_summarize_data",
         serializer=_compact_aggregation_serializer,
     )
@@ -564,9 +592,7 @@ summarize_data = mcp.add_tool(
 
 rank_countries = mcp.add_tool(
     Tool.from_function(
-        instrument_mcp_tool(
-            _rank_countries, tool_name="data360_rank_countries"
-        ),
+        instrument_mcp_tool(_rank_countries, tool_name="data360_rank_countries"),
         name="data360_rank_countries",
         serializer=_compact_aggregation_serializer,
     )
@@ -574,9 +600,7 @@ rank_countries = mcp.add_tool(
 
 compare_countries = mcp.add_tool(
     Tool.from_function(
-        instrument_mcp_tool(
-            _compare_countries, tool_name="data360_compare_countries"
-        ),
+        instrument_mcp_tool(_compare_countries, tool_name="data360_compare_countries"),
         name="data360_compare_countries",
         serializer=_compact_aggregation_serializer,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,23 +12,26 @@ os.environ.setdefault(
     "DATA360_CODELIST_API_BASE_URL",
     f"{_test_api}/codelist",
 )
-os.environ.setdefault("DATA360_SEARCH_URL", f"{_test_api}/portal/v1/public_data360_search")
+os.environ.setdefault(
+    "DATA360_SEARCH_URL", f"{_test_api}/portal/v1/public_data360_search"
+)
 os.environ.setdefault("DATA360_METADATA_URL", f"{_test_api}/metadata")
 os.environ.setdefault("DATA360_DISAGGREGATION_URL", f"{_test_api}/disaggregation")
 os.environ.setdefault("DATA360_DIMENSIONS_URL", f"{_test_api}/portal/v1/dimensions")
 os.environ.setdefault("DATA360_DATA_URL", f"{_test_api}/data")
+os.environ.setdefault("DATA360_INDICATORS_V2_BASE_URL", f"{_test_api}/v2")
 
 import pytest
 
 from data360.api import (
-    _disaggregation_cache,
-    _disaggregation_cache_lock,
-    _metadata_cache,
-    _metadata_cache_lock,
     _dimensions_api_cache,
     _dimensions_api_cache_lock,
     _dimensions_api_inflight,
     _dimensions_api_inflight_lock,
+    _disaggregation_cache,
+    _disaggregation_cache_lock,
+    _metadata_cache,
+    _metadata_cache_lock,
 )
 from data360.http_client import aclose_shared_httpx_client
 
@@ -62,9 +65,9 @@ async def _isolate_data360_api_state():
 def _mock_extdataportal_global(monkeypatch):
     """Globally mock CodelistManager._fetch_extdataportal to prevent test failures from lazy loading."""
     from unittest.mock import AsyncMock
+
     from data360.providers import CodelistManager
+
     monkeypatch.setattr(
-        CodelistManager,
-        "_fetch_extdataportal",
-        AsyncMock(return_value={})
+        CodelistManager, "_fetch_extdataportal", AsyncMock(return_value={})
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,6 +12,7 @@ from data360.api import (
     _obs_value_to_float,
     get_data,
     get_metadata,
+    get_timeseries_v2,
     search,
     search_datasets,
 )
@@ -125,7 +126,9 @@ class TestSearch:
         assert result.error is None
 
     @pytest.mark.asyncio
-    async def test_search_empty_result_preserves_count_zero(self, httpx_mock: pytest_httpx.HTTPXMock):
+    async def test_search_empty_result_preserves_count_zero(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
         """Test that search with empty results preserves count=0 and does not resolve to None."""
         mock_response = {
             "count": 0,
@@ -288,12 +291,17 @@ class TestSearch:
         )
 
         # Test query with parentheses and currency symbols (unsafe) alongside safe characters (_, -, ,, .)
-        await search("GDP per capita (current US$) WB_WDI_NY_GDP_PCAP_CD-2022, test.", limit=5)
+        await search(
+            "GDP per capita (current US$) WB_WDI_NY_GDP_PCAP_CD-2022, test.", limit=5
+        )
 
         assert len(captured_payloads) == 1
         # The parentheses and currency symbols should be replaced by spaces and collapsed,
         # while the underscores, hyphens, commas, and periods are kept.
-        assert captured_payloads[0].get("query_string") == "GDP per capita current US WB_WDI_NY_GDP_PCAP_CD-2022, test."
+        assert (
+            captured_payloads[0].get("query_string")
+            == "GDP per capita current US WB_WDI_NY_GDP_PCAP_CD-2022, test."
+        )
 
     @pytest.mark.asyncio
     async def test_search_empty_query_after_sanitization(self):
@@ -440,7 +448,9 @@ class TestSearchDatasets:
         assert response.items[0].name == "Global Financial Inclusion Database"
 
     @pytest.mark.asyncio
-    async def test_search_datasets_query_sanitization(self, httpx_mock: pytest_httpx.HTTPXMock):
+    async def test_search_datasets_query_sanitization(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
         """Test that special characters are sanitized in dataset search queries."""
         captured_payloads = []
 
@@ -483,10 +493,16 @@ class TestSearchDatasets:
 
         response = await search_datasets("findex")
         assert response.error is not None
-        assert "Server Error" in response.error or "500" in response.error or "Internal Server Error" in response.error
+        assert (
+            "Server Error" in response.error
+            or "500" in response.error
+            or "Internal Server Error" in response.error
+        )
 
     @pytest.mark.asyncio
-    async def test_search_datasets_exception_classification(self, httpx_mock: pytest_httpx.HTTPXMock):
+    async def test_search_datasets_exception_classification(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
         """Test that other exceptions during dataset search are classified robustly."""
         httpx_mock.add_exception(
             httpx.ConnectError("Connection refused"),
@@ -645,11 +661,19 @@ class TestGetMetadata:
         # Verify _Z was filtered out by _get_valid_disaggregations
         field_names = [opt["field_name"] for opt in result.disaggregation_options]
         # REF_AREA is summarized by _strip_disaggregation (count + sample)
-        ref_area = next(opt for opt in result.disaggregation_options if opt["field_name"] == "REF_AREA")
+        ref_area = next(
+            opt
+            for opt in result.disaggregation_options
+            if opt["field_name"] == "REF_AREA"
+        )
         assert ref_area["count"] == 1
         assert "UGA" in ref_area["sample"]
         # UNIT_MEASURE is preserved as-is
-        unit = next(opt for opt in result.disaggregation_options if opt["field_name"] == "UNIT_MEASURE")
+        unit = next(
+            opt
+            for opt in result.disaggregation_options
+            if opt["field_name"] == "UNIT_MEASURE"
+        )
         assert unit["field_value"] == ["_T"]
 
     @pytest.mark.asyncio
@@ -760,7 +784,11 @@ class TestGetData:
         httpx_mock.add_response(
             method="POST",
             url=re.compile(r".*/portal/v1/dimensions.*"),
-            json={"dimensions": [{"field_name": "REF_AREA", "field_value": [{"code": "UGA"}]}]},
+            json={
+                "dimensions": [
+                    {"field_name": "REF_AREA", "field_value": [{"code": "UGA"}]}
+                ]
+            },
         )
 
         # Mock data response
@@ -855,7 +883,10 @@ class TestGetData:
             url=re.compile(r".*/portal/v1/dimensions.*"),
             json={
                 "dimensions": [
-                    {"field_name": "URBANISATION", "field_value": [{"code": "_T"}, {"code": "URB"}]},
+                    {
+                        "field_name": "URBANISATION",
+                        "field_value": [{"code": "_T"}, {"code": "URB"}],
+                    },
                 ]
             },
         )
@@ -892,7 +923,9 @@ class TestGetData:
             json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]},
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []}
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         # First page response
@@ -942,7 +975,9 @@ class TestGetData:
             json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]},
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []}
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         def empty_data_callback(request: httpx.Request) -> httpx.Response | None:
@@ -973,7 +1008,9 @@ class TestGetData:
             json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]},
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []}
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         # Data error
@@ -1003,7 +1040,9 @@ class TestGetData:
             json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]},
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []}
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         def invalid_json_callback(request: httpx.Request) -> httpx.Response | None:
@@ -1044,18 +1083,31 @@ class TestGetDataResilience:
         httpx_mock.add_response(
             method="POST",
             url="https://api.test.example.com/metadata",
-            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL", "name": "Pop"}}]},
+            json={
+                "value": [
+                    {
+                        "series_description": {
+                            "idno": "WB_WDI_SP_POP_TOTL",
+                            "name": "Pop",
+                        }
+                    }
+                ]
+            },
         )
         # Disaggregation fails with 500
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), status_code=500,
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            status_code=500,
             text="Internal Server Error",
         )
         # Data fetch succeeds
         httpx_mock.add_response(
             method="GET",
             url=re.compile(r".*/data\?.*"),
-            json={"value": [{"REF_AREA": "KEN", "TIME_PERIOD": "2020", "OBS_VALUE": 5000}]},
+            json={
+                "value": [{"REF_AREA": "KEN", "TIME_PERIOD": "2020", "OBS_VALUE": 5000}]
+            },
         )
 
         result = await get_data("WB_WDI", "WB_WDI_SP_POP_TOTL")
@@ -1078,7 +1130,9 @@ class TestGetDataResilience:
         )
         # Disaggregation returns 200 empty (doesn't matter)
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []},
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         result = await get_data("WB_WDI", "NONEXISTENT_INDICATOR")
@@ -1099,10 +1153,21 @@ class TestGetDataResilience:
         httpx_mock.add_response(
             method="POST",
             url="https://api.test.example.com/metadata",
-            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL", "name": "Pop"}}]},
+            json={
+                "value": [
+                    {
+                        "series_description": {
+                            "idno": "WB_WDI_SP_POP_TOTL",
+                            "name": "Pop",
+                        }
+                    }
+                ]
+            },
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []},
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         captured_urls: list[str] = []
@@ -1112,10 +1177,20 @@ class TestGetDataResilience:
                 captured_urls.append(str(request.url))
                 return httpx.Response(
                     200,
-                    json={"value": [
-                        {"REF_AREA": "KEN", "TIME_PERIOD": "2020", "OBS_VALUE": 100},
-                        {"REF_AREA": "MAR", "TIME_PERIOD": "2020", "OBS_VALUE": 200},
-                    ]},
+                    json={
+                        "value": [
+                            {
+                                "REF_AREA": "KEN",
+                                "TIME_PERIOD": "2020",
+                                "OBS_VALUE": 100,
+                            },
+                            {
+                                "REF_AREA": "MAR",
+                                "TIME_PERIOD": "2020",
+                                "OBS_VALUE": 200,
+                            },
+                        ]
+                    },
                 )
             return None
 
@@ -1124,7 +1199,10 @@ class TestGetDataResilience:
         result = await get_data("WB_WDI", "WB_WDI_SP_POP_TOTL", country_code="KEN;MAR")
 
         assert len(captured_urls) == 1
-        assert "REF_AREA=KEN%2CMAR" in captured_urls[0] or "REF_AREA=KEN,MAR" in captured_urls[0]
+        assert (
+            "REF_AREA=KEN%2CMAR" in captured_urls[0]
+            or "REF_AREA=KEN,MAR" in captured_urls[0]
+        )
         assert result.data is not None
 
     @pytest.mark.asyncio
@@ -1135,10 +1213,21 @@ class TestGetDataResilience:
         httpx_mock.add_response(
             method="POST",
             url="https://api.test.example.com/metadata",
-            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL", "name": "Pop"}}]},
+            json={
+                "value": [
+                    {
+                        "series_description": {
+                            "idno": "WB_WDI_SP_POP_TOTL",
+                            "name": "Pop",
+                        }
+                    }
+                ]
+            },
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []},
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
         httpx_mock.add_response(
             method="GET",
@@ -1293,7 +1382,9 @@ class TestDatabaseNameInMetadata:
             json=metadata_response,
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []},
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         captured_urls: list[str] = []
@@ -1303,10 +1394,20 @@ class TestDatabaseNameInMetadata:
                 captured_urls.append(str(request.url))
                 return httpx.Response(
                     200,
-                    json={"value": [
-                        {"REF_AREA": "KEN", "TIME_PERIOD": "2020", "OBS_VALUE": 100},
-                        {"REF_AREA": "MAR", "TIME_PERIOD": "2020", "OBS_VALUE": 200},
-                    ]},
+                    json={
+                        "value": [
+                            {
+                                "REF_AREA": "KEN",
+                                "TIME_PERIOD": "2020",
+                                "OBS_VALUE": 100,
+                            },
+                            {
+                                "REF_AREA": "MAR",
+                                "TIME_PERIOD": "2020",
+                                "OBS_VALUE": 200,
+                            },
+                        ]
+                    },
                 )
             return None
 
@@ -1315,7 +1416,10 @@ class TestDatabaseNameInMetadata:
         result = await get_data("WB_WDI", "WB_WDI_SP_POP_TOTL", country_code="KEN,MAR")
 
         assert len(captured_urls) == 1
-        assert "REF_AREA=KEN%2CMAR" in captured_urls[0] or "REF_AREA=KEN,MAR" in captured_urls[0]
+        assert (
+            "REF_AREA=KEN%2CMAR" in captured_urls[0]
+            or "REF_AREA=KEN,MAR" in captured_urls[0]
+        )
         assert result.data is not None
 
 
@@ -1336,11 +1440,22 @@ class TestGetDataApiUrlResilience:
         httpx_mock.add_response(
             method="POST",
             url="https://api.test.example.com/metadata",
-            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL", "name": "Pop"}}]},
+            json={
+                "value": [
+                    {
+                        "series_description": {
+                            "idno": "WB_WDI_SP_POP_TOTL",
+                            "name": "Pop",
+                        }
+                    }
+                ]
+            },
         )
         # Disaggregation fails
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), status_code=500,
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            status_code=500,
             text="Internal Server Error",
         )
 
@@ -1364,7 +1479,9 @@ class TestGetDataApiUrlResilience:
             json={"value": []},
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []},
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         with pytest.raises(ValueError, match="not found"):
@@ -1397,7 +1514,9 @@ class TestDatabaseNameInMetadata:
             json=metadata_response,
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []},
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         result = await get_metadata("WB_GS", "WB_GS_INDICATOR")
@@ -1429,13 +1548,13 @@ class TestDatabaseNameInMetadata:
             json=metadata_response,
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []},
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         # Only request 'name' — database_name should still be included
-        result = await get_metadata(
-            "WB_GS", "WB_GS_INDICATOR", select_fields=["name"]
-        )
+        result = await get_metadata("WB_GS", "WB_GS_INDICATOR", select_fields=["name"])
 
         assert result.indicator_metadata is not None
         assert "name" in result.indicator_metadata
@@ -1464,7 +1583,9 @@ class TestDatabaseNameInMetadata:
             json=metadata_response,
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []},
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         result = await get_metadata("UNKNOWN_DB", "UNKNOWN_DB_IND")
@@ -1679,7 +1800,9 @@ class TestDimensionsResilienceAndParsing:
         httpx_mock.add_response(
             method="POST",
             url="https://api.test.example.com/portal/v1/dimensions",
-            json={"dimensions": [{"field_name": "SEX", "field_value": [{"code": "_T"}]}]},
+            json={
+                "dimensions": [{"field_name": "SEX", "field_value": [{"code": "_T"}]}]
+            },
         )
         httpx_mock.add_response(
             method="POST",
@@ -1690,6 +1813,7 @@ class TestDimensionsResilienceAndParsing:
         # Clear the metadata cache so get_metadata does not hit the metadata cache itself,
         # forcing it to run the dimensions fetch logic.
         from data360.api import _metadata_cache, _metadata_cache_lock
+
         with _metadata_cache_lock:
             _metadata_cache.clear()
 
@@ -1708,19 +1832,25 @@ class TestDimensionsResilienceAndParsing:
         dim_reqs = [r for r in requests if "portal/v1/dimensions" in str(r.url)]
         assert len(dim_reqs) == 1
 
-
-
     @pytest.mark.asyncio
-    async def test_dimensions_api_cache_edge_cases(self, httpx_mock: pytest_httpx.HTTPXMock):
+    async def test_dimensions_api_cache_edge_cases(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
         """Verify:
         1. HTTP 500 status code propagation, and that it's NOT cached.
         2. Blank/empty response body is handled and returns empty dimensions.
         3. Concurrent calls to the same endpoint are deduplicated.
         """
         import asyncio
-        import httpx
         import json
-        from data360.api import _fetch_dimensions_with_cache, _dimensions_api_cache, _dimensions_api_cache_lock
+
+        import httpx
+
+        from data360.api import (
+            _dimensions_api_cache,
+            _dimensions_api_cache_lock,
+            _fetch_dimensions_with_cache,
+        )
 
         # --- 1. HTTP 500 Propagation and No Caching ---
         httpx_mock.add_response(
@@ -1783,3 +1913,152 @@ class TestDimensionsResilienceAndParsing:
                 pass
 
         assert len(conc_reqs) == 1
+
+
+class TestGetTimeseriesV2:
+    """Tests for get_timeseries_v2() — legacy Indicators v2 fallback."""
+
+    _BASE = "https://api.test.example.com/v2"
+
+    def _v2_payload(self) -> list:
+        """A canonical [metadata, data_points] response from the v2 API."""
+        meta = {
+            "page": 1,
+            "pages": 1,
+            "per_page": 50,
+            "total": 3,
+            "sourceid": "2",
+            "lastupdated": "2026-04-08",
+        }
+        points = [
+            {
+                "indicator": {"id": "SP.POP.TOTL", "value": "Population, total"},
+                "country": {"id": "AR", "value": "Argentina"},
+                "countryiso3code": "ARG",
+                "date": "2022",
+                "value": 45407904,
+                "unit": "",
+                "obs_status": "",
+                "decimal": 0,
+            },
+            {
+                "indicator": {"id": "SP.POP.TOTL", "value": "Population, total"},
+                "country": {"id": "AR", "value": "Argentina"},
+                "countryiso3code": "ARG",
+                "date": "2021",
+                "value": 45312281,
+                "unit": "",
+                "obs_status": "",
+                "decimal": 0,
+            },
+            {
+                "indicator": {"id": "SP.POP.TOTL", "value": "Population, total"},
+                "country": {"id": "AR", "value": "Argentina"},
+                "countryiso3code": "ARG",
+                "date": "2020",
+                "value": 45191965,
+                "unit": "",
+                "obs_status": "",
+                "decimal": 0,
+            },
+        ]
+        return [meta, points]
+
+    @pytest.mark.asyncio
+    async def test_success_with_year_range(self, httpx_mock: pytest_httpx.HTTPXMock):
+        """Happy path: indicator + country + bounded year range."""
+        EXPECTED_POINTS = 3
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(
+                rf"{re.escape(self._BASE)}/country/ARG/indicator/SP\.POP\.TOTL\?.*"
+            ),
+            json=self._v2_payload(),
+        )
+
+        result = await get_timeseries_v2(
+            indicator_id="SP.POP.TOTL",
+            country_code="ARG",
+            start_year=2020,
+            end_year=2022,
+        )
+
+        EXPECTED_FIRST_VALUE = 45_407_904
+        assert isinstance(result, IndicatorDataResponse)
+        assert result.error is None
+        assert result.data is not None
+        assert len(result.data) == EXPECTED_POINTS
+        assert result.count == EXPECTED_POINTS
+        assert result.data[0]["date"] == "2022"
+        assert result.data[0]["value"] == EXPECTED_FIRST_VALUE
+        assert result.data[0]["country_code"] == "ARG"
+        assert result.data[0]["indicator_id"] == "SP.POP.TOTL"
+        assert result.metadata is not None
+        assert result.metadata["source_id"] == "2"
+        assert result.metadata["last_updated"] == "2026-04-08"
+
+    @pytest.mark.asyncio
+    async def test_date_param_built_when_only_start_year_given(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
+        """start_year alone should pair with current year, not omit the date filter."""
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(rf"{re.escape(self._BASE)}/country/.*/indicator/.*"),
+            json=self._v2_payload(),
+        )
+
+        await get_timeseries_v2(
+            indicator_id="SP.POP.TOTL", country_code="ARG", start_year=2018
+        )
+
+        sent = [
+            req
+            for req in httpx_mock.get_requests()
+            if "/v2/country/ARG/indicator/SP.POP.TOTL" in str(req.url)
+        ]
+        assert len(sent) == 1
+        # date param should be "2018:<current_year>" — we just check the lower bound
+        assert "date=2018%3A" in str(sent[0].url) or "date=2018:" in str(sent[0].url)
+
+    @pytest.mark.asyncio
+    async def test_http_error_returns_response_with_error(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
+        """Upstream HTTP errors propagate as a structured IndicatorDataResponse."""
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(rf"{re.escape(self._BASE)}/country/.*/indicator/.*"),
+            status_code=503,
+            json={"message": "service unavailable"},
+        )
+
+        result = await get_timeseries_v2(
+            indicator_id="SP.POP.TOTL",
+            country_code="ARG",
+            start_year=2020,
+            end_year=2022,
+        )
+
+        assert isinstance(result, IndicatorDataResponse)
+        assert result.error is not None
+        assert "Indicators v2 API error" in result.error
+        assert result.data is None
+        assert result.count == 0
+
+    @pytest.mark.asyncio
+    async def test_unexpected_shape_returns_error(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
+        """If the v2 API returns something other than [meta, data], surface a clear error."""
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(rf"{re.escape(self._BASE)}/country/.*/indicator/.*"),
+            json={"message": "unexpected dict not list"},
+        )
+
+        result = await get_timeseries_v2(indicator_id="SP.POP.TOTL", country_code="ARG")
+
+        assert isinstance(result, IndicatorDataResponse)
+        assert result.error is not None
+        assert "Unexpected" in result.error or "shape" in result.error


### PR DESCRIPTION
By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/worldbank/data360-mcp/blob/dev/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/worldbank/data360-mcp/blob/dev/CODE_OF_CONDUCT.md), and I agree to license my contribution under the project's [LICENSE](https://github.com/worldbank/data360-mcp/blob/dev/LICENSE).

## Why

The primary Data360 API is rich but still in beta; agents occasionally hit empty responses or transient errors for WDI-classic series that the long-stable [Indicators v2 API](https://api.worldbank.org/v2) at `api.worldbank.org/v2` still returns reliably. This PR adds a dedicated MCP tool that targets v2 explicitly so an LLM can recover from a Data360 miss without giving up.

A typical agent flow becomes:

1. `data360_search_indicators` resolves the topic
2. `data360_get_data` is the primary fetch
3. On empty or error, `data360_get_timeseries_v2` retries against the legacy endpoint using the dotted-form indicator id

## What's in the diff

- **`Data360Settings.indicators_v2_base_url`** (`config.py`) — new optional setting, default `https://api.worldbank.org/v2`, env override `DATA360_INDICATORS_V2_BASE_URL`.
- **`api.get_timeseries_v2`** — async function that uses the existing shared `httpx.AsyncClient` from `http_client.py` and returns the existing `IndicatorDataResponse` model, so callers see the same shape as `get_data` (`data`, `metadata`, `count`, `total_count`, `has_more`, `next_offset`, `error`).
- **`mcp_server/tools._get_timeseries_v2`** registered as `data360_get_timeseries_v2` via `mcp.tool(instrument_mcp_tool(...))`, matching the pattern used by every other tool in `tools.py`.
- **`tests/test_api.py::TestGetTimeseriesV2`** — four cases covering the happy path, date construction with a single bound, upstream HTTP errors surfaced as a structured response, and unexpected response shapes.
- **`tests/conftest.py`** — one extra `os.environ.setdefault` so test runs hit a fake host instead of `api.worldbank.org`.
- **`.env.example`** — one commented-out line documenting the new override.

No breaking changes to any existing tool, model, or env var.

## The thing the LLM gets wrong on its own

The v2 API uses a different indicator format than Data360:

| Data360 | Indicators v2 |
|---|---|
| `WB_WDI_SP_POP_TOTL` | `SP.POP.TOTL` |
| `WB_WDI_NY_GDP_PCAP_CD` | `NY.GDP.PCAP.CD` |

For most WDI indicators you can derive the v2 code by stripping `WB_WDI_` and replacing underscores with dots. The tool docstring spells this out explicitly so the model knows to translate before calling.

## Validation

- All **811** pre-existing tests still pass (excluding `test_prompt_injection.py`, which requires `DATA360_MCP_TEST_URL` against a live server and was already failing locally — unrelated to this PR).
- The **4 new** `TestGetTimeseriesV2` cases pass.
- `ruff format` clean across modified files; no new `ruff check` warnings introduced by the diff.
- **End-to-end on the running MCP server:** I started the server with these changes, called `data360_get_timeseries_v2(indicator_id="SP.POP.TOTL", country_code="ARG", start_year=2020, end_year=2022)` over `streamable_http`, and got three real observations (45,191,965 → 45,312,281 → 45,407,904) with `metadata.source_id="2"` and `last_updated="2026-04-08"`.

## How it came up

We're building [Verifacta](https://github.com/giulitn/verifacta) for the DATA 360 Global Challenge — an anti-misinformation agent layer that consumes this MCP. We hit cases where `get_data` returned empty for indicators that v2 still covers, and needed an explicit fallback path. Rather than fork or wrap externally, contributing this upstream keeps everyone aligned on a single canonical interface.

Happy to iterate on naming, response shape, default settings, or anything else that doesn't match your conventions.