### PR TITLE
fix(api): populate year_selection_note in compare_countries and optimize auto-selection in rank_countries

### DIFF
--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -3065,25 +3065,33 @@ async def rank_countries(
                     total_requested=total_requested,
                 )
     else:
-        # Auto-select: find the year with broadest coverage, tie-break by recency
+        # Auto-select: find the latest available year with data
+        latest_year = max(year_country_map.keys())
+        ranking_year = latest_year
+
+        # Find the year with the broadest coverage for comparison/caveat
         best_year = max(
             year_country_map.keys(),
             key=lambda y: (len(year_country_map[y]), y),
         )
-        latest_year = max(year_country_map.keys())
-        ranking_year = best_year
-        if best_year == latest_year:
+
+        latest_coverage = len(year_country_map[latest_year])
+        best_coverage = len(year_country_map[best_year])
+
+        if latest_year == best_year:
             year_selection_note = (
-                f"Latest year with broadest coverage ({best_year}, "
-                f"{len(year_country_map[best_year])}/{total_requested} countries)"
+                f"Latest available year ({latest_year}) with "
+                f"{latest_coverage}/{total_requested} countries."
             )
         else:
             year_selection_note = (
-                f"Year with broadest coverage: {best_year} "
-                f"({len(year_country_map[best_year])}/{total_requested} countries). "
-                f"Most recent year {latest_year} has "
-                f"{len(year_country_map.get(latest_year, {}))}/{total_requested} countries."
+                f"Latest available year: {latest_year} "
+                f"({latest_coverage}/{total_requested} countries). "
+                f"Note: Coverage is partial/incomplete for this year. "
+                f"An older year ({best_year}) has broader coverage with "
+                f"{best_coverage}/{total_requested} countries."
             )
+
 
     # Build ranking from selected year
     year_data = year_country_map.get(ranking_year, {})
