### PR TITLE
fix(api): resolve partial year bounds in get_data (fix empty results when only end_year is set)

### DIFF
--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -1876,6 +1876,13 @@ def _resolve_time_range(
     current_year = datetime.now().year
     span = _DEFAULT_TIME_WINDOW_YEARS - 1
 
+    if start_year is not None:
+        # TODO: Handle invalid start year, e.g., "2020-01-01" or float
+        start_year = int(start_year)
+    if end_year is not None:
+        # TODO: Handle invalid end year, e.g., "2020-01-01"
+        end_year = int(end_year)
+
     if start_year is None and end_year is None:
         return current_year - span, current_year
 

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -27,6 +27,9 @@ from .models import (
     ComparisonSnapshot,
     ComparisonTimeSeries,
     CountryComparisonResponse,
+    DatasetDescription,
+    DatasetSearchRequest,
+    DatasetSearchResponse,
     DataSummaryResponse,
     DerivedDataResponse,
     DiagnosticSummaryResponse,
@@ -48,9 +51,6 @@ from .models import (
     SearchRequest,
     SearchResponse,
     SeriesDescription,
-    DatasetSearchRequest,
-    DatasetDescription,
-    DatasetSearchResponse,
 )
 from .providers import get_database_mapping
 
@@ -109,7 +109,15 @@ _ENRICHMENT_SELECT_FIELDS = [
 # Based on a 16-database survey (see payload_analysis.md for full documentation).
 # Always-keep fields: the core data the LLM needs.
 _CORE_FIELDS = frozenset(
-    {"OBS_VALUE", "TIME_PERIOD", "REF_AREA", "REF_AREA_NAME", "country_name", "UNIT_MEASURE", "claim_id"}
+    {
+        "OBS_VALUE",
+        "TIME_PERIOD",
+        "REF_AREA",
+        "REF_AREA_NAME",
+        "country_name",
+        "UNIT_MEASURE",
+        "claim_id",
+    }
 )
 # Conditional fields: kept only when their value is non-trivial (not _T or _Z).
 # SEX/AGE/URBANISATION carry real disaggregation in WB_HCP, WB_SSGD, OECD_IDD.
@@ -200,7 +208,8 @@ async def _fetch_dimensions_raw_uncached(
     _cache_key = (database_id, indicator_id)
     try:
         dimensions_url = (
-            data360_config.dimensions_url or f"{data360_config.api_url}/portal/v1/dimensions"
+            data360_config.dimensions_url
+            or f"{data360_config.api_url}/portal/v1/dimensions"
         )
         headers = {"accept": "*/*", "Content-Type": "application/json"}
         payload = {"database_id": database_id, "indicator_id": indicator_id}
@@ -502,7 +511,9 @@ def _get_items_from_response(response_data: dict[str, Any]) -> list[SeriesDescri
             databases = value.get("databases", [])
             db_id = None
             if databases and isinstance(databases, list) and len(databases) > 0:
-                db_id = databases[0].get("idno") if isinstance(databases[0], dict) else None
+                db_id = (
+                    databases[0].get("idno") if isinstance(databases[0], dict) else None
+                )
 
             tp = value.get("time_period")
             time_periods = None
@@ -528,13 +539,16 @@ def _get_items_from_response(response_data: dict[str, Any]) -> list[SeriesDescri
                 "idno": value.get("idno"),
                 "name": value.get("name"),
                 "database_id": db_id or value.get("database_id"),
-                "definition_long": value.get("description") or value.get("definition_long"),
+                "definition_long": value.get("description")
+                or value.get("definition_long"),
                 "periodicity": value.get("frequency") or value.get("periodicity"),
                 "time_periods": time_periods,
                 "ref_country": value.get("ref_country"),
                 "dimensions": dimensions,
                 "metadata_link": ml or [],
-                "connected_entities": value.get("connected_entities") if isinstance(value.get("connected_entities"), list) else None,
+                "connected_entities": value.get("connected_entities")
+                if isinstance(value.get("connected_entities"), list)
+                else None,
             }
 
         if (
@@ -558,7 +572,9 @@ def _process_search_response(
     """Process API response and build SearchResponse."""
     search_response_data = {
         "items": _get_items_from_response(response_data),
-        "total_count": response_data.get("count") if "count" in response_data else response_data.get("@odata.count"),
+        "total_count": response_data.get("count")
+        if "count" in response_data
+        else response_data.get("@odata.count"),
         "offset": request.offset,
     }
     search_response_data["count"] = len(search_response_data["items"])
@@ -605,7 +621,10 @@ async def _search_raw(
         count=count,
     )
 
-    url = data360_config.search_url or f"{data360_config.api_url}/portal/v1/public_data360_search"
+    url = (
+        data360_config.search_url
+        or f"{data360_config.api_url}/portal/v1/public_data360_search"
+    )
     payload = {
         "site": "data360",
         "query_string": request.query,
@@ -636,7 +655,6 @@ async def _search_raw(
     except Exception as e:
         # Convert unknown exceptions to Data360MCPError and raise
         raise classify_error(e, context="search")
-
 
 
 async def _resolve_country_code(country_query: str) -> str | None:
@@ -753,7 +771,9 @@ def _enrich_search_results(
                             ref_countries.add(rc["code"])
                         elif isinstance(rc, str):
                             ref_countries.add(rc)
-                covers_country = {code: (code in ref_countries) for code in requested_codes}
+                covers_country = {
+                    code: (code in ref_countries) for code in requested_codes
+                }
 
         # Extract dimension names
         dimensions = raw.get("dimensions", [])
@@ -794,7 +814,10 @@ def _enrich_search_results(
             # Check if query matches a connected entity (SearchV3 redirect direction is reversed)
             clean_query = query.strip().upper()
             for entity in raw["connected_entities"]:
-                if isinstance(entity, dict) and entity.get("idno", "").upper() == clean_query:
+                if (
+                    isinstance(entity, dict)
+                    and entity.get("idno", "").upper() == clean_query
+                ):
                     original_idno = entity.get("idno")
                     _logger.debug(
                         "Mapped primary source %s -> %s/%s via connected_entities for query %s",
@@ -1092,7 +1115,9 @@ async def search(  # noqa: PLR0911
                 query=q,
                 limit=limit,
                 offset=offset,
-                economy_codes=[c.strip() for c in country_code.split(";")] if country_code else None,
+                economy_codes=[c.strip() for c in country_code.split(";")]
+                if country_code
+                else None,
             )
             for q in clean_queries
         ]
@@ -1229,7 +1254,9 @@ async def search(  # noqa: PLR0911
             query=query,  # type: ignore[arg-type]  # validated non-None above
             limit=limit,
             offset=offset,
-            economy_codes=[c.strip() for c in country_code.split(";")] if country_code else None,
+            economy_codes=[c.strip() for c in country_code.split(";")]
+            if country_code
+            else None,
         )
     except PydanticValidationError as e:
         return EnrichedSearchResponse(error=str(e))
@@ -1350,7 +1377,11 @@ async def _build_multi_query_response(
     enriched_lists = []
     for i, (q, raw_result) in enumerate(zip(clean_queries, raw_results)):
         code_for_query = per_query_codes[i]
-        if isinstance(raw_result, Exception) or raw_result.error or not raw_result.items:
+        if (
+            isinstance(raw_result, Exception)
+            or raw_result.error
+            or not raw_result.items
+        ):
             enriched_lists.append((None, None))
             continue
 
@@ -1486,7 +1517,10 @@ async def search_datasets(
     except PydanticValidationError as e:
         return DatasetSearchResponse(error=str(e))
 
-    url = data360_config.search_url or f"{data360_config.api_url}/portal/v1/public_data360_search"
+    url = (
+        data360_config.search_url
+        or f"{data360_config.api_url}/portal/v1/public_data360_search"
+    )
     payload = {
         "site": "data360",
         "query_string": request.query,
@@ -1518,7 +1552,11 @@ async def search_datasets(
                 )
             )
 
-        total_count = response_data.get("count") or response_data.get("@odata.count") or len(items)
+        total_count = (
+            response_data.get("count")
+            or response_data.get("@odata.count")
+            or len(items)
+        )
 
         has_more = False
         next_offset = None
@@ -1740,9 +1778,7 @@ async def get_disaggregation(
     queried_countries = await _resolve_queried_countries(required_country)
 
     try:
-        dimensions_json = await _fetch_dimensions_with_cache(
-            database_id, indicator_id
-        )
+        dimensions_json = await _fetch_dimensions_with_cache(database_id, indicator_id)
         raw_data = _parse_dimensions_response(dimensions_json)
         # Filter out _Z values and format response
         valid_dimensions = _get_valid_disaggregations(raw_data)
@@ -1821,6 +1857,40 @@ async def get_comp_breakdown_dim_names(
     return dim_names
 
 
+_DEFAULT_TIME_WINDOW_YEARS = 5
+
+
+def _resolve_time_range(
+    start_year: int | None,
+    end_year: int | None,
+) -> tuple[int, int]:
+    """Resolve inclusive [start_year, end_year] for Data API timePeriodFrom/To.
+
+    - Neither bound: last ``_DEFAULT_TIME_WINDOW_YEARS`` calendar years through today.
+    - Only ``end_year``: same-width window ending at ``end_year``.
+    - Only ``start_year``: from ``start_year`` through the current calendar year.
+    - Both: use as given (swapped if reversed).
+    """
+    from datetime import datetime  # noqa: PLC0415
+
+    current_year = datetime.now().year
+    span = _DEFAULT_TIME_WINDOW_YEARS - 1
+
+    if start_year is None and end_year is None:
+        return current_year - span, current_year
+
+    if start_year is None:
+        return end_year - span, end_year
+
+    if end_year is None:
+        return start_year, max(start_year, current_year)
+
+    if start_year > end_year:
+        return end_year, start_year
+
+    return start_year, end_year
+
+
 async def get_data(
     database_id: str,
     indicator_id: str,
@@ -1849,8 +1919,10 @@ async def get_data(
             Use value None to request all values for a dimension (e.g. {"SEX": None}). When REF_AREA
             is omitted or None, the Data API returns all geographic series—including regional aggregates
             (e.g. EAS, EMU)—mixed with member economies.
-        start_year: Optional start year (inclusive). Defaults to last 5 years if both start/end omitted.
-        end_year: Optional end year (inclusive). Defaults to current year if both start/end omitted.
+        start_year: Optional start year (inclusive). With neither bound, defaults to last 5 years.
+            With only ``end_year``, defaults to a 5-year window ending at ``end_year``.
+            With only ``start_year``, defaults through the current calendar year.
+        end_year: Optional end year (inclusive). See ``start_year`` for partial-bound behavior.
         limit: Maximum records per page (default 50, max 100).
         offset: Number of records to skip for pagination (default 0).
         ref_area_filter: When ``member_economies_only``, drop rows whose ``REF_AREA`` is not an FMR
@@ -1886,14 +1958,16 @@ async def get_data(
     # Cap limit to prevent token overflow
     limit = min(limit, 100)
 
-    # Smart time defaults: if no time range specified, default to last 5 years
-    if start_year is None and end_year is None:
-        from datetime import datetime  # noqa: PLC0415
-
-        current_year = datetime.now().year
-        end_year = current_year
-        start_year = current_year - 4  # Last 5 years
-        _logger.info(f"Smart default: Applied time range {start_year}-{end_year}")
+    resolved_start, resolved_end = _resolve_time_range(start_year, end_year)
+    if (start_year, end_year) != (resolved_start, resolved_end):
+        _logger.info(
+            "Resolved time range %s-%s from start_year=%s end_year=%s",
+            resolved_start,
+            resolved_end,
+            start_year,
+            end_year,
+        )
+    start_year, end_year = resolved_start, resolved_end
 
     # Validate arguments using Pydantic model
     try:
@@ -1914,8 +1988,8 @@ async def get_data(
     params: dict[str, Any] = {
         "DATABASE_ID": database_id,
         "INDICATOR": indicator_id,
-        "timePeriodFrom": str(start_year),
-        "timePeriodTo": str(end_year),
+        "timePeriodFrom": start_year,
+        "timePeriodTo": end_year,
         "skip": offset,
         # Request one extra to detect if there are more results
         # Note: API uses "top" not "$top" (OData style would be URL-encoded to %24top which API ignores)
@@ -2019,6 +2093,7 @@ async def get_data(
             raw_data = raw_data[:limit]
 
         from .providers import get_codelist_manager  # noqa: PLC0415
+
         _cm = get_codelist_manager()
         await _cm._ensure_extdataportal_loaded()
         for row in raw_data:
@@ -3092,7 +3167,6 @@ async def rank_countries(
                 f"{best_coverage}/{total_requested} countries."
             )
 
-
     # Build ranking from selected year
     year_data = year_country_map.get(ranking_year, {})
     unit_measure = None
@@ -3292,7 +3366,9 @@ async def compare_countries(
     elif common_years:
         snap_year = common_years[-1]  # Latest common year
         n_countries = sum(
-            1 for c in codes if c in country_year_map and snap_year in country_year_map[c]
+            1
+            for c in codes
+            if c in country_year_map and snap_year in country_year_map[c]
         )
         year_selection_note = (
             f"Latest year with data for all compared countries: {snap_year} "
@@ -3303,7 +3379,9 @@ async def compare_countries(
         snap_year = max(all_years) if all_years else None
         if snap_year:
             n_countries = sum(
-                1 for c in codes if c in country_year_map and snap_year in country_year_map[c]
+                1
+                for c in codes
+                if c in country_year_map and snap_year in country_year_map[c]
             )
             year_selection_note = (
                 f"Latest year with data (partial coverage): {snap_year} "

--- a/src/data360/mcp_server/tools.py
+++ b/src/data360/mcp_server/tools.py
@@ -17,7 +17,6 @@ from data360 import visualization as data360_viz
 from ._server_definition import mcp
 from .tool_spans import instrument_mcp_tool
 
-
 # ---------------------------------------------------------------------------
 # Serializer for aggregation tools
 # ---------------------------------------------------------------------------
@@ -148,8 +147,9 @@ async def _get_data(
         indicator_id: Indicator ID (e.g., "WB_WDI_NY_GDP_PCAP_KD").
         country_code: Semicolon-separated ISO country codes (e.g. "KEN;USA").
         disaggregation_filters: Optional dimension filters. Values must be strings or null. Call `data360_get_disaggregation` first to find valid options.
-        start_year: Start year (inclusive). Defaults to last 5 years if omitted.
-        end_year: End year (inclusive). Defaults to current year if omitted.
+        start_year: Start year (inclusive). Defaults to last 5 years if both bounds omitted;
+            if only end_year is set, defaults to a 5-year window ending at end_year.
+        end_year: End year (inclusive). See start_year for partial-bound defaults.
         limit: Max records per page (default 50, max 100).
         offset: Number of records to skip for pagination.
         ref_area_filter: Filter mode: "member_economies_only" (default) or "none".
@@ -493,30 +493,22 @@ get_data = mcp.tool(
 )
 
 get_disaggregation = mcp.tool(
-    instrument_mcp_tool(
-        _get_disaggregation, tool_name="data360_get_disaggregation"
-    ),
+    instrument_mcp_tool(_get_disaggregation, tool_name="data360_get_disaggregation"),
     name="data360_get_disaggregation",
 )
 
 find_codelist_value = mcp.tool(
-    instrument_mcp_tool(
-        _find_codelist_value, tool_name="data360_find_codelist_value"
-    ),
+    instrument_mcp_tool(_find_codelist_value, tool_name="data360_find_codelist_value"),
     name="data360_find_codelist_value",
 )
 
 list_indicators = mcp.tool(
-    instrument_mcp_tool(
-        _list_indicators, tool_name="data360_list_indicators"
-    ),
+    instrument_mcp_tool(_list_indicators, tool_name="data360_list_indicators"),
     name="data360_list_indicators",
 )
 
 get_data_api_url = mcp.tool(
-    instrument_mcp_tool(
-        _get_data_api_url, tool_name="data360_get_data_api_url"
-    ),
+    instrument_mcp_tool(_get_data_api_url, tool_name="data360_get_data_api_url"),
     name="data360_get_data_api_url",
 )
 
@@ -554,9 +546,7 @@ expand_country_group = mcp.tool(
 
 summarize_data = mcp.add_tool(
     Tool.from_function(
-        instrument_mcp_tool(
-            _summarize_data, tool_name="data360_summarize_data"
-        ),
+        instrument_mcp_tool(_summarize_data, tool_name="data360_summarize_data"),
         name="data360_summarize_data",
         serializer=_compact_aggregation_serializer,
     )
@@ -564,9 +554,7 @@ summarize_data = mcp.add_tool(
 
 rank_countries = mcp.add_tool(
     Tool.from_function(
-        instrument_mcp_tool(
-            _rank_countries, tool_name="data360_rank_countries"
-        ),
+        instrument_mcp_tool(_rank_countries, tool_name="data360_rank_countries"),
         name="data360_rank_countries",
         serializer=_compact_aggregation_serializer,
     )
@@ -574,9 +562,7 @@ rank_countries = mcp.add_tool(
 
 compare_countries = mcp.add_tool(
     Tool.from_function(
-        instrument_mcp_tool(
-            _compare_countries, tool_name="data360_compare_countries"
-        ),
+        instrument_mcp_tool(_compare_countries, tool_name="data360_compare_countries"),
         name="data360_compare_countries",
         serializer=_compact_aggregation_serializer,
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -125,7 +125,9 @@ class TestSearch:
         assert result.error is None
 
     @pytest.mark.asyncio
-    async def test_search_empty_result_preserves_count_zero(self, httpx_mock: pytest_httpx.HTTPXMock):
+    async def test_search_empty_result_preserves_count_zero(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
         """Test that search with empty results preserves count=0 and does not resolve to None."""
         mock_response = {
             "count": 0,
@@ -288,12 +290,17 @@ class TestSearch:
         )
 
         # Test query with parentheses and currency symbols (unsafe) alongside safe characters (_, -, ,, .)
-        await search("GDP per capita (current US$) WB_WDI_NY_GDP_PCAP_CD-2022, test.", limit=5)
+        await search(
+            "GDP per capita (current US$) WB_WDI_NY_GDP_PCAP_CD-2022, test.", limit=5
+        )
 
         assert len(captured_payloads) == 1
         # The parentheses and currency symbols should be replaced by spaces and collapsed,
         # while the underscores, hyphens, commas, and periods are kept.
-        assert captured_payloads[0].get("query_string") == "GDP per capita current US WB_WDI_NY_GDP_PCAP_CD-2022, test."
+        assert (
+            captured_payloads[0].get("query_string")
+            == "GDP per capita current US WB_WDI_NY_GDP_PCAP_CD-2022, test."
+        )
 
     @pytest.mark.asyncio
     async def test_search_empty_query_after_sanitization(self):
@@ -440,7 +447,9 @@ class TestSearchDatasets:
         assert response.items[0].name == "Global Financial Inclusion Database"
 
     @pytest.mark.asyncio
-    async def test_search_datasets_query_sanitization(self, httpx_mock: pytest_httpx.HTTPXMock):
+    async def test_search_datasets_query_sanitization(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
         """Test that special characters are sanitized in dataset search queries."""
         captured_payloads = []
 
@@ -483,10 +492,16 @@ class TestSearchDatasets:
 
         response = await search_datasets("findex")
         assert response.error is not None
-        assert "Server Error" in response.error or "500" in response.error or "Internal Server Error" in response.error
+        assert (
+            "Server Error" in response.error
+            or "500" in response.error
+            or "Internal Server Error" in response.error
+        )
 
     @pytest.mark.asyncio
-    async def test_search_datasets_exception_classification(self, httpx_mock: pytest_httpx.HTTPXMock):
+    async def test_search_datasets_exception_classification(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
         """Test that other exceptions during dataset search are classified robustly."""
         httpx_mock.add_exception(
             httpx.ConnectError("Connection refused"),
@@ -645,11 +660,19 @@ class TestGetMetadata:
         # Verify _Z was filtered out by _get_valid_disaggregations
         field_names = [opt["field_name"] for opt in result.disaggregation_options]
         # REF_AREA is summarized by _strip_disaggregation (count + sample)
-        ref_area = next(opt for opt in result.disaggregation_options if opt["field_name"] == "REF_AREA")
+        ref_area = next(
+            opt
+            for opt in result.disaggregation_options
+            if opt["field_name"] == "REF_AREA"
+        )
         assert ref_area["count"] == 1
         assert "UGA" in ref_area["sample"]
         # UNIT_MEASURE is preserved as-is
-        unit = next(opt for opt in result.disaggregation_options if opt["field_name"] == "UNIT_MEASURE")
+        unit = next(
+            opt
+            for opt in result.disaggregation_options
+            if opt["field_name"] == "UNIT_MEASURE"
+        )
         assert unit["field_value"] == ["_T"]
 
     @pytest.mark.asyncio
@@ -760,7 +783,11 @@ class TestGetData:
         httpx_mock.add_response(
             method="POST",
             url=re.compile(r".*/portal/v1/dimensions.*"),
-            json={"dimensions": [{"field_name": "REF_AREA", "field_value": [{"code": "UGA"}]}]},
+            json={
+                "dimensions": [
+                    {"field_name": "REF_AREA", "field_value": [{"code": "UGA"}]}
+                ]
+            },
         )
 
         # Mock data response
@@ -855,7 +882,10 @@ class TestGetData:
             url=re.compile(r".*/portal/v1/dimensions.*"),
             json={
                 "dimensions": [
-                    {"field_name": "URBANISATION", "field_value": [{"code": "_T"}, {"code": "URB"}]},
+                    {
+                        "field_name": "URBANISATION",
+                        "field_value": [{"code": "_T"}, {"code": "URB"}],
+                    },
                 ]
             },
         )
@@ -892,7 +922,9 @@ class TestGetData:
             json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]},
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []}
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         # First page response
@@ -942,7 +974,9 @@ class TestGetData:
             json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]},
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []}
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         def empty_data_callback(request: httpx.Request) -> httpx.Response | None:
@@ -973,7 +1007,9 @@ class TestGetData:
             json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]},
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []}
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         # Data error
@@ -1003,7 +1039,9 @@ class TestGetData:
             json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL"}}]},
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []}
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         def invalid_json_callback(request: httpx.Request) -> httpx.Response | None:
@@ -1044,18 +1082,31 @@ class TestGetDataResilience:
         httpx_mock.add_response(
             method="POST",
             url="https://api.test.example.com/metadata",
-            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL", "name": "Pop"}}]},
+            json={
+                "value": [
+                    {
+                        "series_description": {
+                            "idno": "WB_WDI_SP_POP_TOTL",
+                            "name": "Pop",
+                        }
+                    }
+                ]
+            },
         )
         # Disaggregation fails with 500
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), status_code=500,
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            status_code=500,
             text="Internal Server Error",
         )
         # Data fetch succeeds
         httpx_mock.add_response(
             method="GET",
             url=re.compile(r".*/data\?.*"),
-            json={"value": [{"REF_AREA": "KEN", "TIME_PERIOD": "2020", "OBS_VALUE": 5000}]},
+            json={
+                "value": [{"REF_AREA": "KEN", "TIME_PERIOD": "2020", "OBS_VALUE": 5000}]
+            },
         )
 
         result = await get_data("WB_WDI", "WB_WDI_SP_POP_TOTL")
@@ -1078,7 +1129,9 @@ class TestGetDataResilience:
         )
         # Disaggregation returns 200 empty (doesn't matter)
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []},
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         result = await get_data("WB_WDI", "NONEXISTENT_INDICATOR")
@@ -1092,17 +1145,28 @@ class TestGetDataResilience:
     # ---------------------------------------------------------------------------
 
     @pytest.mark.asyncio
-    async def test_get_data_country_code_param_sets_ref_area(
+    async def test_get_data_end_year_only_resolves_five_year_window(
         self, httpx_mock: pytest_httpx.HTTPXMock
     ):
-        """country_code parameter should be passed as REF_AREA in the data request URL."""
+        """Only end_year should not send timePeriodFrom=None; use 5-year window ending at end_year."""
         httpx_mock.add_response(
             method="POST",
             url="https://api.test.example.com/metadata",
-            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL", "name": "Pop"}}]},
+            json={
+                "value": [
+                    {
+                        "series_description": {
+                            "idno": "WB_WDI_SP_POP_TOTL",
+                            "name": "Pop",
+                        }
+                    }
+                ]
+            },
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []},
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         captured_urls: list[str] = []
@@ -1112,10 +1176,79 @@ class TestGetDataResilience:
                 captured_urls.append(str(request.url))
                 return httpx.Response(
                     200,
-                    json={"value": [
-                        {"REF_AREA": "KEN", "TIME_PERIOD": "2020", "OBS_VALUE": 100},
-                        {"REF_AREA": "MAR", "TIME_PERIOD": "2020", "OBS_VALUE": 200},
-                    ]},
+                    json={
+                        "value": [
+                            {
+                                "REF_AREA": "PHL",
+                                "TIME_PERIOD": "2018",
+                                "OBS_VALUE": 16.7,
+                            }
+                        ]
+                    },
+                )
+            return None
+
+        httpx_mock.add_callback(data_callback)
+
+        result = await get_data(
+            "WB_WDI",
+            "WB_WDI_SP_POP_TOTL",
+            country_code="PHL",
+            end_year=2019,
+        )
+
+        assert len(captured_urls) == 1
+        assert "timePeriodFrom=2015" in captured_urls[0]
+        assert "timePeriodTo=2019" in captured_urls[0]
+        assert result.error is None
+        assert result.data is not None
+
+    @pytest.mark.asyncio
+    async def test_get_data_country_code_param_sets_ref_area(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
+        """country_code parameter should be passed as REF_AREA in the data request URL."""
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.test.example.com/metadata",
+            json={
+                "value": [
+                    {
+                        "series_description": {
+                            "idno": "WB_WDI_SP_POP_TOTL",
+                            "name": "Pop",
+                        }
+                    }
+                ]
+            },
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
+        )
+
+        captured_urls: list[str] = []
+
+        def data_callback(request: httpx.Request) -> httpx.Response | None:
+            if request.method == "GET" and request.url.path == "/data":
+                captured_urls.append(str(request.url))
+                return httpx.Response(
+                    200,
+                    json={
+                        "value": [
+                            {
+                                "REF_AREA": "KEN",
+                                "TIME_PERIOD": "2020",
+                                "OBS_VALUE": 100,
+                            },
+                            {
+                                "REF_AREA": "MAR",
+                                "TIME_PERIOD": "2020",
+                                "OBS_VALUE": 200,
+                            },
+                        ]
+                    },
                 )
             return None
 
@@ -1124,7 +1257,10 @@ class TestGetDataResilience:
         result = await get_data("WB_WDI", "WB_WDI_SP_POP_TOTL", country_code="KEN;MAR")
 
         assert len(captured_urls) == 1
-        assert "REF_AREA=KEN%2CMAR" in captured_urls[0] or "REF_AREA=KEN,MAR" in captured_urls[0]
+        assert (
+            "REF_AREA=KEN%2CMAR" in captured_urls[0]
+            or "REF_AREA=KEN,MAR" in captured_urls[0]
+        )
         assert result.data is not None
 
     @pytest.mark.asyncio
@@ -1135,10 +1271,21 @@ class TestGetDataResilience:
         httpx_mock.add_response(
             method="POST",
             url="https://api.test.example.com/metadata",
-            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL", "name": "Pop"}}]},
+            json={
+                "value": [
+                    {
+                        "series_description": {
+                            "idno": "WB_WDI_SP_POP_TOTL",
+                            "name": "Pop",
+                        }
+                    }
+                ]
+            },
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []},
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
         httpx_mock.add_response(
             method="GET",
@@ -1293,7 +1440,9 @@ class TestDatabaseNameInMetadata:
             json=metadata_response,
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []},
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         captured_urls: list[str] = []
@@ -1303,10 +1452,20 @@ class TestDatabaseNameInMetadata:
                 captured_urls.append(str(request.url))
                 return httpx.Response(
                     200,
-                    json={"value": [
-                        {"REF_AREA": "KEN", "TIME_PERIOD": "2020", "OBS_VALUE": 100},
-                        {"REF_AREA": "MAR", "TIME_PERIOD": "2020", "OBS_VALUE": 200},
-                    ]},
+                    json={
+                        "value": [
+                            {
+                                "REF_AREA": "KEN",
+                                "TIME_PERIOD": "2020",
+                                "OBS_VALUE": 100,
+                            },
+                            {
+                                "REF_AREA": "MAR",
+                                "TIME_PERIOD": "2020",
+                                "OBS_VALUE": 200,
+                            },
+                        ]
+                    },
                 )
             return None
 
@@ -1315,7 +1474,10 @@ class TestDatabaseNameInMetadata:
         result = await get_data("WB_WDI", "WB_WDI_SP_POP_TOTL", country_code="KEN,MAR")
 
         assert len(captured_urls) == 1
-        assert "REF_AREA=KEN%2CMAR" in captured_urls[0] or "REF_AREA=KEN,MAR" in captured_urls[0]
+        assert (
+            "REF_AREA=KEN%2CMAR" in captured_urls[0]
+            or "REF_AREA=KEN,MAR" in captured_urls[0]
+        )
         assert result.data is not None
 
 
@@ -1336,11 +1498,22 @@ class TestGetDataApiUrlResilience:
         httpx_mock.add_response(
             method="POST",
             url="https://api.test.example.com/metadata",
-            json={"value": [{"series_description": {"idno": "WB_WDI_SP_POP_TOTL", "name": "Pop"}}]},
+            json={
+                "value": [
+                    {
+                        "series_description": {
+                            "idno": "WB_WDI_SP_POP_TOTL",
+                            "name": "Pop",
+                        }
+                    }
+                ]
+            },
         )
         # Disaggregation fails
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), status_code=500,
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            status_code=500,
             text="Internal Server Error",
         )
 
@@ -1364,7 +1537,9 @@ class TestGetDataApiUrlResilience:
             json={"value": []},
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []},
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         with pytest.raises(ValueError, match="not found"):
@@ -1397,7 +1572,9 @@ class TestDatabaseNameInMetadata:
             json=metadata_response,
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []},
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         result = await get_metadata("WB_GS", "WB_GS_INDICATOR")
@@ -1429,13 +1606,13 @@ class TestDatabaseNameInMetadata:
             json=metadata_response,
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []},
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         # Only request 'name' — database_name should still be included
-        result = await get_metadata(
-            "WB_GS", "WB_GS_INDICATOR", select_fields=["name"]
-        )
+        result = await get_metadata("WB_GS", "WB_GS_INDICATOR", select_fields=["name"])
 
         assert result.indicator_metadata is not None
         assert "name" in result.indicator_metadata
@@ -1464,7 +1641,9 @@ class TestDatabaseNameInMetadata:
             json=metadata_response,
         )
         httpx_mock.add_response(
-            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"), json={"dimensions": []},
+            method="POST",
+            url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": []},
         )
 
         result = await get_metadata("UNKNOWN_DB", "UNKNOWN_DB_IND")
@@ -1679,7 +1858,9 @@ class TestDimensionsResilienceAndParsing:
         httpx_mock.add_response(
             method="POST",
             url="https://api.test.example.com/portal/v1/dimensions",
-            json={"dimensions": [{"field_name": "SEX", "field_value": [{"code": "_T"}]}]},
+            json={
+                "dimensions": [{"field_name": "SEX", "field_value": [{"code": "_T"}]}]
+            },
         )
         httpx_mock.add_response(
             method="POST",
@@ -1690,6 +1871,7 @@ class TestDimensionsResilienceAndParsing:
         # Clear the metadata cache so get_metadata does not hit the metadata cache itself,
         # forcing it to run the dimensions fetch logic.
         from data360.api import _metadata_cache, _metadata_cache_lock
+
         with _metadata_cache_lock:
             _metadata_cache.clear()
 
@@ -1708,19 +1890,25 @@ class TestDimensionsResilienceAndParsing:
         dim_reqs = [r for r in requests if "portal/v1/dimensions" in str(r.url)]
         assert len(dim_reqs) == 1
 
-
-
     @pytest.mark.asyncio
-    async def test_dimensions_api_cache_edge_cases(self, httpx_mock: pytest_httpx.HTTPXMock):
+    async def test_dimensions_api_cache_edge_cases(
+        self, httpx_mock: pytest_httpx.HTTPXMock
+    ):
         """Verify:
         1. HTTP 500 status code propagation, and that it's NOT cached.
         2. Blank/empty response body is handled and returns empty dimensions.
         3. Concurrent calls to the same endpoint are deduplicated.
         """
         import asyncio
-        import httpx
         import json
-        from data360.api import _fetch_dimensions_with_cache, _dimensions_api_cache, _dimensions_api_cache_lock
+
+        import httpx
+
+        from data360.api import (
+            _dimensions_api_cache,
+            _dimensions_api_cache_lock,
+            _fetch_dimensions_with_cache,
+        )
 
         # --- 1. HTTP 500 Propagation and No Caching ---
         httpx_mock.add_response(


### PR DESCRIPTION
## Summary

- Fixes a bug where `data360_get_data` returned **zero rows** when callers passed only `end_year` (or only `start_year`) without the other bound.
- Root cause: `get_data` only applied the “last 5 years” default when **both** bounds were omitted. With only `end_year`, `start_year` stayed `None` and the Data API received `timePeriodFrom=None` (the literal string `"None"`), which matches no observations.
- Adds `_resolve_time_range()` to normalize inclusive `[start_year, end_year]` before every fetch:
  - **Neither bound** → last 5 calendar years through the current year (unchanged)
  - **Only `end_year`** → 5-year window ending at `end_year` (e.g. `end_year=2019` → 2015–2019)
  - **Only `start_year`** → `start_year` through the current calendar year
  - **Both** → used as given (swapped if reversed)
- Passes integer years to `timePeriodFrom` / `timePeriodTo` instead of `str(None)`.
- Aggregation tools that call `get_data` internally (`summarize_data`, `rank_countries`, `compare_countries`) inherit the fix via `_fetch_all_pages`.
- Updates `data360_get_data` docstrings and adds `test_get_data_end_year_only_resolves_five_year_window`.

**Example:** Before the fix, poverty for Philippines with `country_code=PHL` and `end_year=2019` returned `data: []` with no error. After the fix, the same call returns available points in the resolved window (e.g. 2015 and 2018 for `WB_WDI_SI_POV_NAHC`; 2019 may still be empty if the series has no PHL value that year).