### PR TITLE
feat: enrich search, rank, compare, and summarize tools with country names and units

### DIFF
--- a/packages/tool-types/package.json
+++ b/packages/tool-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data360/tool-types",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "TypeScript types and runtime guards for Data360 MCP tool JSON payloads.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/tool-types/src/search-contract.ts
+++ b/packages/tool-types/src/search-contract.ts
@@ -57,6 +57,8 @@ export const data360SearchToolResultSchema = z
     indicators: z.array(enrichedIndicatorSchema),
     /** Resolved 3-letter country code used for coverage checks (e.g. "KEN"). */
     required_country: z.string().nullable().optional(),
+    /** Resolved country names mapping codes to display names. */
+    country_names: z.record(z.string(), z.string()).nullable().optional(),
     /** Error message if the search failed; otherwise null/absent. */
     error: z.string().nullable().optional(),
     /** Total indicators available (before page limit). */
@@ -118,6 +120,8 @@ export const data360MultiQuerySearchToolResultSchema = z
     queries: z.array(z.string()),
     /** Resolved country code(s) shared across all sub-queries. */
     required_country: z.string().nullable().optional(),
+    /** Resolved country names mapping codes to display names. */
+    country_names: z.record(z.string(), z.string()).nullable().optional(),
     /** Total indicators found before deduplication. */
     total_candidates: z.number(),
     /** Number of duplicates removed (merged layout only). */

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -116,6 +116,7 @@ _CORE_FIELDS = frozenset(
         "REF_AREA_NAME",
         "country_name",
         "UNIT_MEASURE",
+        "UNIT_MEASURE_NAME",
         "claim_id",
     }
 )
@@ -1372,9 +1373,14 @@ async def search(  # noqa: PLR0911
             )
         )
 
