### PR TITLE
Compatible with Cloudflare MCP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ DATA360_API_BASE_URL=https://data360api.worldbank.org
 # WEBSITE_HOSTNAME=http://127.0.0.1:8000
 MCP_PORT=8000  # use 8022 in dev
 MCP_TRANSPORT=http
+# Streamable HTTP /mcp returns JSON by default (compatible with strict proxies).
+# MCP_JSON_RESPONSE=true
 MCP_CHARTS_API_URL=https://localhost:8001/api/v1/charts
 MCP_CHARTS_API_TOKEN=replace-with-charts-write-token
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ cp .env.example .env
 | `DATA360_API_BASE_URL` | Base URL for the World Bank Data360 API | `https://data360api.worldbank.org` |
 | `MCP_PORT` | Port for the MCP server | `8000` |
 | `MCP_TRANSPORT` | Transport protocol (`http` or `sse`) | `http` |
+| `MCP_JSON_RESPONSE` | Streamable HTTP `/mcp` returns JSON (`true`) instead of SSE framing | `true` |
 | `MCP_CHARTS_API_URL` | Optional URL for an external chart rendering API | _(none)_ |
 
 ### Run the Server
@@ -101,6 +102,23 @@ uv run poe serve --port 8021 --transport sse
 | URL (http) | `http://localhost:8000/mcp` |
 | URL (sse) | `http://localhost:8021/sse` |
 | Docker / external | Replace `localhost` with `host.docker.internal` |
+
+`/mcp` defaults to JSON Streamable HTTP (`MCP_JSON_RESPONSE=true`) so proxies that reject `text/event-stream` Content-Length mismatches (for example Cloudflare) can complete `initialize` / `tools/list` / `tools/call`. Set `MCP_JSON_RESPONSE=false` to restore SSE-framed Streamable HTTP. Legacy SSE remains available via `--transport sse`.
+
+Registered tools are also callable as ordinary HTTP JSON (no MCP session):
+
+```bash
+curl -sS -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
+
+curl -sS -X POST http://localhost:8000/api/v1/tools/data360_search_indicators \
+  -H "Content-Type: application/json" \
+  -d '{"query":"GDP per capita","required_country":"KEN","limit":3}'
+```
+
+List tool names: `GET /api/v1/tools`.
 
 ### Try the Demo
 

--- a/src/data360/config.py
+++ b/src/data360/config.py
@@ -68,7 +68,15 @@ class MCPServerSettings(BaseSettings):
         default=5.0,
         description="Per-check timeout in seconds for GET /ready outbound probes.",
     )
-
+    json_response: bool = Field(
+        default=True,
+        description=(
+            "When true, Streamable HTTP /mcp returns application/json instead of "
+            "text/event-stream framing. JSON responses carry a valid Content-Length "
+            "and are compatible with strict proxies (e.g. Cloudflare). Set "
+            "MCP_JSON_RESPONSE=false to restore SSE-framed Streamable HTTP."
+        ),
+    )
 
     model_config = SettingsConfigDict(env_prefix="MCP_")
 