@@ -3275,13 +3283,29 @@ async def compare_countries(
         if c in country_year_map:
             common_years = [y for y in common_years if y in country_year_map[c]]
 
+    year_selection_note = None
     if year:
         snap_year = str(year)
+        year_selection_note = f"User-specified year: {year}"
     elif common_years:
         snap_year = common_years[-1]  # Latest common year
+        year_selection_note = (
+            f"Latest year with data for all compared countries: {snap_year} "
+            f"({len(codes)}/{len(codes)} countries)"
+        )
     else:
         # Fallback: latest year from any country
         snap_year = max(all_years) if all_years else None
+        if snap_year:
+            n_countries = sum(
+                1 for c in codes if c in country_year_map and snap_year in country_year_map[c]
+            )
+            year_selection_note = (
+                f"Latest year with data (partial coverage): {snap_year} "
+                f"({n_countries}/{len(codes)} countries)"
+            )
+        else:
+            year_selection_note = "No data available for any country."
 
     # Build snapshot
     snapshot = None
@@ -3329,6 +3353,7 @@ async def compare_countries(
 
         snapshot = ComparisonSnapshot(
             year=snap_year,
+            year_selection_note=year_selection_note,
             rankings=ranked,
             spread=spread,
         )

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -3280,8 +3280,10 @@ async def compare_countries(
         all_years.update(yrs.keys())
     common_years = sorted(all_years)
     for c in codes:
-        if c in country_year_map:
-            common_years = [y for y in common_years if y in country_year_map[c]]
+        if c not in country_year_map:
+            common_years = []
+            break
+        common_years = [y for y in common_years if y in country_year_map[c]]
 
     year_selection_note = None
     if year:
@@ -3289,9 +3291,12 @@ async def compare_countries(
         year_selection_note = f"User-specified year: {year}"
     elif common_years:
         snap_year = common_years[-1]  # Latest common year
+        n_countries = sum(
+            1 for c in codes if c in country_year_map and snap_year in country_year_map[c]
+        )
         year_selection_note = (
             f"Latest year with data for all compared countries: {snap_year} "
-            f"({len(codes)}/{len(codes)} countries)"
+            f"({n_countries}/{len(codes)} countries)"
         )
     else:
         # Fallback: latest year from any country

--- a/src/data360/models.py
+++ b/src/data360/models.py
@@ -631,6 +631,11 @@ class ComparisonSnapshot(BaseModel):
     """Single-year comparison snapshot across countries."""
 
     year: str = Field(..., description="The comparison year")
+    year_selection_note: str | None = Field(
+        None,
+        description="Explains how the comparison year was chosen. "
+        "E.g. 'User-specified year: 2022' or 'Latest year with data for all compared countries: 2023'.",
+    )
     rankings: list[RankedCountry] = Field(
         default_factory=list,
         description="Countries sorted by obs_value with rank and gap_to_leader",
@@ -650,6 +655,7 @@ class ComparisonSnapshot(BaseModel):
         """
         return {
             "year": self.year,
+            "year_selection_note": self.year_selection_note,
             "rankings": [r.to_compact() for r in self.rankings],
             "spread": self.spread,
         }

--- a/tests/test_aggregation_tools.py
+++ b/tests/test_aggregation_tools.py
@@ -1194,6 +1194,41 @@ class TestCompareCountries:
         assert "Latest year with data (partial coverage): 2022" in result.snapshot.year_selection_note
         assert "1/2 countries" in result.snapshot.year_selection_note
 
+    @pytest.mark.asyncio
+    async def test_compare_countries_year_selection_note_missing_country(self):
+        """Should handle one country completely missing from results (empty years) and fall back with correct note."""
+        # KEN has data for 2022, but NGA is completely missing from rows/response.
+        rows = [
+            _make_row("KEN", "2022", 100.0),
+        ]
+        full_page = _make_data_page(rows, has_more=False)
+
+        async def fake_fetch_all(**kwargs):
+            return full_page
+
+        async def fake_resolve(codes):
+            return {c: c for c in codes}
+
+        async def fake_disagg(**kwargs):
+            return {"dimensions": []}
+
+        with (
+            patch("data360.api._fetch_all_pages", side_effect=fake_fetch_all),
+            patch("data360.api._resolve_country_names", side_effect=fake_resolve),
+            patch("data360.api.get_disaggregation", side_effect=fake_disagg),
+        ):
+            result = await compare_countries(
+                "WB_WDI", "IND_ID",
+                country_codes="KEN;NGA",
+            )
+
+        assert result.error is None
+        assert result.snapshot is not None
+        assert result.snapshot.year == "2022"
+        # NGA is completely missing, so common_years should be empty and fallback note used
+        assert "Latest year with data (partial coverage): 2022" in result.snapshot.year_selection_note
+        assert "1/2 countries" in result.snapshot.year_selection_note
+
 
 # ---------------------------------------------------------------------------
 # to_compact() output — PCN + size invariants

--- a/tests/test_aggregation_tools.py
+++ b/tests/test_aggregation_tools.py
@@ -481,6 +481,92 @@ class TestRankCountriesTieHandling:
         assert result.excluded[0].ref_area == "B"
 
 
+class TestRankCountriesAutoYearSelection:
+    """Unit tests for automatic year selection prioritizing recency in rank_countries."""
+
+    @pytest.mark.asyncio
+    async def test_auto_year_selection_selects_latest_year_with_caveat(self):
+        """Should select 2024 (recency) and flag that 2023 has broader coverage."""
+        rows = [
+            _make_row("A", "2022", 10.0),
+            _make_row("B", "2022", 20.0),
+            _make_row("C", "2022", 30.0),
+            _make_row("D", "2022", 40.0),
+
+            _make_row("A", "2023", 15.0),
+            _make_row("B", "2023", 25.0),
+            _make_row("C", "2023", 35.0),
+            _make_row("D", "2023", 45.0),
+
+            _make_row("A", "2024", 18.0),
+            _make_row("B", "2024", 28.0),
+        ]
+        full_page = _make_data_page(rows, has_more=False)
+
+        async def fake_fetch_all(**kwargs):
+            return full_page
+
+        async def fake_resolve(codes):
+            return {c: c for c in codes}
+
+        async def fake_disagg(**kwargs):
+            return {"dimensions": []}
+
+        with (
+            patch("data360.api._fetch_all_pages", side_effect=fake_fetch_all),
+            patch("data360.api._resolve_country_names", side_effect=fake_resolve),
+            patch("data360.api.get_disaggregation", side_effect=fake_disagg),
+        ):
+            result = await rank_countries(
+                "WB_WDI", "IND_ID",
+                country_codes="A;B;C;D",
+                top_n=5,
+            )
+
+        assert result.error is None
+        assert result.year == "2024"
+        assert "Latest available year: 2024" in result.year_selection_note
+        assert "Coverage is partial/incomplete" in result.year_selection_note
+        assert "2023" in result.year_selection_note
+
+    @pytest.mark.asyncio
+    async def test_auto_year_selection_selects_latest_year_when_matches_broadest(self):
+        """Should select 2023 and note it as the latest available year."""
+        rows = [
+            _make_row("A", "2022", 10.0),
+            _make_row("B", "2022", 20.0),
+
+            _make_row("A", "2023", 15.0),
+            _make_row("B", "2023", 25.0),
+            _make_row("C", "2023", 35.0),
+        ]
+        full_page = _make_data_page(rows, has_more=False)
+
+        async def fake_fetch_all(**kwargs):
+            return full_page
+
+        async def fake_resolve(codes):
+            return {c: c for c in codes}
+
+        async def fake_disagg(**kwargs):
+            return {"dimensions": []}
+
+        with (
+            patch("data360.api._fetch_all_pages", side_effect=fake_fetch_all),
+            patch("data360.api._resolve_country_names", side_effect=fake_resolve),
+            patch("data360.api.get_disaggregation", side_effect=fake_disagg),
+        ):
+            result = await rank_countries(
+                "WB_WDI", "IND_ID",
+                country_codes="A;B;C",
+                top_n=5,
+            )
+
+        assert result.error is None
+        assert result.year == "2023"
+        assert "Latest available year (2023)" in result.year_selection_note
+
+
 # ---------------------------------------------------------------------------
 # summarize_data
 # ---------------------------------------------------------------------------
@@ -1001,6 +1087,112 @@ class TestCompareCountries:
         assert result.error is None
         assert result.time_series is not None
         assert result.time_series.cagr.get("KEN") is None
+
+    @pytest.mark.asyncio
+    async def test_compare_countries_year_selection_note_user_specified(self):
+        """Should select user-specified year and set the correct selection note."""
+        rows = [
+            _make_row("KEN", "2021", 100.0),
+            _make_row("NGA", "2021", 110.0),
+            _make_row("KEN", "2022", 120.0),
+            _make_row("NGA", "2022", 130.0),
+        ]
+        full_page = _make_data_page(rows, has_more=False)
+
+        async def fake_fetch_all(**kwargs):
+            return full_page
+
+        async def fake_resolve(codes):
+            return {c: c for c in codes}
+
+        async def fake_disagg(**kwargs):
+            return {"dimensions": []}
+
+        with (
+            patch("data360.api._fetch_all_pages", side_effect=fake_fetch_all),
+            patch("data360.api._resolve_country_names", side_effect=fake_resolve),
+            patch("data360.api.get_disaggregation", side_effect=fake_disagg),
+        ):
+            result = await compare_countries(
+                "WB_WDI", "IND_ID",
+                country_codes="KEN;NGA",
+                year=2021,
+            )
+
+        assert result.error is None
+        assert result.snapshot is not None
+        assert result.snapshot.year == "2021"
+        assert result.snapshot.year_selection_note == "User-specified year: 2021"
+
+    @pytest.mark.asyncio
+    async def test_compare_countries_year_selection_note_common_year(self):
+        """Should select the latest common year and set the correct selection note."""
+        rows = [
+            _make_row("KEN", "2021", 100.0),
+            _make_row("NGA", "2021", 110.0),
+            _make_row("KEN", "2022", 120.0),
+            _make_row("NGA", "2022", 130.0),
+        ]
+        full_page = _make_data_page(rows, has_more=False)
+
+        async def fake_fetch_all(**kwargs):
+            return full_page
+
+        async def fake_resolve(codes):
+            return {c: c for c in codes}
+
+        async def fake_disagg(**kwargs):
+            return {"dimensions": []}
+
+        with (
+            patch("data360.api._fetch_all_pages", side_effect=fake_fetch_all),
+            patch("data360.api._resolve_country_names", side_effect=fake_resolve),
+            patch("data360.api.get_disaggregation", side_effect=fake_disagg),
+        ):
+            result = await compare_countries(
+                "WB_WDI", "IND_ID",
+                country_codes="KEN;NGA",
+            )
+
+        assert result.error is None
+        assert result.snapshot is not None
+        assert result.snapshot.year == "2022"
+        assert "Latest year with data for all compared countries: 2022" in result.snapshot.year_selection_note
+        assert "2/2 countries" in result.snapshot.year_selection_note
+
+    @pytest.mark.asyncio
+    async def test_compare_countries_year_selection_note_fallback(self):
+        """Should fallback to the latest year of any country when no common year exists."""
+        rows = [
+            _make_row("KEN", "2021", 100.0),
+            _make_row("NGA", "2022", 110.0),
+        ]
+        full_page = _make_data_page(rows, has_more=False)
+
+        async def fake_fetch_all(**kwargs):
+            return full_page
+
+        async def fake_resolve(codes):
+            return {c: c for c in codes}
+
+        async def fake_disagg(**kwargs):
+            return {"dimensions": []}
+
+        with (
+            patch("data360.api._fetch_all_pages", side_effect=fake_fetch_all),
+            patch("data360.api._resolve_country_names", side_effect=fake_resolve),
+            patch("data360.api.get_disaggregation", side_effect=fake_disagg),
+        ):
+            result = await compare_countries(
+                "WB_WDI", "IND_ID",
+                country_codes="KEN;NGA",
+            )
+
+        assert result.error is None
+        assert result.snapshot is not None
+        assert result.snapshot.year == "2022"
+        assert "Latest year with data (partial coverage): 2022" in result.snapshot.year_selection_note
+        assert "1/2 countries" in result.snapshot.year_selection_note
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This Pull Request addresses consistency in year selection and reporting:
1. Adds the missing `year_selection_note` field to `ComparisonSnapshot` and populates it in `compare_countries` to match the docstring.
2. Refactors the auto-selection logic in `rank_countries` to prioritize recency (the latest available year with data) over coverage, reporting any coverage deficits in `year_selection_note`.
3. Adds full unit test suites for both `rank_countries` and `compare_countries` auto-selection scenarios.