+    name_map = None
+    if country_code:
+        name_map = await _resolve_country_names([c.strip() for c in country_code.split(";") if c.strip()])
+
     return EnrichedSearchResponse(
         indicators=indicators,
         required_country=country_code,
+        country_names=name_map,
         # Map pagination fields from underlying search result
         count=search_result.count,
         total_count=search_result.total_count,
@@ -1517,6 +1523,12 @@ async def _build_multi_query_response(
     all_codes = sorted({c for c in per_query_codes if c})
     response_country = ";".join(all_codes) if all_codes else None
 
+    # Resolve all individual codes from all queries
+    individual_codes = set()
+    for code in all_codes:
+        individual_codes.update(c.strip() for c in code.split(";") if c.strip())
+    name_map = await _resolve_country_names(list(individual_codes)) if individual_codes else None
+
     if result_layout == "merged":
         merged_indicators: list[EnrichedIndicator] = [
             ind for g in groups for ind in g.indicators
@@ -1538,6 +1550,7 @@ async def _build_multi_query_response(
             result_layout="merged",
             queries=clean_queries,
             required_country=response_country,
+            country_names=name_map,
             total_candidates=total_candidates,
             deduplicated_count=deduplicated_count if dedupe else None,
         )
@@ -1547,6 +1560,7 @@ async def _build_multi_query_response(
             result_layout="by_query",
             queries=clean_queries,
             required_country=response_country,
+            country_names=name_map,
             total_candidates=total_candidates,
             deduplicated_count=deduplicated_count if dedupe else None,
         )
@@ -2160,6 +2174,11 @@ async def get_data(
                 label = _cm.get_label("REF_AREA", str(ref_area))
                 if label and label != str(ref_area):
                     row["REF_AREA_NAME"] = label
+            unit_measure = row.get("UNIT_MEASURE")
+            if unit_measure:
+                unit_label = _cm.get_label("UNIT_MEASURE", str(unit_measure))
+                if unit_label and unit_label != str(unit_measure):
+                    row["UNIT_MEASURE_NAME"] = unit_label
 
         # Promote COMMENT_TS to metadata (repeats identically per row)
         if raw_data and api_metadata is not None:
@@ -2513,21 +2532,19 @@ async def _fetch_all_pages(
 
 
 async def _resolve_country_names(codes: list[str]) -> dict[str, str]:
-    """Batch-resolve country codes to display names in a single codelist call.
+    """Batch-resolve country codes to display names.
 
-    Uses find_codelist_value's native comma-separated query support to resolve
-    all codes in one call. Silently returns an empty dict on any error since
-    country names are optional enrichment — the codes themselves are always valid.
+    Uses the in-memory CodelistManager to lookup human-readable country names
+    from the REF_AREA codelist. Silently returns empty names on any error.
     """
-    from .providers import find_codelist_value  # noqa: PLC0415
+    from .providers import get_codelist_manager  # noqa: PLC0415
 
     if not codes:
         return {}
     try:
-        batch_query = ",".join(codes)
-        results = await find_codelist_value("REF_AREA", batch_query, limit=1)
-        # find_value returns one best match per comma-separated part
-        return {r["id"]: r.get("name", r["id"]) for r in results}
+        _cm = get_codelist_manager()
+        await _cm._ensure_extdataportal_loaded()
+        return {code: _cm.get_label("REF_AREA", code) for code in codes}
     except Exception:
         return {}
 
@@ -2932,7 +2949,12 @@ async def summarize_data(
     # Extract unit_measure from first row
     unit_measure = None
     if data_response.data:
-        unit_measure = data_response.data[0].get("UNIT_MEASURE")
+        raw_unit = data_response.data[0].get("UNIT_MEASURE")
+        if raw_unit:
+            from .providers import get_codelist_manager  # noqa: PLC0415
+            _cm = get_codelist_manager()
+            await _cm._ensure_extdataportal_loaded()
+            unit_measure = _cm.get_label("UNIT_MEASURE", str(raw_unit))
 
     # Group rows by the specified dimensions
     raw_field_names = [_GROUPBY_FIELD_MAP[c.lower()] for c in group_by]
@@ -3228,7 +3250,12 @@ async def rank_countries(
     year_data = year_country_map.get(ranking_year, {})
     unit_measure = None
     if data_response.data:
-        unit_measure = data_response.data[0].get("UNIT_MEASURE")
+        raw_unit = data_response.data[0].get("UNIT_MEASURE")
+        if raw_unit:
+            from .providers import get_codelist_manager  # noqa: PLC0415
+            _cm = get_codelist_manager()
+            await _cm._ensure_extdataportal_loaded()
+            unit_measure = _cm.get_label("UNIT_MEASURE", str(raw_unit))
 
     # Batch-resolve country names in a single call
     name_map = await _resolve_country_names(resolved_codes)
@@ -3401,9 +3428,14 @@ async def compare_countries(
     # Batch-resolve country names in a single call
     name_map = await _resolve_country_names(codes)
 
-    unit_measure = (
-        data_response.data[0].get("UNIT_MEASURE") if data_response.data else None
-    )
+    unit_measure = None
+    if data_response.data:
+        raw_unit = data_response.data[0].get("UNIT_MEASURE")
+        if raw_unit:
+            from .providers import get_codelist_manager  # noqa: PLC0415
+            _cm = get_codelist_manager()
+            await _cm._ensure_extdataportal_loaded()
+            unit_measure = _cm.get_label("UNIT_MEASURE", str(raw_unit))
 
     # Determine snapshot year
     all_years = set()
@@ -3585,6 +3617,7 @@ async def compare_countries(
         time_series=ts_response,
         metadata=data_response.metadata,
         unit_measure=unit_measure,
+        country_names=name_map,
     )
 
 

--- a/src/data360/models.py
+++ b/src/data360/models.py
@@ -230,6 +230,9 @@ class EnrichedSearchResponse(MCPPagedResponse):
         description="Resolved country code(s). Semicolon-separated for multiple countries "
         "(e.g. 'KEN' or 'KEN;GHA').",
     )
+    country_names: dict[str, str] | None = Field(
+        None, description="Resolved names of requested countries"
+    )
     error: str | None = Field(None, description="Error message if search failed")
 
 
@@ -306,6 +309,9 @@ class MultiQuerySearchResponse(BaseModel):
         None,
         description="Resolved country code(s) used for all sub-queries. "
         "Semicolon-separated for multiple countries (e.g. 'KEN;GHA').",
+    )
+    country_names: dict[str, str] | None = Field(
+        None, description="Resolved names of requested countries"
     )
     total_candidates: int = Field(
         0,
@@ -732,6 +738,7 @@ class CountryComparisonResponse(BaseModel):
     metadata: dict[str, Any] | None = Field(None, description="Indicator metadata")
     unit_measure: str | None = Field(None, description="Unit of measurement")
     error: str | None = Field(None, description="Error message if request failed")
+    country_names: dict[str, str] | None = Field(None, description="Resolved names of compared countries")
 
     def to_compact(self) -> dict[str, Any]:
         """Return a slimmed dict for LLM context.
@@ -745,6 +752,7 @@ class CountryComparisonResponse(BaseModel):
             "unit": self.unit_measure,
             "snapshot": self.snapshot.to_compact() if self.snapshot else None,
             "time_series": self.time_series.to_compact() if self.time_series else None,
+            "country_names": self.country_names,
             "error": self.error,
         }
 

--- a/src/data360/providers.py
+++ b/src/data360/providers.py
@@ -705,6 +705,19 @@ def _make_group_note(group_code: str, info: dict) -> str:
     )
 
 
+_UNIT_MEASURE_FALLBACKS = {
+    "ZS": "Percent",
+    "PS": "Persons",
+    "USD": "US Dollars",
+    "LCU": "Local Currency Unit",
+    "DY": "Days",
+    "YR": "Years",
+    "MR": "Meters",
+    "KG": "Kilograms",
+    "TN": "Tonnes",
+}
+
+
 class CodelistManager:
     """Unified manager for all Data360 codelists.
 
@@ -1023,6 +1036,8 @@ class CodelistManager:
             Human-readable label or the original ``code`` if not found.
         """
         key = self._resolve_extdataportal_key(dimension)
+        if key == "UNIT_MEASURE" and code in _UNIT_MEASURE_FALLBACKS:
+            return _UNIT_MEASURE_FALLBACKS[code]
         return self._extdataportal.get(key, {}).get(code, code)
 
     def get_dimension_labels(self, dimension: str) -> dict[str, str]:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1429,6 +1429,50 @@ class TestGetDataResilience:
         assert "KEN" in areas
 
 
+class TestCountryNamesInSearch:
+    """Tests that search results carry resolved country_names mapping."""
+
+    @pytest.mark.asyncio
+    async def test_search_resolves_country_names(
+        self, httpx_mock: pytest_httpx.HTTPXMock, monkeypatch
+    ):
+        mock_response = {
+            "count": 1,
+            "results": [
+                {
+                    "idno": "WB_GS_SP_POP_TOTL",
+                    "name": "Population, total",
+                    "databases": [{"idno": "WB_GS"}],
+                    "description": "Total population",
+                    "dimensions": [],
+                }
+            ],
+        }
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.test.example.com/portal/v1/public_data360_search",
+            json=mock_response,
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.test.example.com/portal/v1/dimensions",
+            json={"dimensions": []},
+        )
+
+        # Mock CodelistManager.get_label to return custom names
+        from data360.providers import CodelistManager
+        monkeypatch.setattr(
+            CodelistManager,
+            "get_label",
+            lambda self, dim, code: "Japan" if code == "JPN" else "Philippines" if code == "PHL" else code
+        )
+
+        result = await search("population", required_country="JPN;PHL")
+
+        assert isinstance(result, EnrichedSearchResponse)
+        assert result.country_names == {"JPN": "Japan", "PHL": "Philippines"}
+
+
 class TestDatabaseNameInSearch:
     """Tests that search results carry the correct database_name for each indicator."""
 


### PR DESCRIPTION
### Summary
This PR enriches multiple tool response contracts and outputs with resolved country name mappings and unit measurement labels. It also updates search contract Zod schemas and ensures unified retrieval of dimension names from the local CodelistManager.

This PR serves as the backend backbone for the chatbot frontend changes introduced in https://github.com/worldbank/data-ai-chatbot/pull/144.

### Details
- **Country Names Mapping**: Search and multi-query search responses now carry resolved country name dictionaries.
- **Unit Labels Resolution**: Rank, compare, and summarize tools resolve raw unit measure codes (e.g. `ZS`) to their human-readable labels (e.g. `Percent`) using the CodelistManager.
- **CodelistManager Integration**: Batched country name queries utilize the local CodelistManager instead of direct API queries for improved resilience and speed.
- **Contract Updates**: Updated the search contracts schema under `packages/tool-types` and bumped version to `0.0.5`.