--- a/src/data360/http_tools.py
+++ b/src/data360/http_tools.py
@@ -1,0 +1,123 @@
+"""Standard HTTP routes that invoke registered MCP tools.
+
+These endpoints reuse the existing FastMCP tool registry (no duplicated Data360
+logic). Clients POST JSON arguments once and receive JSON — no SSE session.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from fastmcp.exceptions import NotFoundError, ToolError, ValidationError
+from pydantic import ValidationError as PydanticValidationError
+
+from data360.mcp_server import mcp
+
+_logger = logging.getLogger(__name__)
+
+# Standard HTTP route prefix for tool list and tool invocation.
+TOOLS_HTTP_PREFIX = "/api/v1/tools"
+
+tools_http_router = APIRouter()
+
+
+def serialize_tool_result(result: Any) -> Any:
+    """Turn a FastMCP ToolResult into a JSON-serializable payload."""
+    structured = getattr(result, "structured_content", None)
+    if structured is not None:
+        return structured
+
+    content = getattr(result, "content", None) or []
+    texts: list[str] = []
+    for block in content:
+        text = getattr(block, "text", None)
+        if text is not None:
+            texts.append(text)
+
+    if len(texts) == 1:
+        try:
+            return json.loads(texts[0])
+        except (json.JSONDecodeError, TypeError):
+            return {"result": texts[0]}
+
+    if texts:
+        parsed: list[Any] = []
+        for text in texts:
+            try:
+                parsed.append(json.loads(text))
+            except (json.JSONDecodeError, TypeError):
+                parsed.append(text)
+        return {"result": parsed}
+
+    return {}
+
+
+def _parse_tool_arguments(
+    body_bytes: bytes,
+) -> tuple[dict[str, Any] | None, JSONResponse | None]:
+    if not body_bytes:
+        return {}, None
+    try:
+        parsed_body = json.loads(body_bytes)
+    except json.JSONDecodeError:
+        return None, JSONResponse(
+            status_code=400,
+            content={"error": "Request body must be JSON."},
+        )
+    if not isinstance(parsed_body, dict):
+        return None, JSONResponse(
+            status_code=400,
+            content={"error": "Request body must be a JSON object."},
+        )
+    return parsed_body, None
+
+
+def _tool_error_text(result: Any) -> str:
+    content = getattr(result, "content", None) or []
+    for block in content:
+        text = getattr(block, "text", None)
+        if text:
+            return text
+    return "Tool execution failed."
+
+
+@tools_http_router.get(TOOLS_HTTP_PREFIX)
+async def list_tools_http() -> dict[str, list[str]]:
+    """Standard HTTP route: list registered MCP tool names."""
+    tools = await mcp.list_tools()
+    return {"tools": [t.name for t in tools]}
+
+
+@tools_http_router.post(f"{TOOLS_HTTP_PREFIX}/{{tool_name}}")
+async def call_tool_http(tool_name: str, request: Request) -> JSONResponse:
+    """Standard HTTP route: invoke one registered MCP tool and return JSON."""
+    arguments, error_response = _parse_tool_arguments(await request.body())
+    if error_response is not None:
+        return error_response
+
+    try:
+        result = await mcp.call_tool(tool_name, arguments or {})
+    except NotFoundError:
+        return JSONResponse(
+            status_code=404,
+            content={"error": f"Unknown tool: {tool_name}"},
+        )
+    except Exception as exc:
+        if isinstance(exc, (ToolError, ValidationError, PydanticValidationError)):
+            return JSONResponse(status_code=400, content={"error": str(exc)})
+        _logger.exception("Standard HTTP tool call failed: %s", tool_name)
+        return JSONResponse(
+            status_code=500,
+            content={"error": "Tool execution failed due to an internal error."},
+        )
+
+    if getattr(result, "is_error", False):
+        return JSONResponse(
+            status_code=400,
+            content={"error": _tool_error_text(result)},
+        )
+    return JSONResponse(content=serialize_tool_result(result))

--- a/src/data360/server.py
+++ b/src/data360/server.py
@@ -113,7 +113,25 @@ def _rest_tool_name(path: str) -> str | None:
     return name or None
 
 
-def _tool_security_error(tool_name: str, arguments: dict[str, Any]) -> str | None:
+def _rest_arguments_from_body(body_bytes: bytes) -> tuple[dict[str, Any], bool]:
+    """Parse REST tool arguments. Empty body is ``{}``; unparsed body is name-only."""
+    if not body_bytes:
+        return {}, True
+    try:
+        parsed = json.loads(body_bytes)
+    except json.JSONDecodeError:
+        return {}, False
+    if isinstance(parsed, dict):
+        return parsed, True
+    return {}, False
+
+
+def _tool_security_error(
+    tool_name: str,
+    arguments: dict[str, Any],
+    *,
+    validate_arguments: bool = True,
+) -> str | None:
     """Return a security error message, or None if the tool call is allowed."""
     from data360.mcp_server.security_validator import (  # noqa: PLC0415
         validate_search_arguments,
@@ -126,7 +144,7 @@ def _tool_security_error(tool_name: str, arguments: dict[str, Any]) -> str | Non
     is_valid, error_msg = validate_tool_call(tool_name, arguments)
     if not is_valid:
         return error_msg
-    if tool_name == "data360_search_indicators":
+    if validate_arguments and tool_name == "data360_search_indicators":
         is_valid, error_msg = validate_search_arguments(arguments)
         if not is_valid:
             return error_msg
@@ -160,19 +178,19 @@ class SecurityValidationMiddleware(BaseHTTPMiddleware):
         if not _is_tool_request_path(request.url.path):
             return await call_next(request)
 
+        rest_tool = _rest_tool_name(request.url.path)
+
         try:
-            # Read and parse body
             body_bytes = await request.body()
-            if not body_bytes:
-                return await call_next(request)
 
-            body = json.loads(body_bytes)
-            rest_tool = _rest_tool_name(request.url.path)
-
-            # Standard HTTP route: body is tool arguments (not JSON-RPC)
+            # REST tool calls must be validated even when the body is empty.
             if rest_tool is not None:
-                arguments = body if isinstance(body, dict) else {}
-                error_msg = _tool_security_error(rest_tool, arguments)
+                arguments, arguments_parsed = _rest_arguments_from_body(body_bytes)
+                error_msg = _tool_security_error(
+                    rest_tool,
+                    arguments,
+                    validate_arguments=arguments_parsed,
+                )
                 if error_msg:
                     logging.warning(
                         f"Security violation: {error_msg} | Tool: {rest_tool}"
@@ -182,6 +200,10 @@ class SecurityValidationMiddleware(BaseHTTPMiddleware):
                     )
                 return await call_next(request)
 
+            if not body_bytes:
+                return await call_next(request)
+
+            body = json.loads(body_bytes)
             method = body.get("method", "")
 
             # Log tools/list requests for monitoring (allowed but monitored)

--- a/src/data360/server.py
+++ b/src/data360/server.py
@@ -6,19 +6,18 @@ import uuid
 
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
-from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
-from data360.mcp_server.resources import CORSStaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request as StarletteRequest
 
 from data360.config import get_mcp_server_settings, setup_logging
 from data360.health import get_liveness_body, run_readiness
 from data360.http_client import aclose_shared_httpx_client
+from data360.mcp_server.resources import CORSStaticFiles
 from data360.otel_setup import (
     configure_open_telemetry_for_server,
     instrument_httpx_outbound,
@@ -40,14 +39,18 @@ for _arg in sys.argv:
         try:
             _parsed_port = int(_arg.split("=", 1)[1])
         except ValueError:
-            logging.warning("Could not parse port from argv argument '%s'; using default.", _arg)
+            logging.warning(
+                "Could not parse port from argv argument '%s'; using default.", _arg
+            )
         break
     if _arg == "--port":
         _idx = sys.argv.index(_arg)
         try:
             _parsed_port = int(sys.argv[_idx + 1])
         except (ValueError, IndexError):
-            logging.warning("Could not parse port after '--port' in argv; using default.")
+            logging.warning(
+                "Could not parse port after '--port' in argv; using default."
+            )
         break
 if _parsed_port is not None:
     mcp_settings.port = _parsed_port
@@ -90,14 +93,71 @@ if mcp_settings.env != "local" and _connection_string:
         pass
 
 
+_HEALTH_PATHS = frozenset({"/mcp/health", "/mcp/ready"})
+_TOOLS_HTTP_PREFIX = "/api/v1/tools"
+
+
+def _is_tool_request_path(path: str) -> bool:
+    """True for MCP Streamable HTTP and standard HTTP tool routes (not health probes)."""
+    if path in _HEALTH_PATHS:
+        return False
+    return path.startswith("/mcp") or path.startswith(_TOOLS_HTTP_PREFIX)
+
+
+def _rest_tool_name(path: str) -> str | None:
+    """Extract tool name from POST /api/v1/tools/{name}; None for the list route."""
+    prefix = f"{_TOOLS_HTTP_PREFIX}/"
+    if not path.startswith(prefix):
+        return None
+    name = path[len(prefix) :].strip("/")
+    return name or None
+
+
+def _tool_security_error(tool_name: str, arguments: dict[str, Any]) -> str | None:
+    """Return a security error message, or None if the tool call is allowed."""
+    from data360.mcp_server.security_validator import (  # noqa: PLC0415
+        validate_search_arguments,
+        validate_tool_call,
+    )
+
+    if not isinstance(arguments, dict):
+        arguments = {}
+
+    is_valid, error_msg = validate_tool_call(tool_name, arguments)
+    if not is_valid:
+        return error_msg
+    if tool_name == "data360_search_indicators":
+        is_valid, error_msg = validate_search_arguments(arguments)
+        if not is_valid:
+            return error_msg
+    return None
+
+
+def _forbidden_response(
+    *,
+    path: str,
+    error_msg: str,
+    jsonrpc_id: Any = None,
+) -> JSONResponse:
+    """403 body: JSON-RPC on /mcp, plain JSON on standard HTTP tool routes."""
+    if path.startswith(_TOOLS_HTTP_PREFIX):
+        return JSONResponse(status_code=403, content={"error": error_msg})
+    return JSONResponse(
+        status_code=403,
+        content={
+            "jsonrpc": "2.0",
+            "id": jsonrpc_id,
+            "error": {"code": -32001, "message": error_msg},
+        },
+    )
+
+
 class SecurityValidationMiddleware(BaseHTTPMiddleware):
     """Validate MCP tool calls to prevent prompt injection and unauthorized access."""
 
     async def dispatch(self, request: Request, call_next):
-        # Only validate MCP JSON-RPC tool calls (not health probes under /mcp/*)
-        if request.url.path in ("/mcp/health", "/mcp/ready"):
-            return await call_next(request)
-        if not request.url.path.startswith("/mcp"):
+        # MCP Streamable HTTP route and standard HTTP tool routes (not health probes)
+        if not _is_tool_request_path(request.url.path):
             return await call_next(request)
 
         try:
@@ -107,6 +167,21 @@ class SecurityValidationMiddleware(BaseHTTPMiddleware):
                 return await call_next(request)
 
             body = json.loads(body_bytes)
+            rest_tool = _rest_tool_name(request.url.path)
+
+            # Standard HTTP route: body is tool arguments (not JSON-RPC)
+            if rest_tool is not None:
+                arguments = body if isinstance(body, dict) else {}
+                error_msg = _tool_security_error(rest_tool, arguments)
+                if error_msg:
+                    logging.warning(
+                        f"Security violation: {error_msg} | Tool: {rest_tool}"
+                    )
+                    return _forbidden_response(
+                        path=request.url.path, error_msg=error_msg
+                    )
+                return await call_next(request)
+
             method = body.get("method", "")
 
             # Log tools/list requests for monitoring (allowed but monitored)
@@ -119,46 +194,19 @@ class SecurityValidationMiddleware(BaseHTTPMiddleware):
 
             # Validate tools/call requests
             if method == "tools/call":
-                from data360.mcp_server.security_validator import (  # noqa: PLC0415
-                    validate_search_arguments,
-                    validate_tool_call,
-                )
-
                 params = body.get("params", {})
                 tool_name = params.get("name", "")
                 arguments = params.get("arguments", {})
-
-                # Validate tool call
-                is_valid, error_msg = validate_tool_call(tool_name, arguments)
-                if not is_valid:
+                error_msg = _tool_security_error(tool_name, arguments)
+                if error_msg:
                     logging.warning(
                         f"Security violation: {error_msg} | Tool: {tool_name}"
                     )
-                    return JSONResponse(
-                        status_code=403,
-                        content={
-                            "jsonrpc": "2.0",
-                            "id": body.get("id"),
-                            "error": {"code": -32001, "message": error_msg},
-                        },
+                    return _forbidden_response(
+                        path=request.url.path,
+                        error_msg=error_msg,
+                        jsonrpc_id=body.get("id"),
                     )
-
-                # Additional validation for all search term inputs
-                if tool_name == "data360_search_indicators":
-                    is_valid, error_msg = validate_search_arguments(arguments)
-                    if not is_valid:
-                        logging.warning(
-                            "Search query blocked: %s",
-                            str(arguments)[:200],
-                        )
-                        return JSONResponse(
-                            status_code=403,
-                            content={
-                                "jsonrpc": "2.0",
-                                "id": body.get("id"),
-                                "error": {"code": -32001, "message": error_msg},
-                            },
-                        )
 
         except json.JSONDecodeError:
             pass  # Let MCP handle invalid JSON
@@ -173,10 +221,8 @@ class AuditLogMiddleware(BaseHTTPMiddleware):
     """Log structured audit entries for every MCP request."""
 
     async def dispatch(self, request: Request, call_next):
-        # Only audit MCP JSON-RPC calls (not health probes)
-        if request.url.path in ("/mcp/health", "/mcp/ready"):
-            return await call_next(request)
-        if not request.url.path.startswith("/mcp"):
+        # MCP Streamable HTTP route and standard HTTP tool routes (not health probes)
+        if not _is_tool_request_path(request.url.path):
             return await call_next(request)
         session_id = str(uuid.uuid4())
         requestor_id = request.headers.get(
@@ -189,11 +235,14 @@ class AuditLogMiddleware(BaseHTTPMiddleware):
         prompt_hash = ""
         try:
             body = json.loads(body_bytes)
-            method = body.get("method", "")
-            params = body.get("params", {})
-            prompt = json.dumps(
-                {"method": method, "params": params}, separators=(",", ":")
-            )
+            if isinstance(body, dict) and "method" in body:
+                method = body.get("method", "")
+                params = body.get("params", {})
+                prompt = json.dumps(
+                    {"method": method, "params": params}, separators=(",", ":")
+                )
+            else:
+                prompt = json.dumps(body, separators=(",", ":"))
             prompt_hash = hashlib.sha256(prompt.encode()).hexdigest()[:16]
         except Exception:
             pass
@@ -226,11 +275,17 @@ class AuditLogMiddleware(BaseHTTPMiddleware):
 
 
 from fastmcp import settings
+
 settings.stateless_http = True
 
-# NOTE: import to be able to run the server with all definitions loaded
+# MCP Streamable HTTP route: JSON responses avoid SSE framing that
+# Cloudflare rejects as Content-Length ProtocolViolation.
 # path="/mcp" means the MCP endpoint lives at /mcp (no trailing slash needed)
-mcp_app = mcp.http_app(path="/mcp")
+mcp_app = mcp.http_app(
+    path="/mcp",
+    json_response=mcp_settings.json_response,
+    stateless_http=True,
+)
 
 
 async def health_check(request: StarletteRequest) -> JSONResponse:
@@ -273,6 +328,7 @@ app.add_middleware(AuditLogMiddleware)
 app.add_middleware(SecurityValidationMiddleware)
 
 from fastapi.middleware.cors import CORSMiddleware
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -300,8 +356,8 @@ async def root():
         "health": "/mcp/health",
         "ready": "/mcp/ready",
         "mcp": "/mcp",
+        "tools_http": "/api/v1/tools",
     }
-
 
 
 class VizSpecRequest(BaseModel):
@@ -315,6 +371,12 @@ class VizSpecRequest(BaseModel):
     relevant_fields: list[str] | None = None
     chart_title: str | None = None
     series_labels: dict[str, str] | None = None
+
+
+from data360.http_tools import tools_http_router  # noqa: E402
+
+# Standard HTTP routes: list tools and POST /api/v1/tools/{name}
+app.include_router(tools_http_router)
 
 
 @app.post("/api/viz-spec")
@@ -341,22 +403,31 @@ async def get_viz_spec_endpoint(req: VizSpecRequest):
         )
     except Exception as e:
         _logger.exception("Failed to generate viz spec: %s", e)
-        return JSONResponse(status_code=500, content={"error": "Failed to generate visualization spec due to an internal error."})
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": "Failed to generate visualization spec due to an internal error."
+            },
+        )
 
     if res.get("error"):
         return JSONResponse(status_code=400, content={"error": res.get("error")})
 
     spec = res.get("spec")
     if not spec:
-        return JSONResponse(status_code=500, content={"error": "Vega-Lite spec was not generated."})
+        return JSONResponse(
+            status_code=500, content={"error": "Vega-Lite spec was not generated."}
+        )
 
-    return {k: v for k, v in {
-        "spec": spec,
-        "reason": res.get("reason"),
-        "strategy": res.get("strategy"),
-    }.items() if v is not None}
-
-
+    return {
+        k: v
+        for k, v in {
+            "spec": spec,
+            "reason": res.get("reason"),
+            "strategy": res.get("strategy"),
+        }.items()
+        if v is not None
+    }
 
 
 if os.environ.get("PYTEST_CURRENT_TEST"):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -18,7 +18,9 @@ _codelist_url = f"{_test_api}/data360/codelist"
 _codelist_probe_url = f"{_codelist_url}?type=REF_AREA"
 
 
-def _mock_codelist(httpx_mock: pytest_httpx.HTTPXMock, json_body: dict | None = None) -> None:
+def _mock_codelist(
+    httpx_mock: pytest_httpx.HTTPXMock, json_body: dict | None = None
+) -> None:
     httpx_mock.add_response(
         url=_codelist_probe_url,
         method="GET",
@@ -49,6 +51,7 @@ def test_root_discoverability(health_client: TestClient) -> None:
     assert body["health"] == "/mcp/health"
     assert body["ready"] == "/mcp/ready"
     assert body["mcp"] == "/mcp"
+    assert body["tools_http"] == "/api/v1/tools"
 
 
 @pytest.mark.asyncio
@@ -64,9 +67,7 @@ async def test_ready_all_ok(
         method="POST",
         json={"value": [{"series_description": {"database_id": "WB_WDI"}}]},
     )
-    _mock_codelist(
-        httpx_mock, {"value": [{"id": "USA", "name": "United States"}]}
-    )
+    _mock_codelist(httpx_mock, {"value": [{"id": "USA", "name": "United States"}]})
 
     code, body = await health_mod.run_readiness()
 

--- a/tests/test_http_tools.py
+++ b/tests/test_http_tools.py
@@ -97,3 +97,39 @@ def test_call_tool_http_unauthorized_tool_returns_403(client: TestClient) -> Non
     )
     assert response.status_code == 403
     assert "error" in response.json()
+
+
+def test_call_tool_http_unauthorized_tool_empty_body_returns_403(
+    client: TestClient,
+) -> None:
+    response = client.post("/api/v1/tools/system_admin_tool")
+    assert response.status_code == 403
+    assert "error" in response.json()
+
+
+def test_call_tool_http_search_empty_body_returns_403(client: TestClient) -> None:
+    response = client.post("/api/v1/tools/data360_search_indicators")
+    assert response.status_code == 403
+    assert "error" in response.json()
+
+
+def test_call_tool_http_unauthorized_tool_invalid_json_returns_403(
+    client: TestClient,
+) -> None:
+    response = client.post(
+        "/api/v1/tools/system_admin_tool",
+        content=b"not-json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 403
+    assert "error" in response.json()
+
+
+def test_call_tool_http_search_invalid_json_returns_400(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/tools/data360_search_indicators",
+        content=b"not-json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 400
+    assert "JSON" in response.json()["error"]

--- a/tests/test_http_tools.py
+++ b/tests/test_http_tools.py
@@ -1,0 +1,99 @@
+"""Tests for Streamable HTTP JSON responses and standard HTTP tool routes."""
+
+# ruff: noqa: PLR2004
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+_MCP_INITIALIZE = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2024-11-05",
+        "capabilities": {},
+        "clientInfo": {"name": "test", "version": "0"},
+    },
+}
+
+
+@pytest.fixture
+def client():
+    """TestClient as a context manager so FastMCP Streamable HTTP lifespan starts."""
+    from data360.server import app  # noqa: PLC0415
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_mcp_initialize_returns_json(client: TestClient) -> None:
+    """Streamable HTTP /mcp initialize is application/json, not text/event-stream."""
+    response = client.post(
+        "/mcp",
+        json=_MCP_INITIALIZE,
+        headers={"Accept": "application/json, text/event-stream"},
+    )
+    assert response.status_code == 200
+    content_type = response.headers.get("content-type", "")
+    assert "application/json" in content_type
+    assert "text/event-stream" not in content_type
+    body = response.json()
+    assert body["jsonrpc"] == "2.0"
+    assert "result" in body
+
+
+def test_root_includes_tools_http(client: TestClient) -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json()["tools_http"] == "/api/v1/tools"
+
+
+def test_list_tools_http(client: TestClient) -> None:
+    response = client.get("/api/v1/tools")
+    assert response.status_code == 200
+    tools = response.json()["tools"]
+    assert "data360_search_indicators" in tools
+    assert "data360_interactive_choices" in tools
+
+
+def test_call_tool_http_interactive_choices(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/tools/data360_interactive_choices",
+        json={
+            "prompt": "Which series?",
+            "options": ["Real GDP", "Nominal GDP", "Specify custom..."],
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["prompt"] == "Which series?"
+    assert "Real GDP" in body["options"]
+
+
+def test_call_tool_http_unknown_tool_returns_404(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/tools/data360_not_a_real_tool",
+        json={},
+    )
+    assert response.status_code == 404
+    assert "error" in response.json()
+
+
+def test_call_tool_http_blocked_search_returns_403(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/tools/data360_search_indicators",
+        json={"query": "*"},
+    )
+    assert response.status_code == 403
+    assert "error" in response.json()
+
+
+def test_call_tool_http_unauthorized_tool_returns_403(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/tools/system_admin_tool",
+        json={},
+    )
+    assert response.status_code == 403
+    assert "error" in response.json()


### PR DESCRIPTION
feat(server): add JSON Streamable HTTP and REST tool routes for proxy compatibility

Enable json_response on /mcp by default (MCP_JSON_RESPONSE) so strict proxies such as Cloudflare receive application/json with a valid Content-Length instead of SSE-framed responses.

Add thin REST dispatcher at GET/POST /api/v1/tools that reuses mcp.call_tool without duplicating Data360 business logic. Extend security and audit middleware to cover the new routes.