### PR TITLE
fix(viz): apply post-processing rules to strategy specs to fix year gaps and axes

### DIFF
--- a/src/data360/visualization.py
+++ b/src/data360/visualization.py
@@ -1507,6 +1507,22 @@ async def get_viz_spec(
             x_label="Value",
             unit_measure=_unit_measure_for_formatting(raw_unit, raw_unit_label),
         )
+        # Apply post-processing rules
+        for rule in viz_config.POST_PROCESSING_RULES:
+            spec = rule.apply(
+                spec,
+                data_frequency=data_frequency,
+                unit_measure=_unit_measure_for_formatting(raw_unit, raw_unit_label),
+            )
+
+        out_reason = strategy_result.reason
+        if strategy_result.strategy == viz_config.ChartStrategy.TEMPORAL_SINGLE:
+            resolved_mark = viz_config.extract_top_level_mark_type(spec)
+            if resolved_mark:
+                out_reason = viz_config.patch_strategy_reason_chart_phrase(
+                    strategy_result.reason, resolved_mark
+                )
+
         dim_summary = _extract_dimension_summary(viz_data)
         data_summary = _build_data_summary(viz_data)
 
@@ -1542,7 +1558,7 @@ async def get_viz_spec(
             warning=warning_msg,
             source_attribution=source_attribution,
             strategy=strategy_result.strategy.value,
-            reason=strategy_result.reason,
+            reason=out_reason,
             dimensions=dim_summary or None,
             data_summary=data_summary or None,
         )
@@ -1962,6 +1978,24 @@ async def get_multi_indicator_viz_spec(
         "indicator_name": indicator_display_multi,
     }
 
+    # Apply post-processing rules
+    for rule in viz_config.POST_PROCESSING_RULES:
+        spec = rule.apply(
+            spec,
+            data_frequency=None,
+            unit_measure=_unit_measure_for_formatting(
+                shared_unit_raw, shared_unit_label
+            ),
+        )
+
+    out_reason = strategy_result.reason
+    if strategy_result.strategy == viz_config.ChartStrategy.TEMPORAL_SINGLE:
+        resolved_mark = viz_config.extract_top_level_mark_type(spec)
+        if resolved_mark:
+            out_reason = viz_config.patch_strategy_reason_chart_phrase(
+                strategy_result.reason, resolved_mark
+            )
+
     url = await _store_spec(spec)
 
     warning_msg = None
@@ -1996,5 +2030,5 @@ async def get_multi_indicator_viz_spec(
         warning=warning_msg,
         source_attribution=source_attribution_multi,
         strategy=strategy_result.strategy.value,
-        reason=strategy_result.reason,
+        reason=out_reason,
     )

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -102,6 +102,45 @@ class TestGetVizSpecStrategyDispatch:
         assert result["url"] is None
         assert result["error"] is not None
 
+    @pytest.mark.asyncio
+    async def test_get_viz_spec_applies_post_processing_rules(self, patches):
+        """get_viz_spec should automatically apply post-processing rules (e.g. LineYearGapStrokeDashRule)."""
+        df_gap = pd.DataFrame(
+            {
+                "TIME_PERIOD": ["2020-01-01", "2023-01-01"],
+                "OBS_VALUE": [100.0, 300.0],
+                "REF_AREA": ["KEN", "KEN"],
+            }
+        )
+
+        captured_spec = {}
+        def fake_save(spec):
+            captured_spec["spec"] = spec
+            return "http://localhost:8021/static/viz_specs/test.json"
+
+        with (
+            patch(
+                "data360.visualization._fetch_data_internal",
+                new_callable=AsyncMock,
+                return_value=df_gap,
+            ),
+            patch(
+                "data360.visualization.save_specs_to_static",
+                side_effect=fake_save,
+            )
+        ):
+            result = await get_viz_spec(
+                database_id="WB_WDI",
+                indicator_id="FAKE_IND",
+            )
+
+        assert result["error"] is None
+        spec = captured_spec.get("spec")
+        assert spec is not None
+        assert "strokeDash" in spec["encoding"]
+        assert spec["encoding"]["detail"]["field"] == "_d360_lseg"
+
+
 
 # =============================================================================
 # New tests for improvements: MCP-002, MCP-003, MCP-004 + WB style + null guard


### PR DESCRIPTION
This PR re-integrates the post-processing rules loop (which was removed in the visualization revamp) to correctly apply gap-dashed segmentation and discrete bar axes.

<img width="697" height="537" alt="image" src="https://github.com/user-attachments/assets/3f0bbc24-a273-4877-aae1-4c6cf874750e" />
