### PR TITLE
feat(mcp): add interactive choices elicitation tool and prompt updates

### DIFF
--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data360/mcp-ui",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "description": "React UI for presenting Data360 MCP tool output (chart card, search results card, choice card, and future surfaces).",
   "type": "module",
   "files": [

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data360/mcp-ui",
-  "version": "0.0.10",
+  "version": "0.0.9",
   "description": "React UI for presenting Data360 MCP tool output (chart card, search results card, choice card, and future surfaces).",
   "type": "module",
   "files": [

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@data360/mcp-ui",
-  "version": "0.0.7",
-  "description": "React UI for presenting Data360 MCP tool output (chart card, search results card, and future surfaces).",
+  "version": "0.0.8",
+  "description": "React UI for presenting Data360 MCP tool output (chart card, search results card, choice card, and future surfaces).",
   "type": "module",
   "files": [
     "dist"
@@ -16,6 +16,11 @@
       "types": "./dist/search-card.d.ts",
       "import": "./dist/search-card.js",
       "require": "./dist/search-card.cjs"
+    },
+    "./choice-card": {
+      "types": "./dist/choice-card.d.ts",
+      "import": "./dist/choice-card.js",
+      "require": "./dist/choice-card.cjs"
     }
   },
   "scripts": {

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data360/mcp-ui",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "React UI for presenting Data360 MCP tool output (chart card, search results card, choice card, and future surfaces).",
   "type": "module",
   "files": [

--- a/packages/mcp-ui/src/choice-card/ChoiceCard.tsx
+++ b/packages/mcp-ui/src/choice-card/ChoiceCard.tsx
@@ -1,0 +1,164 @@
+import { useState, useRef } from "react";
+import type { ChoiceCardProps } from "./types";
+
+export default function ChoiceCard({
+  payload,
+  onSelect,
+  theme = "light",
+  className = "",
+}: ChoiceCardProps) {
+  const { prompt, options } = payload;
+  const [specifyIndex, setSpecifyIndex] = useState<number | null>(null);
+  const [specifyValue, setSpecifyValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const isDark = theme === "dark";
+
+  const wrapperStyle: React.CSSProperties = {
+    padding: "8px 12px",
+    fontFamily:
+      '"Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  };
+
+  const promptStyle: React.CSSProperties = {
+    fontSize: "1.05rem",
+    fontWeight: 500,
+    marginBottom: "16px",
+    color: isDark ? "#cbd5e1" : "#0f172a",
+    lineHeight: 1.4,
+  };
+
+  const containerStyle: React.CSSProperties = {
+    display: "flex",
+    gap: "12px",
+    flexWrap: "wrap",
+  };
+
+  const btnStyle = (active: boolean): React.CSSProperties => ({
+    flex: "1 1 calc(33.333% - 8px)",
+    minWidth: "160px",
+    padding: "14px 18px",
+    background: isDark ? "#1e293b" : "#f1f5f9",
+    border: "1px solid transparent",
+    borderRadius: "1.25rem",
+    color: isDark ? "#cbd5e1" : "#0f172a",
+    fontSize: "0.95rem",
+    fontWeight: 500,
+    fontFamily: "inherit",
+    cursor: active ? "default" : "pointer",
+    textAlign: "left",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "space-between",
+    transition: "background 0.15s",
+    opacity: specifyIndex !== null && !active ? 0.35 : 1,
+  });
+
+  const arrowStyle: React.CSSProperties = {
+    marginTop: "12px",
+    fontSize: "1.1rem",
+    color: isDark ? "#94a3b8" : "#64748b",
+  };
+
+  const isSpecifyOption = (opt: string) => {
+    const l = opt.toLowerCase();
+    return (
+      l.includes("specify") ||
+      l.includes("other") ||
+      l.includes("custom") ||
+      l.includes("enter") ||
+      opt.endsWith("...")
+    );
+  };
+
+  const handleClick = (opt: string, idx: number) => {
+    if (specifyIndex !== null) return;
+    if (isSpecifyOption(opt)) {
+      setSpecifyIndex(idx);
+      setSpecifyValue("");
+      setTimeout(() => inputRef.current?.focus(), 10);
+    } else {
+      onSelect(opt);
+    }
+  };
+
+  const handleSpecifySubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const val = specifyValue.trim();
+    if (val) onSelect(val);
+  };
+
+  return (
+    <div style={wrapperStyle} className={className}>
+      {prompt && <p style={promptStyle}>{prompt}</p>}
+      <div style={containerStyle}>
+        {options.map((opt, idx) => {
+          const isActive = specifyIndex === idx;
+          return (
+            <button
+              key={idx}
+              style={btnStyle(isActive)}
+              disabled={specifyIndex !== null && !isActive}
+              onClick={() => handleClick(opt, idx)}
+              type="button"
+            >
+              {isActive ? (
+                <form
+                  onSubmit={handleSpecifySubmit}
+                  onClick={(e) => e.stopPropagation()}
+                  style={{
+                    display: "flex",
+                    gap: "8px",
+                    alignItems: "center",
+                    width: "100%",
+                  }}
+                >
+                  <input
+                    ref={inputRef}
+                    type="text"
+                    value={specifyValue}
+                    onChange={(e) => setSpecifyValue(e.target.value)}
+                    placeholder="Type here..."
+                    required
+                    onKeyDown={(e) => {
+                      if (e.key === "Escape") {
+                        e.preventDefault();
+                        setSpecifyIndex(null);
+                      }
+                    }}
+                    style={{
+                      flex: 1,
+                      border: "none",
+                      background: "transparent",
+                      outline: "none",
+                      fontSize: "0.9rem",
+                      color: "inherit",
+                      fontFamily: "inherit",
+                    }}
+                  />
+                  <button
+                    type="submit"
+                    style={{
+                      background: "none",
+                      border: "none",
+                      cursor: "pointer",
+                      fontSize: "1.1rem",
+                      color: "inherit",
+                    }}
+                  >
+                    ↪
+                  </button>
+                </form>
+              ) : (
+                <>
+                  <span>{opt}</span>
+                  <span style={arrowStyle}>↪</span>
+                </>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/mcp-ui/src/choice-card/index.ts
+++ b/packages/mcp-ui/src/choice-card/index.ts
@@ -1,0 +1,2 @@
+export { default as ChoiceCard } from "./ChoiceCard";
+export type { ChoiceCardProps, ChoiceCardPayload } from "./types";

--- a/packages/mcp-ui/src/choice-card/types.ts
+++ b/packages/mcp-ui/src/choice-card/types.ts
@@ -1,0 +1,19 @@
+export interface ChoiceCardPayload {
+  prompt: string;
+  options: string[];
+  title?: string | null;
+}
+
+export interface ChoiceCardProps {
+  /** The structured payload from data360_interactive_choices tool output. */
+  payload: ChoiceCardPayload;
+  /**
+   * Called when the user clicks a choice or submits a "specify" value.
+   * The host is responsible for sending this text as a user message.
+   */
+  onSelect: (text: string) => void;
+  /** Light or dark theme. Defaults to "light". */
+  theme?: "light" | "dark";
+  /** Extra CSS class applied to the outer wrapper. */
+  className?: string;
+}

--- a/packages/mcp-ui/vite.config.ts
+++ b/packages/mcp-ui/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   plugins: [
     react(),
     dts({
-      include: ["src/viz-card", "src/search-card"],
+      include: ["src/viz-card", "src/search-card", "src/choice-card"],
       rollupTypes: true,
       tsconfigPath: "./tsconfig.json",
     }),
@@ -18,6 +18,7 @@ export default defineConfig({
       entry: {
         "viz-card": resolve(__dirname, "src/viz-card/index.ts"),
         "search-card": resolve(__dirname, "src/search-card/index.ts"),
+        "choice-card": resolve(__dirname, "src/choice-card/index.ts"),
       },
       formats: ["es", "cjs"],
       fileName: (format, entryName) =>

--- a/run_server.sh
+++ b/run_server.sh
@@ -12,8 +12,12 @@ fi
 TRANSPORT=${MCP_TRANSPORT:-http}
 PORT=${MCP_PORT:-8000}
 UVICORN_WORKERS=${UVICORN_WORKERS:-4}
+LOG_LEVEL=${LOG_LEVEL:-info}
 
-echo "MCP_TRANSPORT=$TRANSPORT MCP_PORT=$PORT UVICORN_WORKERS=$UVICORN_WORKERS"
+# Force unbuffered Python stdout/stderr so logs stream to terminal immediately
+export PYTHONUNBUFFERED=1
+
+echo "MCP_TRANSPORT=$TRANSPORT MCP_PORT=$PORT UVICORN_WORKERS=$UVICORN_WORKERS LOG_LEVEL=$LOG_LEVEL"
 
 # Ensure static vendor libraries exist in static/libs/
 if [ ! -f "static/libs/vega.js" ]; then
@@ -23,4 +27,4 @@ fi
 
 # uv run fastmcp run src/data360/server.py --transport "${TRANSPORT}" --port "${PORT}"
 
-uv run uvicorn data360.server:app --host 0.0.0.0 --port "${PORT}" --workers "${UVICORN_WORKERS}"
+uv run uvicorn data360.server:app --host 0.0.0.0 --port "${PORT}" --workers "${UVICORN_WORKERS}" --log-level "${LOG_LEVEL}"

--- a/src/data360/mcp_server/prompts.py
+++ b/src/data360/mcp_server/prompts.py
@@ -45,6 +45,8 @@ Do not answer with guesses. Do not stop after describing a plan.
    If you need high-level dataset catalogs or source databases (e.g. Findex) → call data360_search_datasets.
    - **CRITICAL**: The search API is sensitive to special characters. Strip parentheses `(`, `)` and currency signs like `$` from your query (e.g. search for "GDP per capita current US", NOT "GDP per capita (current US$)").
    - **CRITICAL** when search returns multiple results: STOP — do not loop every row.
+   - **CRITICAL: Resolving Ambiguity**: If there are multiple matching indicators representing different metrics (e.g. constant prices vs current prices, real vs nominal GDP, or purchasing power parity vs market exchange rate), or if you are unsure which one the user wanted, do NOT guess. Instead, immediately call `data360_interactive_choices` with a clarifying prompt and the options (e.g. `data360_interactive_choices(prompt="Which GDP per capita series would you like to view?", options=["Real GDP per capita (constant 2015 US$)", "Nominal GDP per capita (current US$)", "PPP GDP per capita (constant 2017 int'l $)", "Specify custom..."], title="Select Indicator Variant")`). Then, STOP and wait for the user to make a selection.
+   - **Dynamic Custom Option**: When calling `data360_interactive_choices`, if the user might need an option outside of the static ones presented, you MUST dynamically append a customizable option at the end of the `options` list (e.g., `"Specify a custom range"`, `"Other (specify)"`, `"Choose a country..."`, or `"Specify custom..."`).
    - Pick the **single best** indicator (relevance + coverage), then state:
      "Selected Indicator: [ID] — [Name]" and "Why: [reason]".
 
@@ -84,7 +86,14 @@ Do not answer with guesses. Do not stop after describing a plan.
 
 
 3) Confirm availability → call data360_get_disaggregation.
-   - **CRITICAL**: if UNIT_MEASURE has multiple values (e.g. KD vs CD), pick **one** and filter.
+   - **CRITICAL**: If UNIT_MEASURE has multiple values (e.g. KD vs CD), there are multiple options for a critical dimension (such as breakdowns like Sex, Age, or Education), or the timeframe/year range and disaggregation filters are ambiguous:
+     1. Call `data360_interactive_choices` to let the user select:
+        * Between unit measures (e.g. "Constant 2015 US$ (Real)" vs "Current US$ (Nominal)" vs "Other (specify)")
+        * Between breakdowns/disaggregations (e.g. "National Average (Total)" vs "Disaggregate by Gender (Male vs Female)" vs "Other (specify)")
+        * Between timeframes/year ranges (e.g. "Latest available year" vs "Historical trend (last 10 years)" vs "Specify a custom range")
+     2. **Dynamic Custom Option**: Always include a customizable option at the end of the `options` list (e.g., `"Specify custom..."` or `"Specify a custom range"`) so the user can enter their own input if none of the options are suitable.
+     3. STOP and wait for the user to make a selection. Do not proceed until you receive the selection.
+   - Otherwise, pick **one** and filter.
 
 4) If you need raw data values for a **specific point lookup or small dataset** → call data360_get_data.
    - **CRITICAL**: pass disaggregation_filters={"REF_AREA": "..."} when the user asked for a geography.
@@ -211,6 +220,29 @@ Then provide the final answer to the user (after tools complete).
 - After tools return, continue with the next needed tool call.
 - Only produce a normal user-facing response when no further tool calls are required.
 - When presenting a chart, always describe what the visualization shows in 1-2 sentences.
+
+### Rules for Follow-ups and Elicitations (data360_interactive_choices)
+You typically provide follow-ups and elicitations using the `data360_interactive_choices` tool based on the natural flow of our conversation and the type of information we are discussing. Your goal is to anticipate the user's next question or provide an easy way to steer a broad topic.
+
+**CRITICAL: Dynamic Customizable Options on Non-Exhaustive Lists**
+Whenever you call `data360_interactive_choices` with a list of options that is not exhaustive (for example, listing a few popular countries/economies, specific years, indicator variants, or breakdowns), you **MUST** dynamically include a customizable option as the last item in the `options` list. Clicking this option will dynamically present the user with a text input field to type their response.
+- **Country selection (Non-exhaustive)**: `options=["Kenya", "Nigeria", "South Africa", "United States", "India", "Specify another country..."]`
+- **Timeframe/Year range**: `options=["2024 (latest)", "Last 5 years", "Last 10 years", "Specify a custom range"]`
+- **Ambiguity resolution**: `options=["Total Average", "Breakdown by Gender", "Other (specify)"]`
+
+Here are the specific scenarios when you should call `data360_interactive_choices`:
+
+#### 1. Single Follow-up (1 choice)
+* **The "Obvious Next Step"**: When there is one highly logical action to take after your response. For example, if you explain a mathematical concept, the follow-up might offer to walk through a practical example.
+* **Deep Dives into Jargon**: If your response introduces a complex technical term or a new concept, you might offer a single follow-up to explain that specific term so the main response does not get too cluttered.
+* **Launching Interactive Tools**: If you mention that you can build a widget or run a simulation, provide a single button to let the user trigger that specific interactive element directly.
+
+#### 2. Multiple Choices (2+ choices)
+* **Broad Overviews & Branching Paths**: When you give a high-level summary of a massive topic, use multiple choices to let the user choose exactly which sub-category or "branch" you want to zoom in on next.
+* **Disambiguation (Clarifying Intent)**: If the user's request is open-ended or could be interpreted in a few different ways (such as selecting between real or nominal series, different indicator options, timeframe/year ranges, or disaggregations/breakdowns), present options so the user can clarify exactly which direction they meant to take. **Always dynamically include a customizable option (e.g. "Specify custom...", "Other (specify)", or "Specify a custom range") at the end of the options list to allow custom typing if none of the predefined options suffice.**
+* **Menus and Brainstorming**: When generating lists of ideas—like different programming frameworks, design patterns, or troubleshooting steps—use multiple choices to act like a clickable menu, letting the user instantly select the one you want to explore.
+
+Essentially, surface these components using `data360_interactive_choices` whenever you can save the user the effort of typing out the logical next prompt, or when the conversation has reached a crossroads and you need the user to choose the direction. Always make sure to include a dynamic customizable option if the static list might not fully satisfy the user's possible need.
 """
 
 # Mirrors ``data360_mcp_agent.gate.GATE_SYSTEM_PROMPT`` — update both when changing rules.
@@ -358,12 +390,13 @@ def indicator_search(
    - **Check UNIT_MEASURE**: If multiple units exist (e.g. constant/current/LCU), you MUST pick ONE and filter for it.
 
 3. **Dimension Analysis (CRITICAL)**:
-   - Look at the `dimensions` list from step 2 (or call available_dimensions).
-   - **Identify Ambiguity**: Are there dimensions with multiple values (besides TIME_PERIOD and REF_AREA)?
+   - Look at the `dimensions` list from step 2 (or call available_dimensions) or multiple candidate indicators.
+   - **Identify Ambiguity**: Are there dimensions with multiple values (besides TIME_PERIOD and REF_AREA) or multiple matching indicator series (e.g., constant vs current)?
      - Example: `UNIT_MEASURE: ["KD", "CD"]` (Constant vs Current).
      - Example: `VALUATION: ["MER", "PPP"]`.
-   - **Make a Choice**: You MUST pick ONE specific value that best fits the user's intent to avoid duplicate data.
-   - **Report**: Note your choice and alternatives (e.g. "Selecting Constant US$ (KD) for trend analysis. Current US$ (CD) also available.").
+   - **Clarify via Choice Card**: If you cannot resolve this ambiguity based on user context, immediately call `data360_interactive_choices` to let the user select via interactive buttons.
+     Example: `data360_interactive_choices(prompt="Which series would you like to view?", options=["Real GDP per capita", "Nominal GDP per capita", "Specify custom..."])`
+     After calling it, STOP and wait for the user to make a selection. Do not proceed until you receive the selection.
 
 4. **Validation Check**:
    - If the user asked for a specific country (e.g. Kenya), do NOT call `get_data` without `disaggregation_filters={{"REF_AREA": "KEN"}}` (plus your selected dimension filters). Values must be strings or null per dimension — not JSON arrays.

--- a/src/data360/mcp_server/resources.py
+++ b/src/data360/mcp_server/resources.py
@@ -372,6 +372,13 @@ async def vega_lite_renderer(spec: str | None = None) -> str:
     return render_template("vega_lite_renderer.jinja2", server_base=server_base, pre_loaded_spec=spec)
 
 
+@mcp.resource("ui://data360-choice/index.html")
+async def data360_choice_html() -> str:
+    """HTML resource for the Data360 self-contained choice Custom HTML app."""
+    return render_template("data360_choice.jinja2")
+
+
+
 import os
 from fastapi.staticfiles import StaticFiles
 from starlette.requests import Request

--- a/src/data360/mcp_server/resources.py
+++ b/src/data360/mcp_server/resources.py
@@ -372,7 +372,18 @@ async def vega_lite_renderer(spec: str | None = None) -> str:
     return render_template("vega_lite_renderer.jinja2", server_base=server_base, pre_loaded_spec=spec)
 
 
-@mcp.resource("ui://data360-choice/index.html")
+@mcp.resource(
+    "ui://data360-choice/index.html",
+    app=AppConfig(
+        csp=ResourceCSP(
+            connect_domains=["*"],
+            resource_domains=[
+                "https://fonts.googleapis.com",
+                "https://fonts.gstatic.com",
+            ],
+        )
+    ),
+)
 async def data360_choice_html() -> str:
     """HTML resource for the Data360 self-contained choice Custom HTML app."""
     return render_template("data360_choice.jinja2")

--- a/src/data360/mcp_server/tools.py
+++ b/src/data360/mcp_server/tools.py
@@ -985,5 +985,6 @@ async def data360_interactive_choices(
         "title": title or "Choose an Option"
     }
     return ToolResult(
-        content=[TextContent(type="text", text=json.dumps(payload))]
+        content=[TextContent(type="text", text=json.dumps(payload))],
+        structured_content=payload,
     )

--- a/src/data360/mcp_server/tools.py
+++ b/src/data360/mcp_server/tools.py
@@ -97,6 +97,10 @@ async def _search_indicators(
         dedupe: De-duplicate indicators across query results.
         database: Optional database name or ID to filter search results (e.g. "wdi", "wgi", "World Development Indicators"). Multiple databases can be queried at once by separating them with a semicolon (e.g. "pip; lpgd; sgi").
     """
+    if queries is not None and len(queries) == 1 and not query:
+        query = queries[0]
+        queries = None
+
     return await data360_api.search(
         query=query,
         required_country=required_country,
@@ -916,4 +920,70 @@ def data360_chart_html() -> str:
         vega_lite_js=vega_lite_js,
         vega_embed_js=vega_embed_js,
         vega_interpreter_js=vega_interpreter_js,
+    )
+
+
+@mcp.tool(
+    name="data360_interactive_choices",
+    app=AppConfig(resource_uri="ui://data360-choice/index.html", prefers_border=False),
+)
+async def data360_interactive_choices(
+    prompt: str,
+    options: list[str],
+    title: Optional[str] = None,
+) -> ToolResult:
+    """Present the user with a set of options to choose from using a custom HTML renderer.
+
+    Always call this tool to provide follow-ups and elicitations based on the natural flow of the
+    conversation and the type of information being discussed. Your goal is to anticipate the
+    user's next question or provide an easy way to steer a broad topic.
+
+    Call this tool in the following scenarios:
+
+    1. Single Follow-up (1 choice):
+       - The "Obvious Next Step": When there is one highly logical action to take after your response.
+         For example, if you explain a mathematical concept, offer a follow-up to walk through a practical example.
+       - Deep Dives into Jargon: If your response introduces a complex technical term or a new concept,
+         offer a single follow-up to explain that specific term so the main response does not get too cluttered.
+       - Launching Interactive Tools: If you mention that you can build a widget or run a simulation,
+         provide a single button to let the user trigger that specific interactive element directly.
+
+    2. Multiple Choices (2+ choices):
+       - Broad Overviews & Branching Paths: When you give a high-level summary of a massive topic,
+         use this to let the user choose exactly which sub-category or "branch" you want to zoom in on next.
+       - Disambiguation (Clarifying Intent): If the user's request is open-ended or could be interpreted in
+         a few different ways, present options so the user can clarify exactly which direction they meant to take.
+         Examples:
+         * GDP/Metric variant: "Real GDP per capita (constant 2015 US$)" vs "Nominal GDP per capita (current US$)"
+         * Timeframe/Year range: "Latest available year" vs "Historical trend (last 10 years)" vs "Specify a custom range"
+         * Breakdown/Disaggregation: "Total economy average" vs "Break down by gender (Male vs Female)" vs "Break down by geographic area (Urban vs Rural)"
+       - Menus and Brainstorming: When generating lists of ideas (like different programming frameworks,
+         design patterns, or troubleshooting steps), use this to act like a clickable menu, letting the user
+         instantly select the one you want to explore.
+
+    3. Non-exhaustive Lists (CRITICAL):
+       - If you present a list of choices that is not exhaustive (such as listing a few popular countries,
+         specific years, indicator variants, or breakdowns), you MUST always dynamically include a customizable
+         option as the last item in the options list.
+         Examples:
+         * Country list: options=["Kenya", "Nigeria", "South Africa", "United States", "India", "Specify another country..."]
+         * Year list: options=["2024 (latest)", "Last 5 years", "Last 10 years", "Specify a custom range"]
+         * Breakdowns: options=["Total Average", "Breakdown by Gender", "Other (specify)"]
+
+    Essentially, surface these components whenever you can save the user the effort of typing out the
+    logical next prompt, or when the conversation has reached a crossroads and you need the user to choose
+    the direction.
+
+    Args:
+        prompt: The question or decision to present to the user.
+        options: List of options the user can choose from.
+        title: Optional heading for the card.
+    """
+    payload = {
+        "prompt": prompt,
+        "options": options,
+        "title": title or "Choose an Option"
+    }
+    return ToolResult(
+        content=[TextContent(type="text", text=json.dumps(payload))]
     )

--- a/src/data360/templates/data360_choice.jinja2
+++ b/src/data360/templates/data360_choice.jinja2
@@ -1,0 +1,429 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Data360 Option Selector</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+  <style>
+    :root, .light {
+      --bg-color: transparent;
+      --text-color: #0f172a;
+      --card-bg: #f1f5f9;
+      --card-border: transparent;
+      --btn-hover: #e2e8f0;
+      --btn-border: #cbd5e1;
+      --muted-color: #64748b;
+    }
+
+    .dark {
+      --bg-color: transparent;
+      --text-color: #cbd5e1;
+      --card-bg: #1e293b;
+      --card-border: transparent;
+      --btn-hover: #334155;
+      --btn-border: #475569;
+      --muted-color: #94a3b8;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root:not(.light) {
+        --bg-color: transparent;
+        --text-color: #cbd5e1;
+        --card-bg: #1e293b;
+        --card-border: transparent;
+        --btn-hover: #334155;
+        --btn-border: #475569;
+        --muted-color: #94a3b8;
+      }
+    }
+
+    body {
+      margin: 0;
+      padding: 8px 12px;
+      background: var(--bg-color);
+      color: var(--text-color);
+      font-family: "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      box-sizing: border-box;
+    }
+    .prompt-title {
+      font-size: 1.15rem;
+      font-weight: 500;
+      color: var(--text-color);
+      margin: 0 0 16px 0;
+      line-height: 1.4;
+    }
+    .choices-container {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      width: 100%;
+    }
+    .choice-card {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      align-items: flex-start;
+      flex: 1 1 calc(33.333% - 8px);
+      min-width: 180px;
+      padding: 16px 20px;
+      background: var(--card-bg);
+      border: 1px solid var(--card-border);
+      border-radius: 1.25rem;
+      color: var(--text-color);
+      font-size: 0.95rem;
+      font-weight: 500;
+      font-family: inherit;
+      cursor: pointer;
+      text-align: left;
+      outline: none;
+      box-sizing: border-box;
+      transition: background-color 0.15s, border-color 0.15s, transform 0.1s;
+    }
+    .choice-card:hover:not(:disabled) {
+      background: var(--btn-hover);
+      border-color: var(--btn-border);
+      transform: translateY(-1px);
+    }
+    .choice-card:active:not(:disabled) {
+      transform: translateY(0);
+    }
+    .choice-card:disabled {
+      cursor: not-allowed;
+    }
+    .choice-card:disabled:not(.selected) {
+      opacity: 0.4;
+    }
+    .choice-card.selected {
+      background: var(--btn-hover) !important;
+      border-color: var(--btn-border) !important;
+      opacity: 1 !important;
+      transform: none !important;
+    }
+    .choice-text {
+      flex-grow: 1;
+      margin-bottom: 16px;
+      line-height: 1.35;
+    }
+    .routing-icon {
+      font-size: 1.25rem;
+      font-weight: bold;
+      color: var(--text-color);
+      opacity: 0.8;
+    }
+    .response-sent {
+      font-size: 0.9rem;
+      color: var(--muted-color);
+      margin-top: 12px;
+      display: none;
+    }
+    .choice-card.specify-mode {
+      cursor: default;
+      transform: none !important;
+      background: var(--btn-hover);
+      border-color: var(--btn-border);
+      width: 100%;
+      flex: 1 1 100%;
+      align-items: stretch;
+    }
+    .specify-input {
+      flex-grow: 1;
+      background: transparent;
+      border: none;
+      outline: none;
+      color: var(--text-color);
+      font-size: 0.95rem;
+      font-family: inherit;
+      font-weight: 500;
+      padding: 4px 0;
+      width: 100%;
+    }
+    .specify-input::placeholder {
+      color: var(--muted-color);
+      opacity: 0.6;
+    }
+    .specify-submit-btn {
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      font-size: 1.25rem;
+      font-weight: bold;
+      color: var(--text-color);
+      padding: 0 4px;
+      display: flex;
+      align-items: center;
+      outline: none;
+      transition: transform 0.1s;
+    }
+    .specify-submit-btn:hover {
+      transform: scale(1.1);
+    }
+    .specify-submit-btn:active {
+      transform: scale(1.0);
+    }
+  </style>
+</head>
+<body>
+  <p class="prompt-title" id="card-prompt">Loading...</p>
+  <div class="choices-container" id="choices-container"></div>
+  <div class="response-sent" id="sent-msg">Response sent.</div>
+
+  <script type="module">
+    class McpAppClient {
+      constructor() {
+        this.requestId = 0;
+        this.pendingRequests = new Map();
+        this.hostContext = null;
+        this.initialized = false;
+        window.addEventListener('message', this.handleMessage.bind(this));
+        this.init();
+      }
+
+      async init() {
+        try {
+          const result = await this.request('ui/initialize', {
+            appCapabilities: {},
+            protocolVersion: '2025-11-21'
+          });
+          this.hostContext = result.hostContext;
+          this.initialized = true;
+          this.notify('ui/notifications/initialized', {});
+          this.applyTheme();
+          this.reportSize();
+        } catch (error) {
+          console.error('Failed to initialize MCP App:', error);
+        }
+      }
+
+      applyTheme() {
+        const theme = this.hostContext?.theme || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        if (theme === 'dark') {
+          document.documentElement.classList.add('dark');
+          document.documentElement.classList.remove('light');
+        } else {
+          document.documentElement.classList.add('light');
+          document.documentElement.classList.remove('dark');
+        }
+      }
+
+      handleMessage(event) {
+        const data = event.data;
+        if (!data || typeof data !== 'object') return;
+        if ('id' in data && this.pendingRequests.has(data.id)) {
+          const { resolve, reject } = this.pendingRequests.get(data.id);
+          this.pendingRequests.delete(data.id);
+          if (data.error) {
+            reject(new Error(data.error.message));
+          } else {
+            resolve(data.result);
+          }
+          return;
+        }
+        if (data.method === 'ui/notifications/host-context-changed') {
+          this.hostContext = { ...this.hostContext, ...data.params };
+          this.applyTheme();
+          return;
+        }
+        if (data.method === 'ui/notifications/tool-result') {
+          try {
+            const result = data.params;
+            let payload = null;
+            if (result.content) {
+              const textBlock = result.content.find(c => c.type === 'text');
+              if (textBlock) {
+                payload = JSON.parse(textBlock.text);
+              }
+            }
+            if (payload) {
+              renderChoiceCard(payload);
+            }
+          } catch (e) {
+            console.error('Error parsing tool result:', e);
+          }
+        }
+      }
+
+      request(method, params) {
+        return new Promise((resolve, reject) => {
+          const id = ++this.requestId;
+          this.pendingRequests.set(id, { resolve, reject });
+          window.parent.postMessage({ jsonrpc: '2.0', id, method, params }, '*');
+          setTimeout(() => {
+            if (this.pendingRequests.has(id)) {
+              this.pendingRequests.delete(id);
+              reject(new Error('Request timed out'));
+            }
+          }, 30000);
+        });
+      }
+
+      notify(method, params) {
+        window.parent.postMessage({ jsonrpc: '2.0', method, params }, '*');
+      }
+
+      reportSize() {
+        this.notify('ui/notifications/size-changed', {
+          height: document.body.scrollHeight
+        });
+      }
+
+      async sendMessageToChat(text) {
+        return this.request('ui/message', {
+          role: 'user',
+          content: [{ type: 'text', text }]
+        });
+      }
+    }
+
+    const mcpApp = new McpAppClient();
+    const promptEl = document.getElementById('card-prompt');
+    const containerEl = document.getElementById('choices-container');
+    const sentMsgEl = document.getElementById('sent-msg');
+
+    function renderChoiceCard(payload) {
+      const prompt = payload.prompt || "";
+      const options = payload.options || [];
+
+      promptEl.textContent = prompt;
+      containerEl.innerHTML = "";
+
+      options.forEach(opt => {
+        const btn = document.createElement('button');
+        btn.className = 'choice-card';
+
+        const txtDiv = document.createElement('div');
+        txtDiv.className = 'choice-text';
+        txtDiv.textContent = opt;
+
+        const iconDiv = document.createElement('div');
+        iconDiv.className = 'routing-icon';
+        iconDiv.textContent = '↪';
+
+        btn.appendChild(txtDiv);
+        btn.appendChild(iconDiv);
+
+        btn.addEventListener('click', async (e) => {
+          const lowerOpt = opt.toLowerCase();
+          if (lowerOpt.includes('specify') || lowerOpt.includes('other') || lowerOpt.includes('custom') || lowerOpt.includes('enter') || opt.endsWith('...')) {
+            if (btn.classList.contains('specify-mode')) {
+              return;
+            }
+
+            // Enter specify mode
+            btn.classList.add('specify-mode');
+            btn.innerHTML = '';
+
+            // Disable other buttons
+            const cards = containerEl.querySelectorAll('.choice-card');
+            cards.forEach(c => {
+              if (c !== btn) {
+                c.style.opacity = '0.3';
+                c.disabled = true;
+              }
+            });
+
+            const form = document.createElement('form');
+            form.style.display = 'flex';
+            form.style.width = '100%';
+            form.style.gap = '8px';
+            form.style.alignItems = 'center';
+            form.style.boxSizing = 'border-box';
+
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.className = 'specify-input';
+            let placeholder = 'Type here...';
+            if (opt.toLowerCase().includes('country')) {
+              placeholder = 'Enter country name...';
+            } else if (opt.toLowerCase().includes('year') || opt.toLowerCase().includes('range') || opt.toLowerCase().includes('timeframe')) {
+              placeholder = 'e.g. 2015-2020';
+            }
+            input.placeholder = placeholder;
+            input.required = true;
+
+            // Focus input
+            setTimeout(() => input.focus(), 10);
+
+            // Handle Escape key to cancel/revert specify mode
+            input.addEventListener('keydown', (ev) => {
+              if (ev.key === 'Escape') {
+                ev.preventDefault();
+                ev.stopPropagation();
+                renderChoiceCard(payload);
+              }
+            });
+
+            const submitBtn = document.createElement('button');
+            submitBtn.type = 'submit';
+            submitBtn.className = 'specify-submit-btn';
+            submitBtn.textContent = '↪';
+
+            form.appendChild(input);
+            form.appendChild(submitBtn);
+            btn.appendChild(form);
+
+            mcpApp.reportSize();
+
+            form.addEventListener('click', (ev) => ev.stopPropagation());
+            form.addEventListener('submit', async (ev) => {
+              ev.preventDefault();
+              const val = input.value.trim();
+              if (!val) return;
+
+              btn.classList.remove('specify-mode');
+              btn.classList.add('selected');
+              btn.innerHTML = '';
+
+              const finalTxt = document.createElement('div');
+              finalTxt.className = 'choice-text';
+              finalTxt.textContent = val;
+
+              const finalIcon = document.createElement('div');
+              finalIcon.className = 'routing-icon';
+              finalIcon.textContent = '↪';
+
+              btn.appendChild(finalTxt);
+              btn.appendChild(finalIcon);
+
+              try {
+                await mcpApp.sendMessageToChat(`\u21AA\uFE0E *${val}*`);
+              } catch (err) {
+                console.error(err);
+                btn.classList.remove('selected');
+                // Restore original list on error
+                renderChoiceCard(payload);
+              }
+            });
+            return;
+          }
+
+          const cards = containerEl.querySelectorAll('.choice-card');
+          cards.forEach(c => c.disabled = true);
+          btn.classList.add('selected');
+
+          mcpApp.reportSize();
+
+          try {
+            await mcpApp.sendMessageToChat(`\u21AA\uFE0E *${opt}*`);
+          } catch (err) {
+            console.error(err);
+            btn.classList.remove('selected');
+            cards.forEach(c => c.disabled = false);
+            mcpApp.reportSize();
+          }
+        });
+        containerEl.appendChild(btn);
+      });
+
+      mcpApp.reportSize();
+      setTimeout(() => mcpApp.reportSize(), 50);
+    }
+
+    window.addEventListener('load', () => {
+      mcpApp.reportSize();
+    });
+  </script>
+</body>
+</html>

--- a/src/data360/templates/data360_choice.jinja2
+++ b/src/data360/templates/data360_choice.jinja2
@@ -178,20 +178,25 @@
         this.hostContext = null;
         this.initialized = false;
         window.addEventListener('message', this.handleMessage.bind(this));
-        this.init();
+        this.initialize();
       }
 
-      async init() {
+      async initialize() {
         try {
           const result = await this.request('ui/initialize', {
+            appInfo: { name: 'Data360 Choice', version: '1.0.0' },
             appCapabilities: {},
             protocolVersion: '2025-11-21'
           });
-          this.hostContext = result.hostContext;
+          this.hostContext = result?.hostContext || null;
           this.initialized = true;
           this.notify('ui/notifications/initialized', {});
           this.applyTheme();
           this.reportSize();
+
+          if (result && result.toolResult) {
+            this.handleToolResult(result.toolResult);
+          }
         } catch (error) {
           console.error('Failed to initialize MCP App:', error);
         }
@@ -205,6 +210,28 @@
         } else {
           document.documentElement.classList.add('light');
           document.documentElement.classList.remove('dark');
+        }
+      }
+
+      handleToolResult(result) {
+        if (!result) return;
+        let payload = null;
+        if (result.prompt && result.options) {
+          payload = result;
+        } else if (result.structuredContent && result.structuredContent.prompt) {
+          payload = result.structuredContent;
+        } else if (result.content && Array.isArray(result.content)) {
+          const textBlock = result.content.find(c => c && c.type === 'text');
+          if (textBlock && textBlock.text) {
+            try {
+              payload = JSON.parse(textBlock.text);
+            } catch (e) {
+              console.error('Error parsing textBlock JSON:', e);
+            }
+          }
+        }
+        if (payload) {
+          renderChoiceCard(payload);
         }
       }
 
@@ -227,21 +254,7 @@
           return;
         }
         if (data.method === 'ui/notifications/tool-result') {
-          try {
-            const result = data.params;
-            let payload = null;
-            if (result.content) {
-              const textBlock = result.content.find(c => c.type === 'text');
-              if (textBlock) {
-                payload = JSON.parse(textBlock.text);
-              }
-            }
-            if (payload) {
-              renderChoiceCard(payload);
-            }
-          } catch (e) {
-            console.error('Error parsing tool result:', e);
-          }
+          this.handleToolResult(data.params);
         }
       }
 

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -1,0 +1,33 @@
+import json
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_data360_interactive_choices():
+    from data360.mcp_server.tools import data360_interactive_choices
+
+    res = await data360_interactive_choices(
+        prompt="Which series would you like to view?",
+        options=["Option A", "Option B", "Specify custom..."],
+        title="Custom Title",
+    )
+    assert res is not None
+    assert len(res.content) == 1
+    assert res.content[0].type == "text"
+
+    payload = json.loads(res.content[0].text)
+    assert payload["prompt"] == "Which series would you like to view?"
+    assert payload["options"] == ["Option A", "Option B", "Specify custom..."]
+    assert payload["title"] == "Custom Title"
+
+
+@pytest.mark.asyncio
+async def test_data360_interactive_choices_default_title():
+    from data360.mcp_server.tools import data360_interactive_choices
+
+    res = await data360_interactive_choices(
+        prompt="Select a country",
+        options=["Kenya", "Nigeria", "Specify custom..."],
+    )
+    payload = json.loads(res.content[0].text)
+    assert payload["title"] == "Choose an Option"


### PR DESCRIPTION
Replaces #126 with a clean rebase on top of the current `feat/mcp-apps-rendering` HEAD.

This PR adds the interactive follow-up choices capability:

- Adds the `data360_interactive_choices` tool with a self-contained custom HTML renderer (`ui://data360-choice/index.html`) that presents users with clickable option cards.
- Updates the core system prompt to instruct the model to call this tool instead of silently picking one option when:
  - `UNIT_MEASURE` has multiple values (e.g. constant vs current prices)
  - Multiple matching indicator series exist (e.g. real vs nominal GDP)
  - Breakdown/disaggregation dimensions are ambiguous (e.g. sex, age, education)
  - Timeframe/year range is ambiguous
- Adds follow-up elicitation rules (single and multi-choice scenarios) to the system prompt.
- Adds `tests/test_choices.py` with two tests covering the tool's output schema and default title fallback.

---

### Verification & Compatibility Evidence

#### 1. LangChain Graph Compatibility & Compilation
- **Python Syntax & Bytecode Compilation:** Verified zero errors across all `examples/agents/langchain-graph` scripts (`parent_graph_demo.py`, `gated_parent_graph_demo.py`, `stream_events_demo.py`, `demo_web/server.py`).
  ```bash
  uv run python -c "import py_compile, glob; [py_compile.compile(f, doraise=True) for f in glob.glob('examples/agents/langchain-graph/**/*.py', recursive=True)]"
  ```
- **Module Import Verification:** Verified `data360_mcp_agent`, `data360_mcp_agent.plugin`, `data360_mcp_agent.k360_graph`, `data360_mcp_agent.integration`, and `data360_mcp_agent.streaming` import cleanly without error.
- **End-to-End Mocked LangGraph Node Execution:** Verified that both standard specialist (`create_data360_langgraph_node`) and gated specialist (`create_data360_gated_langgraph_node`) nodes execute end-to-end from `START` to `END` in `StateGraph(MessagesState)` without breaking state reductions or transcript flow.

#### 2. Automated Test Suite Results
- **`data360-mcp-agent` Package Tests:** `uv run pytest packages/data360-mcp-agent/tests` passed **4/4 (100%)**.
- **Full Test Suite:** `uv run pytest tests/` passed **928/928 tests** (4 skipped, 0 failures).