### PR TITLE
feat: handle UNIT_MULT to qualify unit measure labels (#118)

### DIFF
--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -2211,10 +2211,22 @@ async def get_data(
             unit_measure = row.get("UNIT_MEASURE")
             if unit_measure:
                 unit_label = _cm.get_label("UNIT_MEASURE", str(unit_measure))
-                unit_name = unit_label if unit_label else str(unit_measure)
-                qualified_unit = _qualify_unit_name(unit_name, row.get("UNIT_MULT"), str(unit_measure))
-                if qualified_unit:
-                    row["UNIT_MEASURE_NAME"] = qualified_unit
+                has_mapping = bool(unit_label and unit_label != str(unit_measure))
+
+                # Check if we have a valid multiplier that warrants qualification
+                unit_mult = row.get("UNIT_MULT")
+                try:
+                    mult = int(unit_mult) if unit_mult is not None else 0
+                except (ValueError, TypeError):
+                    mult = 0
+                has_valid_mult = mult in (3, 6, 9, 12)
+
+                if has_mapping or has_valid_mult:
+                    base_unit = unit_label if has_mapping else row.get("UNIT_MEASURE_NAME") or str(unit_measure)
+                    qualified_unit = _qualify_unit_name(base_unit, unit_mult, str(unit_measure))
+                    if qualified_unit:
+                        row["UNIT_MEASURE_NAME"] = qualified_unit
+
 
         # Promote COMMENT_TS to metadata (repeats identically per row)
         if raw_data and api_metadata is not None:

--- a/src/data360/api.py
+++ b/src/data360/api.py
@@ -117,6 +117,7 @@ _CORE_FIELDS = frozenset(
         "country_name",
         "UNIT_MEASURE",
         "UNIT_MEASURE_NAME",
+        "UNIT_MULT",
         "claim_id",
     }
 )
@@ -133,6 +134,39 @@ _TRIVIAL_VALUES = frozenset({"_T", "_Z"})
 def _short_hash(data: dict[str, Any]) -> str:
     """PCN claim_id 8-character hash for data verification."""
     return f"{zlib.crc32(json.dumps(data, sort_keys=True).encode()) & 0xFFFFFFFF:08x}"
+
+
+def _qualify_unit_name(unit_name: str | None, unit_mult: Any, unit_code: str | None = None) -> str | None:
+    """Qualify a unit name/label using its unit multiplier (e.g. 'million people')."""
+    if not unit_mult:
+        return unit_name
+    try:
+        mult = int(unit_mult)
+    except (ValueError, TypeError):
+        return unit_name
+
+    if mult == 0:
+        return unit_name
+
+    mult_map = {
+        3: "thousand",
+        6: "million",
+        9: "billion",
+        12: "trillion"
+    }
+    qualifier = mult_map.get(mult)
+    if not qualifier:
+        return unit_name
+
+    if not unit_name:
+        return qualifier
+
+    unit_norm = unit_name.strip().lower()
+    is_people = (unit_code and unit_code.upper() == "PS") or (unit_norm in ("persons", "people"))
+    if is_people:
+        return f"{qualifier} people"
+
+    return f"{qualifier} {unit_name}"
 
 
 def _obs_value_to_float(val: Any) -> float | None:
@@ -2177,8 +2211,10 @@ async def get_data(
             unit_measure = row.get("UNIT_MEASURE")
             if unit_measure:
                 unit_label = _cm.get_label("UNIT_MEASURE", str(unit_measure))
-                if unit_label and unit_label != str(unit_measure):
-                    row["UNIT_MEASURE_NAME"] = unit_label
+                unit_name = unit_label if unit_label else str(unit_measure)
+                qualified_unit = _qualify_unit_name(unit_name, row.get("UNIT_MULT"), str(unit_measure))
+                if qualified_unit:
+                    row["UNIT_MEASURE_NAME"] = qualified_unit
 
         # Promote COMMENT_TS to metadata (repeats identically per row)
         if raw_data and api_metadata is not None:

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -500,8 +500,12 @@ async def _fetch_single_indicator(
 
         from data360.api import _qualify_unit_name
         has_mapping = bool(resolved_label or unit)
-        if raw_unit_mult > 0 or has_mapping:
+        is_special_ps = bool(raw_unit and raw_unit.upper() == "PS" and raw_unit_mult > 0)
+        if has_mapping or is_special_ps:
             unit = _qualify_unit_name(unit_name, raw_unit_mult, raw_unit)
+        else:
+            unit = None
+
     except Exception as e:
         _logger.warning(f"Could not qualify unit for {indicator_id}: {e}")
 
@@ -1426,9 +1430,11 @@ async def get_viz_spec(
             raw_unit_label = _resolved if has_mapping else ""
 
             from data360.api import _qualify_unit_name
-            if raw_unit_mult > 0 or has_mapping:
+            is_special_ps = bool(raw_unit and raw_unit.upper() == "PS" and raw_unit_mult > 0)
+            if has_mapping or is_special_ps:
                 unit_name = raw_unit_label if raw_unit_label else raw_unit
                 raw_unit_label = _qualify_unit_name(unit_name, raw_unit_mult, raw_unit) or ""
+
     except Exception:
         pass  # No label; y-axis will have no title rather than a raw code
 

--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -470,6 +470,41 @@ async def _fetch_single_indicator(
     except Exception as e:
         _logger.warning(f"Could not fetch metadata for {indicator_id}: {e}")
 
+    # Qualify unit using unit_mult if present
+    raw_unit = ""
+    raw_unit_mult = 0
+    if not df.empty:
+        if "unit_measure" in df.columns:
+            _units = df["unit_measure"].dropna().unique().tolist()
+            if len(_units) == 1:
+                raw_unit = _units[0]
+        if "unit_mult" in df.columns:
+            _mults = df["unit_mult"].dropna().unique().tolist()
+            if len(_mults) == 1:
+                try:
+                    raw_unit_mult = int(_mults[0])
+                except (ValueError, TypeError):
+                    pass
+
+    try:
+        from data360.providers import get_codelist_manager
+        _cl_mgr = get_codelist_manager()
+        await _cl_mgr._ensure_extdataportal_loaded()
+
+        resolved_label = ""
+        if raw_unit:
+            _resolved = _cl_mgr.get_label("UNIT_MEASURE", raw_unit)
+            resolved_label = _resolved if _resolved != raw_unit else ""
+
+        unit_name = resolved_label or unit or raw_unit
+
+        from data360.api import _qualify_unit_name
+        has_mapping = bool(resolved_label or unit)
+        if raw_unit_mult > 0 or has_mapping:
+            unit = _qualify_unit_name(unit_name, raw_unit_mult, raw_unit)
+    except Exception as e:
+        _logger.warning(f"Could not qualify unit for {indicator_id}: {e}")
+
     return df, title, unit
 
 
@@ -1371,6 +1406,15 @@ async def get_viz_spec(
     # no mapping exists and we suppress the label (show nothing rather than a raw
     # code like "PS" or a freeform metadata string like "Unit").
     raw_unit_label: str = ""
+    raw_unit_mult = 0
+    if "unit_mult" in data.columns:
+        _data_mults = data["unit_mult"].dropna().unique().tolist()
+        if len(_data_mults) == 1:
+            try:
+                raw_unit_mult = int(_data_mults[0])
+            except (ValueError, TypeError):
+                pass
+
     try:
         from data360.providers import get_codelist_manager
 
@@ -1378,7 +1422,13 @@ async def get_viz_spec(
         if raw_unit:
             _resolved = _cl_mgr.get_label("UNIT_MEASURE", raw_unit)
             # Only use the resolved label if get_label actually found a mapping.
-            raw_unit_label = _resolved if _resolved != raw_unit else ""
+            has_mapping = _resolved != raw_unit
+            raw_unit_label = _resolved if has_mapping else ""
+
+            from data360.api import _qualify_unit_name
+            if raw_unit_mult > 0 or has_mapping:
+                unit_name = raw_unit_label if raw_unit_label else raw_unit
+                raw_unit_label = _qualify_unit_name(unit_name, raw_unit_mult, raw_unit) or ""
     except Exception:
         pass  # No label; y-axis will have no title rather than a raw code
 

--- a/tests/test_prefiltering.py
+++ b/tests/test_prefiltering.py
@@ -44,13 +44,13 @@ class TestStripDataRow:
         return row
 
     def test_core_fields_only(self):
-        """Test that trivial disaggregation returns only 5 core fields."""
-        EXPECTED_FIELD_COUNT = 5
+        """Test that trivial disaggregation returns only 6 core fields."""
+        EXPECTED_FIELD_COUNT = 6
         row = self._make_full_row()
         result = _strip_data_row(row)
         assert len(result) == EXPECTED_FIELD_COUNT
         assert set(result.keys()) == {
-            "OBS_VALUE", "TIME_PERIOD", "REF_AREA", "UNIT_MEASURE", "claim_id",
+            "OBS_VALUE", "TIME_PERIOD", "REF_AREA", "UNIT_MEASURE", "UNIT_MULT", "claim_id",
         }
 
     def test_preserves_sex(self):
@@ -94,7 +94,7 @@ class TestStripDataRow:
         row = self._make_full_row()
         result = _strip_data_row(row)
         boilerplate = {
-            "TIME_FORMAT", "UNIT_MULT", "COMMENT_OBS", "OBS_STATUS", "OBS_CONF",
+            "TIME_FORMAT", "COMMENT_OBS", "OBS_STATUS", "OBS_CONF",
             "AGG_METHOD", "DECIMALS", "COMMENT_TS", "DATA_SOURCE", "LATEST_DATA",
             "DATABASE_ID", "INDICATOR", "FREQ", "UNIT_TYPE", "COMP_BREAKDOWN_3",
         }
@@ -409,3 +409,61 @@ class TestGetDataDisaggregationIndependence:
         assert result.error is None
         assert result.data is not None
         assert len(result.data) == 1
+
+
+class TestUnitMeasureQualification:
+    """Tests for unit measure qualification using UNIT_MULT."""
+
+    def test_qualify_unit_name_helper(self):
+        """Test _qualify_unit_name helper function directly."""
+        from data360.api import _qualify_unit_name
+
+        # Test PS (Persons/people) with UNIT_MULT=6 (million)
+        assert _qualify_unit_name("Persons", 6, "PS") == "million people"
+        assert _qualify_unit_name("people", 6, "PS") == "million people"
+        assert _qualify_unit_name(None, 6, "PS") == "million"
+
+        # Test other units and multipliers
+        assert _qualify_unit_name("US Dollars", 6, "USD") == "million US Dollars"
+        assert _qualify_unit_name("US Dollars", 3, "USD") == "thousand US Dollars"
+        assert _qualify_unit_name("US Dollars", 9, "USD") == "billion US Dollars"
+        assert _qualify_unit_name("US Dollars", 0, "USD") == "US Dollars"
+        assert _qualify_unit_name("US Dollars", None, "USD") == "US Dollars"
+        assert _qualify_unit_name("US Dollars", "invalid", "USD") == "US Dollars"
+
+    @pytest.mark.asyncio
+    async def test_get_data_qualifies_unit_measure_name(self, httpx_mock: pytest_httpx.HTTPXMock):
+        """Test that get_data qualifies UNIT_MEASURE_NAME using UNIT_MULT."""
+        mock_data_response = {
+            "value": [{
+                "OBS_VALUE": "86.0392",
+                "TIME_PERIOD": "2022",
+                "REF_AREA": "NGA",
+                "UNIT_MEASURE": "PS",
+                "UNIT_MULT": 6,
+                "SEX": "_T",
+                "AGE": "_T",
+                "URBANISATION": "_T",
+            }],
+        }
+        httpx_mock.add_response(
+            method="POST", url="https://api.test.example.com/metadata",
+            json={"value": [{"series_description": {"idno": "WB_PIP_NPOOR_IPL"}}]},
+        )
+        httpx_mock.add_response(
+            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": [{"field_name": "REF_AREA", "field_value": [{"code": "NGA"}]}]},
+        )
+        httpx_mock.add_response(
+            method="GET", url=re.compile(r".*/data\\?.*"),
+            json=mock_data_response,
+        )
+        result = await get_data("WB_PIP", "WB_PIP_NPOOR_IPL")
+        assert result.error is None
+        assert result.data is not None
+        assert len(result.data) == 1
+        row = result.data[0]
+        # UNIT_MULT should be preserved
+        assert row["UNIT_MULT"] == 6
+        # UNIT_MEASURE_NAME should be qualified as "million people" instead of "Persons"
+        assert row["UNIT_MEASURE_NAME"] == "million people"

--- a/tests/test_prefiltering.py
+++ b/tests/test_prefiltering.py
@@ -467,3 +467,39 @@ class TestUnitMeasureQualification:
         assert row["UNIT_MULT"] == 6
         # UNIT_MEASURE_NAME should be qualified as "million people" instead of "Persons"
         assert row["UNIT_MEASURE_NAME"] == "million people"
+
+    @pytest.mark.asyncio
+    async def test_get_data_preserves_unmapped_unit_measure_name_without_multiplier(self, httpx_mock: pytest_httpx.HTTPXMock):
+        """Test that get_data does not overwrite UNIT_MEASURE_NAME if no mapping exists and UNIT_MULT is 0."""
+        mock_data_response = {
+            "value": [{
+                "OBS_VALUE": "86.0392",
+                "TIME_PERIOD": "2022",
+                "REF_AREA": "NGA",
+                "UNIT_MEASURE": "XYZ",
+                "UNIT_MEASURE_NAME": "Descriptive XYZ Label",
+                "UNIT_MULT": 0,
+                "SEX": "_T",
+                "AGE": "_T",
+                "URBANISATION": "_T",
+            }],
+        }
+        httpx_mock.add_response(
+            method="POST", url="https://api.test.example.com/metadata",
+            json={"value": [{"series_description": {"idno": "WB_PIP_NPOOR_IPL"}}]},
+        )
+        httpx_mock.add_response(
+            method="POST", url=re.compile(r".*/portal/v1/dimensions.*"),
+            json={"dimensions": [{"field_name": "REF_AREA", "field_value": [{"code": "NGA"}]}]},
+        )
+        httpx_mock.add_response(
+            method="GET", url=re.compile(r".*/data\\?.*"),
+            json=mock_data_response,
+        )
+        result = await get_data("WB_PIP", "WB_PIP_NPOOR_IPL")
+        assert result.error is None
+        assert result.data is not None
+        assert len(result.data) == 1
+        row = result.data[0]
+        # UNIT_MEASURE_NAME should be preserved as "Descriptive XYZ Label" instead of being overwritten with raw code "XYZ"
+        assert row["UNIT_MEASURE_NAME"] == "Descriptive XYZ Label"

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -723,3 +723,62 @@ class TestChartTypeOverrideWarning:
             chart_title=f"Fake {requested_chart}",
         )
         assert "warning" not in result or result["warning"] is None
+
+
+class TestVisualizationUnitQualification:
+    """Tests for unit qualification and suppression in visualization pipelines."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_single_indicator_suppresses_unmapped_unit(self):
+        """Verify that an unmapped unit measure (other than PS) is suppressed (None) in visualizations."""
+        df = pd.DataFrame({
+            "TIME_PERIOD": ["2020", "2021"],
+            "OBS_VALUE": [100.0, 200.0],
+            "REF_AREA": ["KEN", "KEN"],
+            "unit_measure": ["XYZ", "XYZ"],
+            "unit_mult": ["6", "6"],
+        })
+
+        with (
+            patch("data360.api.get_data_api_url", new_callable=AsyncMock, return_value="http://fake-api/data?DATABASE_ID=WB_WDI&INDICATOR=FAKE"),
+            patch("data360.visualization._fetch_data_internal", new_callable=AsyncMock, return_value=df),
+            patch("data360.api.get_metadata", new_callable=AsyncMock, return_value=None),
+        ):
+            from data360.visualization import _fetch_single_indicator
+            _, _, unit = await _fetch_single_indicator(
+                database_id="WB_WDI",
+                indicator_id="FAKE_IND",
+                country_code=None,
+                start_year=None,
+                end_year=None,
+                disaggregation_filters=None,
+            )
+            # XYZ is unmapped and not PS, so it must be suppressed to None
+            assert unit is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_single_indicator_qualifies_unmapped_ps(self):
+        """Verify that the unmapped special case PS is qualified to 'million people'."""
+        df = pd.DataFrame({
+            "TIME_PERIOD": ["2020", "2021"],
+            "OBS_VALUE": [100.0, 200.0],
+            "REF_AREA": ["KEN", "KEN"],
+            "unit_measure": ["PS", "PS"],
+            "unit_mult": ["6", "6"],
+        })
+
+        with (
+            patch("data360.api.get_data_api_url", new_callable=AsyncMock, return_value="http://fake-api/data?DATABASE_ID=WB_WDI&INDICATOR=FAKE"),
+            patch("data360.visualization._fetch_data_internal", new_callable=AsyncMock, return_value=df),
+            patch("data360.api.get_metadata", new_callable=AsyncMock, return_value=None),
+        ):
+            from data360.visualization import _fetch_single_indicator
+            _, _, unit = await _fetch_single_indicator(
+                database_id="WB_WDI",
+                indicator_id="FAKE_IND",
+                country_code=None,
+                start_year=None,
+                end_year=None,
+                disaggregation_filters=None,
+            )
+            assert unit == "million people"


### PR DESCRIPTION
### Problem / Issue
This PR resolves #118.
The Data360 API returns values that are already scaled by `UNIT_MULT` (e.g., population headcount is returned as `86.0392` instead of `86,039,200` with `UNIT_MULT = 6` representing million). Without qualifying the unit labels, numeric value interpretations are ambiguous (e.g., displaying `86.0` on charts/responses instead of clarifying it as `86.0 million people`).

### Approach / Solution
We implement unit label qualification rather than modifying the raw numeric `OBS_VALUE` floats:
1. **Preserve `UNIT_MULT`**: Added `"UNIT_MULT"` to the prefiltering core fields (`_CORE_FIELDS` in `src/data360/api.py`), keeping it in row dictionaries so downstream consumers can inspect it.
2. **Qualify unit measure name**: Added a `_qualify_unit_name` helper function in `src/data360/api.py` that maps `UNIT_MULT` to its English scaling terms (`thousand`, `million`, `billion`, `trillion`) and qualifies the unit name. For `UNIT_MEASURE="PS"` (persons/people), it formats as `"million people"`.
3. **Integrate in data fetch**: Updated `get_data` to automatically qualify `UNIT_MEASURE_NAME` before returning data rows.

### Propagation to Visualizations and Other Tools
1. **Visualization Pipelines**:
   - In `get_viz_spec` and `_fetch_single_indicator` inside `src/data360/visualization.py`, we extract `unit_mult` and qualify `raw_unit_label`.
   - This automatically propagates the qualified unit (e.g. `"million people"`) to y-axis titles, subtitles, and legend labels in both single and multi-indicator charts.
2. **MCP Tool Responses**:
   - By updating the prefiltering and resolving steps in `get_data`, any downstream client or LLM consuming the MCP tools receives the qualified `UNIT_MEASURE_NAME` (e.g. `{"OBS_VALUE": 86.0392, "UNIT_MEASURE_NAME": "million people", "UNIT_MULT": 6}`), avoiding any ambiguity.

### Verification
- Added comprehensive unit tests in `tests/test_prefiltering.py` verifying the helper output and integration within `get_data`.
- All 826 tests pass successfully (`uv run pytest`).
